### PR TITLE
Добавить структурные README для репозитория и сервисов

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,14 @@
 
 - Ответы пользователю и оформление PR на русском языке, тексты коммитов на английском языке.
 - Перед изменениями читать `docs/design-guidelines/AGENTS.md` и файлы, на которые он ссылается с учетом контекста текущей задачи. Если я пишу тебе про "гайды", то это именно `docs/design-guidelines/AGENTS.md` и связанные с ним документы и тебе обязательно надо найти релевантные разделы в этих документах, которые относятся к твоей задаче или замечанию, и прочитать их. 
+- Для быстрой навигации по структуре репозитория и сервисов обязательно использовать:
+  - `README.md` (корневая карта репозитория);
+  - `services/dev/webhook-simulator/README.md`;
+  - `services/external/api-gateway/README.md`;
+  - `services/internal/control-plane/README.md`;
+  - `services/jobs/agent-runner/README.md`;
+  - `services/jobs/worker/README.md`;
+  - `services/staff/web-console/README.md`.
 - Временные правила текущего ручного dev/staging цикла (до полного dogfooding через `run:dev`) см. `.local/agents-temp-dev-rules.md`. Править `.local/agents-temp-dev-rules.md` строго запрещено, если не стоит явная задача на изменение временных правил.
 - Для Go-изменений обязательно исполнять требования из `docs/design-guidelines/go/**.md`, как до правок, так и перед подготовкой PR.
 - Для frontend-изменений обязательно исполнять требования из `docs/design-guidelines/vue/**.md` и `docs/design-guidelines/visual/**.md`.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,94 @@
 # codex-k8s
 
-`codex-k8s` — cloud-сервис (Go + Vue3), который объединяет функциональные требования
-`codexctl`, `github.com/codex-k8s/yaml-mcp-server` и `machine_driven_company_requirements` в единую
-webhook-driven платформу для работы AI-агентов в Kubernetes.
+`codex-k8s` — webhook-driven платформа управления AI-агентами в Kubernetes.
 
