### PR TITLE
worker: не занимать слот для deploy-only run

### DIFF
--- a/services/jobs/worker/internal/domain/repository/runqueue/repository.go
+++ b/services/jobs/worker/internal/domain/repository/runqueue/repository.go
@@ -15,10 +15,10 @@ type (
 
 // Repository provides queue-like operations over agent runs and slots.
 type Repository interface {
-	// ClaimNextPending atomically claims one pending run and leases a free slot.
+	// ClaimNextPending atomically claims one pending run and leases a free slot when required by runtime profile.
 	ClaimNextPending(ctx context.Context, params ClaimParams) (ClaimedRun, bool, error)
 	// ListRunning returns active runs for reconciliation.
 	ListRunning(ctx context.Context, limit int) ([]RunningRun, error)
-	// FinishRun finalizes run status and releases slot lease.
+	// FinishRun finalizes run status and releases slot lease when it exists.
 	FinishRun(ctx context.Context, params FinishParams) (bool, error)
 }

--- a/services/jobs/worker/internal/domain/types/query/run_payload.go
+++ b/services/jobs/worker/internal/domain/types/query/run_payload.go
@@ -48,7 +48,8 @@ type RepositoryPayload struct {
 
 // RunQueuePayload keeps only payload fields required in runqueue repository.
 type RunQueuePayload struct {
-	Repository RepositoryPayload `json:"repository"`
+	Repository RepositoryPayload  `json:"repository"`
+	Runtime    *RunRuntimeProfile `json:"runtime,omitempty"`
 }
 
 // ProjectSettings stores project-level defaults in JSONB settings.

--- a/services/jobs/worker/internal/domain/types/query/runqueue.go
+++ b/services/jobs/worker/internal/domain/types/query/runqueue.go
@@ -20,7 +20,7 @@ type RunQueueClaimParams struct {
 	ProjectLearningModeDefault bool
 }
 
-// RunQueueClaimedRun represents a pending run promoted into running state with slot lease.
+// RunQueueClaimedRun represents a pending run promoted into running state.
 type RunQueueClaimedRun struct {
 	// RunID is a unique run identifier.
 	RunID string
@@ -32,9 +32,9 @@ type RunQueueClaimedRun struct {
 	LearningMode bool
 	// RunPayload stores normalized webhook payload.
 	RunPayload json.RawMessage
-	// SlotNo is a slot number leased for this run.
+	// SlotNo is a slot number leased for this run, zero when lease is not required.
 	SlotNo int
-	// SlotID is a unique slot identifier.
+	// SlotID is a unique slot identifier, empty when lease is not required.
 	SlotID string
 }
 

--- a/services/jobs/worker/internal/repository/postgres/runqueue/repository_helpers_test.go
+++ b/services/jobs/worker/internal/repository/postgres/runqueue/repository_helpers_test.go
@@ -1,0 +1,92 @@
+package runqueue
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	querytypes "github.com/codex-k8s/codex-k8s/services/jobs/worker/internal/domain/types/query"
+)
+
+func TestParseRunQueuePayload_ReturnsDeployOnlyRuntime(t *testing.T) {
+	payload := parseRunQueuePayload([]byte(`{"repository":{"full_name":"Codex-K8S/Repo"},"runtime":{"deploy_only":true}}`))
+
+	if got, want := payload.Repository.FullName, "Codex-K8S/Repo"; got != want {
+		t.Fatalf("Repository.FullName mismatch: got %q want %q", got, want)
+	}
+	if payload.Runtime == nil {
+		t.Fatal("expected runtime payload")
+	}
+	if !payload.Runtime.DeployOnly {
+		t.Fatal("expected deploy_only=true")
+	}
+}
+
+func TestParseRunQueuePayload_InvalidJSON(t *testing.T) {
+	payload := parseRunQueuePayload([]byte(`{"repository":`))
+	if payload.Repository.FullName != "" {
+		t.Fatalf("expected empty repository full_name for invalid json, got %q", payload.Repository.FullName)
+	}
+	if payload.Runtime != nil {
+		t.Fatal("expected nil runtime for invalid json")
+	}
+}
+
+func TestIsDeployOnlyRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload querytypes.RunQueuePayload
+		want    bool
+	}{
+		{
+			name: "runtime missing",
+			payload: querytypes.RunQueuePayload{
+				Repository: querytypes.RepositoryPayload{FullName: "codex-k8s/repo"},
+			},
+			want: false,
+		},
+		{
+			name: "deploy_only false",
+			payload: querytypes.RunQueuePayload{
+				Runtime: &querytypes.RunRuntimeProfile{DeployOnly: false},
+			},
+			want: false,
+		},
+		{
+			name: "deploy_only true",
+			payload: querytypes.RunQueuePayload{
+				Runtime: &querytypes.RunRuntimeProfile{DeployOnly: true},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDeployOnlyRun(tt.payload); got != tt.want {
+				t.Fatalf("isDeployOnlyRun()=%v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveProjectID(t *testing.T) {
+	t.Run("from repository full_name", func(t *testing.T) {
+		payload := querytypes.RunQueuePayload{
+			Repository: querytypes.RepositoryPayload{FullName: "Codex-K8S/Repo"},
+		}
+		got := deriveProjectID("corr-1", payload)
+		want := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("repo:codex-k8s/repo")).String()
+		if got != want {
+			t.Fatalf("deriveProjectID()=%q want %q", got, want)
+		}
+	})
+
+	t.Run("fallback to correlation", func(t *testing.T) {
+		got := deriveProjectID("corr-2", querytypes.RunQueuePayload{})
+		want := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("correlation:corr-2")).String()
+		if got != want {
+			t.Fatalf("deriveProjectID()=%q want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Что сделано
- В `runqueue` добавлена ранняя типизированная распаковка `run_payload` с учётом `runtime.deploy_only`.
- Для `deploy_only=true` в `ClaimNextPending` теперь пропускаются шаги slot-пула (`ensure_project_slots`, `release_expired_slots`, `lease_slot`).
- Run переводится в `running` без slot lease (`slot_no=0`, `slot_id=""`), что не ломает текущий reconcile path.
- Обновлены комментарии контрактов `runqueue` о том, что lease может отсутствовать.
- Добавлены unit-тесты `services/jobs/worker/internal/repository/postgres/runqueue/repository_helpers_test.go` на разбор payload и определение `deploy_only`.

## Почему
`deploy-only` ран не запускает агентный job и не должен занимать `slots` namespace-ранов. Раньше slot lease происходил до проверки профиля рантайма, из-за чего deploy-only временно блокировал слот и сдвигал следующие запуски на другой namespace/slot.

## Проверки
- `go test ./services/jobs/worker/...` ✅
- `make lint-go` ✅
- `make dupl-go` ❌ (падает на существующем baseline дубликатов в репозитории, вне области текущих изменений)

## Self-check
- `docs/design-guidelines/common/check_list.md` — выполнено, релевантно 14 пунктов, все выполнены.
- `docs/design-guidelines/go/check_list.md` — выполнено, релевантно 17 пунктов, все выполнены.

Closes #55