### PR TITLE
Worker: учитывать project settings slots_per_project при лизинге слотов

### DIFF
--- a/services/internal/control-plane/internal/domain/types/query/project.go
+++ b/services/internal/control-plane/internal/domain/types/query/project.go
@@ -15,4 +15,5 @@ type ProjectUpsertParams struct {
 // ProjectSettings stores project-level defaults in JSONB settings.
 type ProjectSettings struct {
 	LearningModeDefault bool `json:"learning_mode_default"`
+	SlotsPerProject     int  `json:"slots_per_project,omitempty"`
 }

--- a/services/jobs/worker/internal/domain/types/query/run_payload.go
+++ b/services/jobs/worker/internal/domain/types/query/run_payload.go
@@ -55,4 +55,5 @@ type RunQueuePayload struct {
 // ProjectSettings stores project-level defaults in JSONB settings.
 type ProjectSettings struct {
 	LearningModeDefault bool `json:"learning_mode_default"`
+	SlotsPerProject     int  `json:"slots_per_project,omitempty"`
 }

--- a/services/jobs/worker/internal/repository/postgres/runqueue/repository_helpers_test.go
+++ b/services/jobs/worker/internal/repository/postgres/runqueue/repository_helpers_test.go
@@ -90,3 +90,51 @@ func TestDeriveProjectID(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveSlotsPerProject(t *testing.T) {
+	tests := []struct {
+		name         string
+		projectJSON  []byte
+		fallback     int
+		wantSlotsNum int
+	}{
+		{
+			name:         "empty settings uses fallback",
+			projectJSON:  nil,
+			fallback:     2,
+			wantSlotsNum: 2,
+		},
+		{
+			name:         "invalid settings uses fallback",
+			projectJSON:  []byte(`{"slots_per_project":`),
+			fallback:     3,
+			wantSlotsNum: 3,
+		},
+		{
+			name:         "zero fallback normalized to one",
+			projectJSON:  nil,
+			fallback:     0,
+			wantSlotsNum: 1,
+		},
+		{
+			name:         "settings override fallback",
+			projectJSON:  []byte(`{"learning_mode_default":true,"slots_per_project":10}`),
+			fallback:     2,
+			wantSlotsNum: 10,
+		},
+		{
+			name:         "non-positive settings value ignored",
+			projectJSON:  []byte(`{"slots_per_project":-1}`),
+			fallback:     4,
+			wantSlotsNum: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveSlotsPerProject(tt.projectJSON, tt.fallback); got != tt.wantSlotsNum {
+				t.Fatalf("resolveSlotsPerProject()=%d want %d", got, tt.wantSlotsNum)
+			}
+		})
+	}
+}

--- a/services/jobs/worker/internal/repository/postgres/runqueue/sql/get_project_settings.sql
+++ b/services/jobs/worker/internal/repository/postgres/runqueue/sql/get_project_settings.sql
@@ -1,0 +1,4 @@
+-- name: runqueue__get_project_settings :one
+SELECT settings
+FROM projects
+WHERE id = $1::uuid;


### PR DESCRIPTION
## Что сделано
- В worker run-queue добавлено чтение `projects.settings` перед `ensure_project_slots`.
- Добавлен SQL `runqueue__get_project_settings`.
- Лимит слотов теперь вычисляется так:
  - если в `projects.settings.slots_per_project` указано положительное число — используется оно;
  - иначе используется текущий глобальный fallback `CODEXK8S_WORKER_SLOTS_PER_PROJECT`.
- Добавлены unit-тесты для резолва effective slot limit.
- `ProjectSettings` в query-типах расширен полем `slots_per_project`.

## Почему
Фактический лимит в worker был `2`, из-за чего несколько `run:dev` уходили в `pending`. При этом ключ `slots_per_project` в settings проекта ранее не учитывался worker-очередью.

## Проверки
- `go test ./services/jobs/worker/... ./services/internal/control-plane/internal/domain/types/query/...`
- `make lint-go`
- `make dupl-go` — падает на существующих дубликатах в репозитории (не в рамках этого изменения), новых дубликатов в затронутом коде не добавлено.

## Оперативно в кластере
Для проекта `3278207d-1cd3-4d6f-adf8-9076dae500e0` выставлено:
- `projects.settings.slots_per_project = 10`
- таблица `slots` расширена до `1..10`.

Это дало немедленный эффект по параллелизму до выката этого PR.