-## Базовые принципы
-
-- только Kubernetes (через Go SDK),
-- repository providers через интерфейсы (GitHub сейчас, GitLab позже),
-- без workflow-first оркестрации: процессы запускаются webhook-событиями,
-- PostgreSQL как центральный state backend (`JSONB` + `pgvector`),
-- встроенные служебные MCP ручки в Go,
-- staff frontend на Vue3, защищённый GitHub OAuth.
-
-## Каркас репозитория
-
-- `services/external/api-gateway` — внешний API/webhook ingress.
-- `services/staff/web-console` — UI/настройки/наблюдение.
-- `services/internal/control-plane` — доменная логика платформы.
-- `services/jobs/worker` — фоновые jobs/reconciliation.
-- `services/dev/webhook-simulator` — dev-only инструменты.
-- `docs/design-guidelines` — обязательные инженерные стандарты.
-
-## Стандарты разработки
-
-Перед изменениями обязательно читать:
-- `AGENTS.md`
-- `docs/design-guidelines/AGENTS.md`
+```text
+codex-k8s/                                                монорепозиторий платформы; с этой карты удобно начинать навигацию
+├── AGENTS.md                                             обязательные правила для всех агентов; ОБЯЗАТЕЛЬНО читать первым перед любыми правками
+├── README.md                                             карта структуры репозитория; смотреть при онбординге и перед поиском нужного контекста
+├── services.yaml                                         инвентарь deployable-сервисов и окружений; ОБЯЗАТЕЛЬНО смотреть при изменениях состава сервисов
+├── services/                                             сервисный код по архитектурным зонам
+│   ├── dev/webhook-simulator/                            dev-only симулятор webhook; смотреть при локальной/стендовой отладке входящих событий
+│   ├── external/api-gateway/                             внешний ingress и edge-слой; смотреть при изменениях OpenAPI/webhook/auth
+│   ├── internal/control-plane/                           доменная логика и владелец БД-схемы; смотреть при изменениях use-case/миграций/policy
+│   ├── jobs/agent-runner/                                runtime запуска агентных pod; смотреть при изменениях выполнения run и toolchain
+│   ├── jobs/worker/                                      фоновые jobs/reconciliation; смотреть при изменениях очередей, ретраев и cleanup
+│   └── staff/web-console/                                staff UI на Vue; смотреть при изменениях интерфейса и staff API-клиента
+├── libs/                                                 общий переиспользуемый код; ОБЯЗАТЕЛЬНО смотреть перед выносом helper-кода
+├── proto/                                                gRPC-контракты internal сервисов; ОБЯЗАТЕЛЬНО смотреть при изменениях внутренних API
+├── deploy/                                               Kubernetes-манифесты и deploy-скрипты; смотреть при изменениях staging/prod выкладки
+├── bootstrap/                                            bootstrap и CI/CD подготовка окружений; смотреть при изменениях env/vars/secrets/процесса выкладки
+├── tools/                                                codegen и сервисные утилиты; смотреть при изменениях генерации контрактов и инфраструктурных утилит
+└── docs/                                                 source of truth по продукту, архитектуре и процессу
+    ├── architecture/                                     архитектурные решения и контракты; ОБЯЗАТЕЛЬНО смотреть при изменении архитектуры/API/данных
+    │   ├── c4_context.md                                 системный контекст и внешние зависимости платформы
+    │   ├── c4_container.md                               контейнерная декомпозиция сервисов и потоков взаимодействия
+    │   ├── api_contract.md                               обзор API-контрактов (OpenAPI/gRPC/AsyncAPI) и правил их эволюции
+    │   ├── data_model.md                                 каноническая модель данных и инварианты сущностей
+    │   ├── agent_runtime_rbac.md                         модель runtime-доступа агентов и RBAC-ограничений
+    │   ├── mcp_approval_and_audit_flow.md                policy для MCP-апрувов, audit events и governance-переходов
+    │   ├── prompt_templates_policy.md                    политика шаблонов промптов и runtime-рендера контекста
+    │   └── adr/                                          архитектурные ADR; смотреть при изменениях фундаментальных решений
+    │       ├── ADR-0001-kubernetes-only.md               базовый ADR: поддерживается только Kubernetes
+    │       ├── ...                                       промежуточные ADR
+    │       └── ADR-0004-repository-provider-interface.md ADR по интерфейсу провайдеров репозиториев
+    ├── delivery/                                         планирование и трассируемость поставки; ОБЯЗАТЕЛЬНО смотреть при планировании и закрытии задач
+    │   ├── development_process_requirements.md           обязательный процесс разработки и doc-governance
+    │   ├── delivery_plan.md                              сквозной план поставки MVP и этапов
+    │   ├── issue_map.md                                  связность issue ↔ документы ↔ этапы
+    │   ├── requirements_traceability.md                  матрица трассируемости требований к реализации
+    │   ├── roadmap.md                                    этапы развития продукта после MVP
+    │   ├── regression_s1_gate.md                         регрессионные критерии и чекпойнты качества
+    │   ├── epic_s1.md                                    каталог эпиков спринта S1
+    │   ├── ...                                           серийные каталоги эпиков по спринтам
+    │   ├── epic_s3.md                                    каталог эпиков спринта S3
+    │   ├── sprint_s1_mvp_vertical_slice.md               план и рамки спринта S1
+    │   ├── ...                                           серийные планы спринтов
+    │   ├── sprint_s3_mvp_completion.md                   план и рамки спринта S3
+    │   └── epics/                                        подневные эпики; смотреть при детализации работ конкретного дня
+    │       ├── epic-s1-day0-bootstrap-baseline.md        первый эпик дневной декомпозиции
+    │       ├── ...                                       остальные day-эпики
+    │       └── epic-s3-day12-mvp-closeout-and-handover.md последний эпик дневной декомпозиции MVP
+    ├── design-guidelines/                                инженерные стандарты; ОБЯЗАТЕЛЬНО смотреть перед кодом и перед PR
+    │   ├── AGENTS.md                                     индекс обязательных гайдов по backend/frontend/common
+    │   ├── common/                                       общие правила проектирования и PR self-check
+    │   │   ├── AGENTS.md                                 обзор common-гайдов и обязательных ссылок
+    │   │   ├── design_principles.md                      DDD/SOLID/DRY/KISS/Clean Architecture для всех языков
+    │   │   ├── project_architecture.md                   целевая структура репозитория и зоны сервисов
+    │   │   ├── libraries_reusable_code_requirements.md   правила выноса общего кода в libs
+    │   │   ├── external_dependencies_catalog.md          каталог разрешённых внешних зависимостей
+    │   │   └── check_list.md                             общий чек-лист перед PR
+    │   ├── go/                                           backend-стандарты; ОБЯЗАТЕЛЬНО смотреть при Go-изменениях
+    │   │   ├── AGENTS.md                                 индекс Go-правил
+    │   │   ├── services_design_requirements.md           правила слоёв и размещения backend-кода
+    │   │   ├── code_generation.md                        правила OpenAPI/gRPC codegen для backend
+    │   │   └── check_list.md                             Go-чек-лист перед PR
+    │   ├── vue/                                          frontend-стандарты; ОБЯЗАТЕЛЬНО смотреть при Vue/TS-изменениях
+    │   │   ├── AGENTS.md                                 индекс frontend-правил
+    │   │   ├── frontend_architecture.md                  архитектура frontend-приложений
+    │   │   ├── frontend_code_rules.md                    правила размещения и стиля кода Vue/TS
+    │   │   ├── frontend_data_and_state.md                правила работы с API-данными и состоянием
+    │   │   └── check_list.md                             Vue-чек-лист перед PR
+    │   └── visual/                                       визуальные и UX-стандарты frontend
+    │       ├── AGENTS.md                                 индекс визуальных правил
+    │       ├── visual_character.md                       стиль и визуальный язык интерфейса
+    │       └── check_list.md                             visual-чек-лист перед PR
+    ├── product/                                          продуктовые требования и операционная модель; ОБЯЗАТЕЛЬНО смотреть при изменениях процесса/лейблов/ролей
+    │   ├── requirements_machine_driven.md                канонический baseline требований платформы
+    │   ├── agents_operating_model.md                     модель ролей агентов, режимов исполнения и ответственности
+    │   ├── labels_and_trigger_policy.md                  политика лейблов (`run:*`, `state:*`, `need:*`) и trigger-flow
+    │   ├── stage_process_model.md                        stage-модель процесса (`intake -> ... -> ops`)
+    │   ├── brief.md                                      продуктовый обзор и контекст инициативы
+    │   ├── constraints.md                                зафиксированные продуктовые ограничения
+    │   └── prompt-seeds/                                 seed-шаблоны агентных промптов
+    │       ├── dev-work.md                               базовый шаблон выполнения задач
+    │       └── dev-review.md                             базовый шаблон ревью и аудита
+    ├── ops/                                              runbook и операционные проверки; смотреть при staging/debug работах
+    │   └── staging_runbook.md                            обязательные проверки staging и типовые диагностические команды
+    ├── research/                                         исследовательские материалы и исходные бизнес-идеи
+    │   └── src_idea-machine_driven_company_requirements.md первоисточник бизнес-идеи (с учётом текущей архитектуры платформы)
+    └── templates/                                        шаблоны проектной документации; смотреть при создании новых продуктовых/архитектурных артефактов
+        ├── adr.md                                        шаблон архитектурного решения (ADR)
+        ├── ...                                           остальные шаблоны документов
+        └── user_story.md                                 шаблон пользовательской истории
+```

