### PR TITLE
Fix echo-probe readiness/liveness 404 in runtime deploy

### DIFF
--- a/deploy/base/echo-probe/echo-probe.yaml.tpl
+++ b/deploy/base/echo-probe/echo-probe.yaml.tpl
@@ -51,6 +51,7 @@ spec:
               fi
               mkdir -p /www/.well-known/codex-k8s-probe
               echo -n "$token" > "/www/.well-known/codex-k8s-probe/$token"
+              echo -n "ok" > /www/index.html
               exec httpd -f -p 8080 -h /www
           readinessProbe:
             httpGet:


### PR DESCRIPTION
## Что исправлено
- В шаблоне `deploy/base/echo-probe/echo-probe.yaml.tpl` добавлена генерация `/www/index.html` со значением `ok`.
- Это гарантирует ответ `200` на `/`, который используют `readinessProbe` и `livenessProbe`.

## Почему падало
- Контейнер создавал только `/.well-known/codex-k8s-probe/<token>`, а `/` возвращал `404`.
- Из-за этого `codex-k8s-echo-probe` уходил в `ProgressDeadlineExceeded`, и runtime-deploy зависал на шаге TLS (`wait echo probe deployment`).

## Проверка
- `go test ./services/internal/control-plane/...`

## Чек-лист
- `docs/design-guidelines/common/check_list.md`: релевантные пункты выполнены.
- Go/Vue чек-листы не релевантны: Go/Vue код не менялся.
