### PR TITLE
Docs sync: finalize Day17 completion and Day18 closeout metadata

### DIFF
--- a/docs/delivery/epic_s3.md
+++ b/docs/delivery/epic_s3.md
@@ -5,7 +5,7 @@ title: "Epic Catalog: Sprint S3 (MVP completion)"
 status: in-progress
 owner_role: EM
 created_at: 2026-02-13
-updated_at: 2026-02-18
+updated_at: 2026-02-19
 related_issues: [19, 45]
 related_prs: []
 approvals:
@@ -62,8 +62,8 @@ approvals:
 - Day 13 (`unified config/secrets governance + GitHub creds fallback`) завершён.
 - Day 14 (`repository onboarding preflight`) завершён.
 - Day 16 (`gRPC transport boundary hardening`) завершён как refactoring-hygiene эпик по Issue #45.
-- Day 17 (`environment-scoped secret overrides + OAuth callback strategy`) завершён.
-- Day 18 (`runtime error journal + staff alert center`) завершён.
+- Day 17 (`environment-scoped secret overrides + OAuth callback strategy`) завершён и согласован Owner (PR #49).
+- Day 18 (`runtime error journal + staff alert center`) завершён и согласован Owner (PR #50).
 - В работе остаются Day15/Day19/Day20/Day20.5/Day20.6 (core-flow + frontend hardening + realtime), после них финальный Day21 full e2e gate.
 
 ## Порядок закрытия остатка S3

--- a/docs/delivery/epics/epic-s3-day17-environment-scoped-secret-overrides-and-oauth-callbacks.md
+++ b/docs/delivery/epics/epic-s3-day17-environment-scoped-secret-overrides-and-oauth-callbacks.md
@@ -5,9 +5,9 @@ title: "Epic S3 Day 17: Environment-scoped secret overrides and OAuth callback s
 status: completed
 owner_role: EM
 created_at: 2026-02-18
-updated_at: 2026-02-18
+updated_at: 2026-02-19
 related_issues: [19]
-related_prs: []
+related_prs: [49]
 approvals:
   required: ["Owner"]
   status: approved

--- a/docs/delivery/epics/epic-s3-day18-runtime-error-journal-and-staff-alert-center.md
+++ b/docs/delivery/epics/epic-s3-day18-runtime-error-journal-and-staff-alert-center.md
@@ -5,12 +5,12 @@ title: "Epic S3 Day 18: Runtime error journal and staff alert center"
 status: completed
 owner_role: EM
 created_at: 2026-02-18
-updated_at: 2026-02-18
+updated_at: 2026-02-19
 related_issues: [19]
-related_prs: []
+related_prs: [50]
 approvals:
   required: ["Owner"]
-  status: pending
+  status: approved
   request_id: ""
 ---
 

--- a/docs/delivery/sprint_s3_mvp_completion.md
+++ b/docs/delivery/sprint_s3_mvp_completion.md
@@ -5,7 +5,7 @@ title: "Sprint S3: MVP completion (full stage flow, MCP control tools, self-impr
 status: in-progress
 owner_role: EM
 created_at: 2026-02-13
-updated_at: 2026-02-18
+updated_at: 2026-02-19
 related_issues: [19, 45]
 related_prs: []
 approvals:
@@ -71,8 +71,8 @@ approvals:
 | Day 14 | Repository onboarding preflight + bot params per repo | P0 | `docs/delivery/epics/epic-s3-day14-repository-onboarding-preflight.md` | completed |
 | Day 15 | Prompt context overhaul (docs tree, role matrix, GitHub service messages) | P0 | `docs/delivery/epics/epic-s3-day15-mvp-closeout-and-handover.md` | planned |
 | Day 16 | gRPC transport boundary hardening (исключить прямые вызовы repository из handlers) | P0 | `docs/delivery/epics/epic-s3-day16-grpc-transport-boundary-hardening.md` | completed |
-| Day 17 | Environment-scoped secret overrides and OAuth callback strategy | P0 | `docs/delivery/epics/epic-s3-day17-environment-scoped-secret-overrides-and-oauth-callbacks.md` | completed |
-| Day 18 | Runtime error journal and staff alert center | P0 | `docs/delivery/epics/epic-s3-day18-runtime-error-journal-and-staff-alert-center.md` | completed |
+| Day 17 | Environment-scoped secret overrides and OAuth callback strategy | P0 | `docs/delivery/epics/epic-s3-day17-environment-scoped-secret-overrides-and-oauth-callbacks.md` | completed (approved) |
+| Day 18 | Runtime error journal and staff alert center | P0 | `docs/delivery/epics/epic-s3-day18-runtime-error-journal-and-staff-alert-center.md` | completed (approved) |
 | Day 19 | Run access key and OAuth bypass flow | P0 | `docs/delivery/epics/epic-s3-day19-run-access-key-and-oauth-bypass.md` | planned |
 | Day 20 | Frontend manual QA hardening loop | P0 | `docs/delivery/epics/epic-s3-day20-frontend-manual-qa-hardening-loop.md` | planned |
 | Day 20.5 | Realtime event bus (PostgreSQL LISTEN/NOTIFY) and WebSocket backplane | P0 | `docs/delivery/epics/epic-s3-day20.5-realtime-event-bus-and-websocket-backplane.md` | planned |


### PR DESCRIPTION
## Что сделано
- Создана отдельная ветка под следующий эпик: `codex/day18-closeout`.
- Синхронизированы статусы Day17 везде, где нужно: подтверждено `completed/approved`, добавлен `related_prs: [49]`.
- Финализирован Day18 как выполненный в delivery-доках: `approved`, `related_prs: [50]`, синхронизированы сводные документы спринта/каталога эпиков.

## Проверки
- `go test ./services/internal/control-plane/...`
- `go test ./services/external/api-gateway/...`
- Self-check: `docs/design-guidelines/common/check_list.md`

## Измененные файлы
- `docs/delivery/epics/epic-s3-day17-environment-scoped-secret-overrides-and-oauth-callbacks.md`
- `docs/delivery/epics/epic-s3-day18-runtime-error-journal-and-staff-alert-center.md`
- `docs/delivery/epic_s3.md`
- `docs/delivery/sprint_s3_mvp_completion.md`