--- a/services/dev/webhook-simulator/README.md
+++ b/services/dev/webhook-simulator/README.md
@@ -1,0 +1,9 @@
+# webhook-simulator
+
+`webhook-simulator` — dev-only сервисная директория для инструментов имитации webhook-событий во время локальной и staging-отладки.
+
+```text
+services/dev/webhook-simulator/                      dev-only зона; в production не используется
+├── README.md                                        описание назначения и структуры директории
+└── .gitkeep                                         временный placeholder, пока dev-утилиты не добавлены
+```

--- a/services/external/api-gateway/README.md
+++ b/services/external/api-gateway/README.md
@@ -1,0 +1,21 @@
+# api-gateway
+
+`api-gateway` — edge-сервис: принимает внешние webhook/API-запросы, валидирует и маршрутизирует их во внутренние доменные сервисы.
+
+```text
+services/external/api-gateway/                       thin-edge сервис без доменной логики
+├── README.md                                        карта структуры сервиса и обязательных точек входа
+├── Dockerfile                                       сборка runtime-образа сервиса
+├── api/                                             contract-first спецификации транспорта; ОБЯЗАТЕЛЬНО смотреть при изменениях HTTP/async контрактов
+│   └── server/
+│       ├── api.yaml                                 OpenAPI source of truth для external/staff HTTP endpoint'ов
+│       └── asyncapi.yaml                            AsyncAPI описание webhook/event payload
+├── cmd/
+│   └── api-gateway/
+│       └── main.go                                  composition root запуска сервиса
+└── internal/
+    ├── app/                                         wiring приложения, конфиг и bootstrap компонентов
+    ├── auth/                                        authn/authz и работа с identity на edge-границе
+    ├── controlplane/                                адаптер клиента во внутренний control-plane
+    └── transport/http/                              HTTP handlers/DTO/casters и middleware транспорта
+```

--- a/services/internal/control-plane/README.md
+++ b/services/internal/control-plane/README.md
@@ -1,0 +1,28 @@
+# control-plane
+
+`control-plane` — внутренний доменный сервис платформы: orchestrates use-cases, владеет схемой БД и политиками выполнения.
+
+```text
+services/internal/control-plane/                     доменный backend (владелец схемы и use-case логики)
+├── README.md                                        карта структуры сервиса и ключевых областей
+├── Dockerfile                                       сборка runtime-образа сервиса
+├── cmd/
+│   ├── control-plane/main.go                        composition root запуска gRPC/MCP/внутренних контуров
+│   └── cli/migrations/                              миграции БД (schema governance этого сервиса)
+└── internal/
+    ├── app/                                         конфигурация, bootstrap и жизненный цикл приложения
+    ├── clients/                                     инфраструктурные адаптеры внешних API (GitHub/Kubernetes)
+    ├── domain/                                      доменные use-cases и типы; ОБЯЗАТЕЛЬНО смотреть при изменении бизнес-логики
+    │   ├── agentcallback/                           обработка callback из agent runtime
+    │   ├── mcp/                                     доменная оркестрация MCP tools/policy
+    │   ├── repository/                              контракты provider/repository для доменного слоя
+    │   ├── runstatus/                               use-cases статусов run и state transitions
+    │   ├── staff/                                   внутренние staff use-cases управления платформой
+    │   ├── types/                                   доменные entity/value/enum/query типы
+    │   └── webhook/                                 обработка webhook-driven сценариев
+    ├── repository/postgres/                         PostgreSQL-реализации доменных репозиториев
+    └── transport/                                   транспортные адаптеры сервиса
+        ├── grpc/                                    внутренний gRPC API
+        ├── mcp/                                     MCP StreamableHTTP/control tools endpoint
+        └── agentcallback/                           callback transport для agent runner
+```

--- a/services/jobs/agent-runner/README.md
+++ b/services/jobs/agent-runner/README.md
@@ -1,0 +1,23 @@
+# agent-runner
+
+`agent-runner` — job-сервис запуска агентных сессий в Kubernetes: подготавливает runtime-контекст, выполняет run и собирает артефакты.
+
+```text
+services/jobs/agent-runner/                          runtime исполнитель агентных запусков
+├── README.md                                        карта структуры сервиса и run-пайплайна
+├── Dockerfile                                       image для выполнения agent-run job
+├── cmd/agent-runner/main.go                         точка входа процесса runner
+├── internal/
+│   ├── app/                                         конфиг и bootstrap runner-приложения
+│   ├── controlplane/client.go                       клиент внутренних API control-plane
+│   └── runner/                                      основная логика запуска/мониторинга агентной сессии
+│       ├── service.go                               orchestration жизненного цикла run
+│       ├── helpers.go                               вспомогательные функции подготовки окружения
+│       ├── kubectl_helpers.go                       утилиты работы с Kubernetes runtime
+│       ├── security_helpers.go                      безопасная обработка токенов/секретных данных
+│       ├── structs.go                               типы payload/runtime состояния runner
+│       └── templates/                               шаблоны runtime-артефактов и job-конфигураций
+└── scripts/                                         вспомогательные скрипты контейнера runner
+    ├── bootstrap_tools.sh                           установка обязательного CLI toolchain
+    └── entrypoint.sh                                стартовый скрипт контейнера
+```

--- a/services/jobs/worker/README.md
+++ b/services/jobs/worker/README.md
@@ -1,0 +1,19 @@
+# worker
+
+`worker` — фоновый сервис очередей и reconciliation: исполняет отложенные задачи, синхронизирует состояние и обслуживает lifecycle run.
+
+```text
+services/jobs/worker/                                фоновые jobs и reconciliation контур
+├── README.md                                        карта структуры worker-сервиса
+├── Dockerfile                                       image фонового исполнителя
+├── cmd/worker/main.go                               точка входа worker-процесса
+└── internal/
+    ├── app/                                         конфигурация и bootstrap worker runtime
+    ├── clients/kubernetes/                          клиентские адаптеры Kubernetes API
+    ├── controlplane/client.go                       клиент внутренних control-plane API
+    ├── domain/                                      доменные контракты и use-cases worker-задач
+    │   ├── repository/                              интерфейсы репозиториев для фоновых сценариев
+    │   ├── types/                                   доменные типы worker-контекста
+    │   └── worker/                                  бизнес-логика очередей, retries и cleanup
+    └── repository/postgres/                         PostgreSQL-адаптеры хранения состояния jobs
+```

--- a/services/staff/web-console/README.md
+++ b/services/staff/web-console/README.md
@@ -1,0 +1,25 @@
+# web-console
+
+`web-console` — staff frontend (Vue 3 + TypeScript) для управления пользователями, проектами, репозиториями и запуском/диагностикой agent run.
+
+```text
+services/staff/web-console/                          staff UI-приложение платформы
+├── README.md                                        карта структуры frontend-сервиса
+├── Dockerfile                                       multi-target сборка (`dev`/`prod`) для staging и runtime
+├── package.json                                     зависимости и npm-скрипты приложения
+├── package-lock.json                                lockfile зависимостей Node.js
+├── index.html                                       HTML-шаблон точки входа Vite
+├── vite.config.ts                                   конфигурация Vite-сборки
+├── tsconfig.json                                    TypeScript-конфигурация проекта
+├── openapi-ts.config.ts                             генерация typed API-клиента из OpenAPI
+├── docker/nginx/default.conf                        runtime-конфиг web-сервера для prod target
+└── src/                                             исходный код приложения
+    ├── main.ts                                      bootstrap приложения
+    ├── app/                                         корневой App и глобальные стили
+    ├── i18n/                                        локализация интерфейса
+    ├── router/                                      маршрутизация страниц
+    ├── pages/                                       page-level компоненты экранов
+    ├── features/                                    feature-модули (auth/projects/runs/users)
+    └── shared/                                      переиспользуемый слой UI/lib/api
+        └── api/                                     typed API-клиенты и контракты транспорта
+```


### PR DESCRIPTION
## Что сделано
- Переписан корневой `README.md`: добавлен единый блок-дерево структуры репозитория с комментариями `что/зачем/когда смотреть`.
- Для `docs/` дерево развёрнуто до ключевых документов.
- Для серийных наборов документов (ADR, sprint/epic, `delivery/epics`, `templates`) показаны первый и последний элементы с `...` между ними.
- Добавлены `README.md` в каждый сервис:
  - `services/dev/webhook-simulator/README.md`
  - `services/external/api-gateway/README.md`
  - `services/internal/control-plane/README.md`
  - `services/jobs/agent-runner/README.md`
  - `services/jobs/worker/README.md`
  - `services/staff/web-console/README.md`
- Обновлён `AGENTS.md`: добавлены прямые ссылки на корневой и сервисные README как обязательный навигационный контур.

## Проверки
- Изменения только в документации (`.md`), без изменений runtime-кода.
- Тесты/линтеры/dupl не запускались (для doc-only изменений не требуются).

## Self-check
- `docs/design-guidelines/common/check_list.md`: релевантные пункты выполнены (архитектурные границы не нарушены, секреты не добавлены, изменения ограничены документацией).
- `docs/design-guidelines/go/check_list.md` и `docs/design-guidelines/vue/check_list.md`: не применимо (Go/Vue код не изменялся).

Closes #21
