### PR TITLE
Issue #68: усилить обратную связь при запуске агента

### DIFF
--- a/docs/architecture/agent_runtime_rbac.md
+++ b/docs/architecture/agent_runtime_rbac.md
@@ -57,6 +57,7 @@ approvals:
   - service account per role/profile,
   - network policy baseline.
 - Cleanup обязателен после завершения run. Если на issue присутствует `run:debug`, cleanup пропускается и namespace сохраняется для отладки.
+- При сохранении namespace в debug-сценарии статус-комментарий run обязан явно отмечать, что namespace не удалён, и давать ссылку на run details для ручного удаления.
 
 Текущий baseline реализации (S2 Day3):
 - Worker создаёт namespace idempotent, применяет `ServiceAccount + Role + RoleBinding + ResourceQuota + LimitRange`.

--- a/docs/product/labels_and_trigger_policy.md
+++ b/docs/product/labels_and_trigger_policy.md
@@ -117,6 +117,7 @@ approvals:
 - `run:debug` не запускает workflow/deploy напрямую.
 - Если label присутствует на issue при старте `run:dev`/`run:dev:revise`, worker не удаляет run-namespace автоматически.
 - Для такого случая пишется событие `run.namespace.cleanup_skipped` с `cleanup_command` для ручного удаления namespace.
+- В статус-комментарии запуска явно указывается, что namespace не удалён, и даётся ссылка на run details, где его можно удалить вручную.
 
 
 ### Service (`state:*`, `need:*`)
@@ -168,6 +169,10 @@ approvals:
     В этом случае платформа запускает соответствующий `run:<stage>:revise`.
     Если stage labels нет или их несколько, ран не создается.
 - Для `run:dev:revise` при отсутствии связанного PR run отклоняется с `failed_precondition` и событием `run.revise.pr_not_found`.
+- При постановке trigger-лейбла платформа сразу даёт обратную связь в issue:
+  - ставит reaction `:eyes:` (если ещё нет);
+  - публикует/обновляет единый статус-комментарий в фазе «планируется запуск агента»;
+  - дальше обновляет тот же комментарий по фазам `подготовка окружения -> запуск -> завершение`.
 - Label transitions после завершения run должны выполняться через MCP (а не вручную в коде агента), чтобы сохранять единый policy/audit контур.
 - Для dev/dev:revise transition выполняется так:
   - снять trigger label с Issue;

--- a/services/internal/control-plane/internal/domain/mcp/github_params.go
+++ b/services/internal/control-plane/internal/domain/mcp/github_params.go
@@ -25,6 +25,15 @@ type GitHubListIssueCommentsParams struct {
 	Limit       int
 }
 
+// GitHubListIssueReactionsParams describes issue reactions list operation in adapter.
+type GitHubListIssueReactionsParams struct {
+	Token       string
+	Owner       string
+	Repository  string
+	IssueNumber int
+	Limit       int
+}
+
 // GitHubListIssueLabelsParams describes issue labels list operation in adapter.
 type GitHubListIssueLabelsParams struct {
 	Token       string
@@ -81,6 +90,15 @@ type GitHubEditIssueCommentParams struct {
 	Repository string
 	CommentID  int64
 	Body       string
+}
+
+// GitHubCreateIssueReactionParams describes issue reaction create operation in adapter.
+type GitHubCreateIssueReactionParams struct {
+	Token       string
+	Owner       string
+	Repository  string
+	IssueNumber int
+	Content     string
 }
 
 // GitHubMutateLabelsParams describes labels add/remove operation in adapter.

--- a/services/internal/control-plane/internal/domain/mcp/model.go
+++ b/services/internal/control-plane/internal/domain/mcp/model.go
@@ -412,6 +412,13 @@ type GitHubIssueComment struct {
 	User string `json:"user"`
 }
 
+// GitHubIssueReaction describes normalized issue reaction details.
+type GitHubIssueReaction struct {
+	ID      int64  `json:"id"`
+	Content string `json:"content"`
+	User    string `json:"user"`
+}
+
 // GitHubLabel describes normalized label details.
 type GitHubLabel struct {
 	Name string `json:"name"`

--- a/services/internal/control-plane/internal/domain/runstatus/constants.go
+++ b/services/internal/control-plane/internal/domain/runstatus/constants.go
@@ -34,6 +34,10 @@ const (
 	runStatusFailed    = "failed"
 )
 
+const (
+	githubIssueReactionEyes = "eyes"
+)
+
 type commentTargetKind string
 
 const (

--- a/services/internal/control-plane/internal/domain/runstatus/helpers.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers.go
@@ -66,14 +66,16 @@ func normalizeRequestedByType(value RequestedByType) RequestedByType {
 func phaseOrder(phase Phase) int {
 	switch phase {
 	case PhaseNamespaceDeleted:
-		return 6
+		return 7
 	case PhaseFinished:
-		return 5
+		return 6
 	case PhaseAuthResolved:
-		return 4
+		return 5
 	case PhaseAuthRequired:
-		return 3
+		return 4
 	case PhaseStarted:
+		return 3
+	case PhasePreparingRuntime:
 		return 2
 	case PhaseCreated:
 		return 1

--- a/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
@@ -85,3 +85,14 @@ func TestResolveCommentTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestPhaseOrder_PreparingRuntimeBetweenCreatedAndStarted(t *testing.T) {
+	t.Parallel()
+
+	if gotCreated, gotPreparing := phaseOrder(PhaseCreated), phaseOrder(PhasePreparingRuntime); gotPreparing <= gotCreated {
+		t.Fatalf("expected preparing phase order to be greater than created: created=%d preparing=%d", gotCreated, gotPreparing)
+	}
+	if gotPreparing, gotStarted := phaseOrder(PhasePreparingRuntime), phaseOrder(PhaseStarted); gotPreparing >= gotStarted {
+		t.Fatalf("expected preparing phase order to be less than started: preparing=%d started=%d", gotPreparing, gotStarted)
+	}
+}

--- a/services/internal/control-plane/internal/domain/runstatus/model.go
+++ b/services/internal/control-plane/internal/domain/runstatus/model.go
@@ -17,6 +17,7 @@ type Phase string
 
 const (
 	PhaseCreated          Phase = "created"
+	PhasePreparingRuntime Phase = "preparing_runtime"
 	PhaseStarted          Phase = "started"
 	PhaseAuthRequired     Phase = "auth_required"
 	PhaseAuthResolved     Phase = "auth_resolved"
@@ -161,6 +162,8 @@ type GitHubClient interface {
 	ListIssueComments(ctx context.Context, params mcpdomain.GitHubListIssueCommentsParams) ([]mcpdomain.GitHubIssueComment, error)
 	CreateIssueComment(ctx context.Context, params mcpdomain.GitHubCreateIssueCommentParams) (mcpdomain.GitHubIssueComment, error)
 	EditIssueComment(ctx context.Context, params mcpdomain.GitHubEditIssueCommentParams) (mcpdomain.GitHubIssueComment, error)
+	ListIssueReactions(ctx context.Context, params mcpdomain.GitHubListIssueReactionsParams) ([]mcpdomain.GitHubIssueReaction, error)
+	CreateIssueReaction(ctx context.Context, params mcpdomain.GitHubCreateIssueReactionParams) (mcpdomain.GitHubIssueReaction, error)
 }
 
 // Dependencies wires required adapters for runstatus service.

--- a/services/internal/control-plane/internal/domain/runstatus/render_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/render_test.go
@@ -5,18 +5,25 @@ import (
 	"testing"
 )
 
+func mustRenderCommentBody(t *testing.T, state commentState, managementURL string) string {
+	t.Helper()
+
+	body, err := renderCommentBody(state, managementURL)
+	if err != nil {
+		t.Fatalf("renderCommentBody returned error: %v", err)
+	}
+	return body
+}
+
 func TestRenderCommentBody_RendersTemplateByLocale(t *testing.T) {
 	t.Parallel()
 
-	body, err := renderCommentBody(commentState{
+	body := mustRenderCommentBody(t, commentState{
 		RunID:        "run-1",
 		Phase:        PhaseStarted,
 		TriggerKind:  triggerKindDev,
 		PromptLocale: localeRU,
 	}, "https://platform.codex-k8s.dev/runs/run-1")
-	if err != nil {
-		t.Fatalf("renderCommentBody returned error: %v", err)
-	}
 	if !strings.Contains(body, "### 🧠 Запуск ИИ-агента") {
 		t.Fatalf("rendered body does not contain russian title: %q", body)
 	}
@@ -25,10 +32,28 @@ func TestRenderCommentBody_RendersTemplateByLocale(t *testing.T) {
 	}
 }
 
+func TestRenderCommentBody_RendersPlannedLaunchState(t *testing.T) {
+	t.Parallel()
+
+	body := mustRenderCommentBody(t, commentState{
+		RunID:        "run-planned",
+		Phase:        PhaseCreated,
+		RuntimeMode:  runtimeModeFullEnv,
+		RunStatus:    "pending",
+		PromptLocale: localeRU,
+	}, "https://platform.codex-k8s.dev/runs/run-planned")
+	if !strings.Contains(body, "Планируется запуск агента") {
+		t.Fatalf("rendered body does not contain planned launch marker: %q", body)
+	}
+	if !strings.Contains(body, "Ожидание подготовки окружения") {
+		t.Fatalf("rendered body does not contain waiting runtime preparation marker: %q", body)
+	}
+}
+
 func TestRenderCommentBody_RendersSlotURLAndAuthTimeline(t *testing.T) {
 	t.Parallel()
 
-	body, err := renderCommentBody(commentState{
+	body := mustRenderCommentBody(t, commentState{
 		RunID:        "run-2",
 		Phase:        PhaseAuthResolved,
 		RuntimeMode:  runtimeModeFullEnv,
@@ -37,9 +62,6 @@ func TestRenderCommentBody_RendersSlotURLAndAuthTimeline(t *testing.T) {
 		RunStatus:    "running",
 		PromptLocale: localeRU,
 	}, "https://platform.codex-k8s.dev/runs/run-2")
-	if err != nil {
-		t.Fatalf("renderCommentBody returned error: %v", err)
-	}
 	if !strings.Contains(body, "Ссылка на слот") {
 		t.Fatalf("rendered body does not contain slot url label: %q", body)
 	}
@@ -51,20 +73,75 @@ func TestRenderCommentBody_RendersSlotURLAndAuthTimeline(t *testing.T) {
 func TestRenderCommentBody_RendersAuthVerificationPayload(t *testing.T) {
 	t.Parallel()
 
-	body, err := renderCommentBody(commentState{
+	body := mustRenderCommentBody(t, commentState{
 		RunID:                    "run-auth",
 		Phase:                    PhaseAuthRequired,
 		PromptLocale:             localeRU,
 		CodexAuthVerificationURL: "https://example.com/device",
 		CodexAuthUserCode:        "ABCD-EFGH",
 	}, "https://platform.codex-k8s.dev/runs/run-auth")
-	if err != nil {
-		t.Fatalf("renderCommentBody returned error: %v", err)
-	}
 	if !strings.Contains(body, "Ссылка авторизации") {
 		t.Fatalf("rendered body does not contain auth verification url label: %q", body)
 	}
 	if !strings.Contains(body, "ABCD-EFGH") {
 		t.Fatalf("rendered body does not contain auth user code: %q", body)
+	}
+}
+
+func TestRenderCommentBody_RuntimePreparationAndNamespaceMessages(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		state         commentState
+		managementURL string
+		mustContain   []string
+	}{
+		{
+			name: "runtime_preparing",
+			state: commentState{
+				RunID:        "run-preparing",
+				Phase:        PhasePreparingRuntime,
+				RuntimeMode:  runtimeModeFullEnv,
+				Namespace:    "codex-k8s-dev-2",
+				RunStatus:    "running",
+				PromptLocale: localeRU,
+			},
+			managementURL: "https://platform.codex-k8s.dev/runs/run-preparing",
+			mustContain: []string{
+				"Идёт подготовка окружения",
+				"namespace, runtime stack, slot URL",
+			},
+		},
+		{
+			name: "namespace_kept",
+			state: commentState{
+				RunID:        "run-debug",
+				Phase:        PhaseNamespaceDeleted,
+				RuntimeMode:  runtimeModeFullEnv,
+				Namespace:    "codex-k8s-dev-2",
+				RunStatus:    "succeeded",
+				PromptLocale: localeRU,
+			},
+			managementURL: "https://platform.codex-k8s.dev/runs/run-debug",
+			mustContain: []string{
+				"Namespace не удален",
+				"Удалить его можно на странице запуска",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := mustRenderCommentBody(t, testCase.state, testCase.managementURL)
+			for _, expected := range testCase.mustContain {
+				if !strings.Contains(body, expected) {
+					t.Fatalf("rendered body does not contain %q: %q", expected, body)
+				}
+			}
+		})
 	}
 }

--- a/services/internal/control-plane/internal/domain/runstatus/templates/comment_en.md.tmpl
+++ b/services/internal/control-plane/internal/domain/runstatus/templates/comment_en.md.tmpl
@@ -8,7 +8,13 @@
 - User code: `{{ .CodexAuthUserCode }}`
 {{- end }}
 {{- else }}
+{{- if .AgentStarted }}
 ✅ Agent started{{- if .ManagementURL }}&nbsp;&nbsp;&nbsp;&nbsp;📎 [Run link]({{ .ManagementURL }}){{- end }}
+{{- else if .PreparingRuntimeReached }}
+🛠 Runtime preparation in progress{{- if .ManagementURL }}&nbsp;&nbsp;&nbsp;&nbsp;📎 [Run link]({{ .ManagementURL }}){{- end }}
+{{- else }}
+👀 Agent launch is planned{{- if .ManagementURL }}&nbsp;&nbsp;&nbsp;&nbsp;📎 [Run link]({{ .ManagementURL }}){{- end }}
+{{- end }}
 {{- end }}
 
 - Run ID: `{{ .RunID }}`
@@ -43,6 +49,17 @@
 {{- else }}
 - ⏳ Run is being created
 {{- end }}
+{{- if .ShowRuntimePreparation }}
+{{- if .PreparingRuntimeReached }}
+{{- if .RuntimePreparationCompleted }}
+- ✅ Runtime preparation completed (namespace, runtime stack, slot URL)
+{{- else }}
+- 🛠 Runtime preparation in progress (namespace, runtime stack, slot URL)
+{{- end }}
+{{- else }}
+- ⏳ Waiting for runtime preparation
+{{- end }}
+{{- end }}
 {{- if .StartedReached }}
 - ✅ Agent started
 {{- else }}
@@ -72,7 +89,7 @@
 {{- else if .Deleted }}
 - 🗑️ Namespace deleted
 {{- else }}
-- 🗑️ Namespace is waiting for cleanup
+- 🧪 Namespace was kept. You can delete it from the run details page.
 {{- end }}
 {{- end }}
 

--- a/services/internal/control-plane/internal/domain/runstatus/templates/comment_ru.md.tmpl
+++ b/services/internal/control-plane/internal/domain/runstatus/templates/comment_ru.md.tmpl
@@ -8,7 +8,13 @@
 - Код авторизации: `{{ .CodexAuthUserCode }}`
 {{- end }}
 {{- else }}
+{{- if .AgentStarted }}
 ✅ Агент запущен{{- if .ManagementURL }}&nbsp;&nbsp;&nbsp;&nbsp;📎 [Ссылка на запуск]({{ .ManagementURL }}){{- end }}
+{{- else if .PreparingRuntimeReached }}
+🛠 Идёт подготовка окружения{{- if .ManagementURL }}&nbsp;&nbsp;&nbsp;&nbsp;📎 [Ссылка на запуск]({{ .ManagementURL }}){{- end }}
+{{- else }}
+👀 Планируется запуск агента{{- if .ManagementURL }}&nbsp;&nbsp;&nbsp;&nbsp;📎 [Ссылка на запуск]({{ .ManagementURL }}){{- end }}
+{{- end }}
 {{- end }}
 
 - Run ID: `{{ .RunID }}`
@@ -43,6 +49,17 @@
 {{- else }}
 - ⏳ Run создаётся
 {{- end }}
+{{- if .ShowRuntimePreparation }}
+{{- if .PreparingRuntimeReached }}
+{{- if .RuntimePreparationCompleted }}
+- ✅ Подготовка окружения завершена (namespace, runtime stack, slot URL)
+{{- else }}
+- 🛠 Идёт подготовка окружения (namespace, runtime stack, slot URL)
+{{- end }}
+{{- else }}
+- ⏳ Ожидание подготовки окружения
+{{- end }}
+{{- end }}
 {{- if .StartedReached }}
 - ✅ Агент запущен
 {{- else }}
@@ -72,7 +89,7 @@
 {{- else if .Deleted }}
 - 🗑️ Namespace удален
 {{- else }}
-- 🗑️ Namespace ожидает удаления
+- 🧪 Namespace не удален. Удалить его можно на странице запуска.
 {{- end }}
 {{- end }}
 

--- a/services/internal/control-plane/internal/transport/grpc/server.go
+++ b/services/internal/control-plane/internal/transport/grpc/server.go
@@ -1344,21 +1344,21 @@ func (s *Server) UpsertRunStatusComment(ctx context.Context, req *controlplanev1
 	}
 
 	result, err := s.runStatus.UpsertRunStatusComment(ctx, runstatusdomain.UpsertCommentParams{
-		RunID:           runID,
-		Phase:           phase,
-		JobName:         strings.TrimSpace(req.GetJobName()),
-		JobNamespace:    strings.TrimSpace(req.GetJobNamespace()),
-		RuntimeMode:     strings.TrimSpace(req.GetRuntimeMode()),
-		Namespace:       strings.TrimSpace(req.GetNamespace()),
-		TriggerKind:     strings.TrimSpace(req.GetTriggerKind()),
-		PromptLocale:    strings.TrimSpace(req.GetPromptLocale()),
-		Model:           strings.TrimSpace(req.GetModel()),
-		ReasoningEffort: strings.TrimSpace(req.GetReasoningEffort()),
-		RunStatus:       strings.TrimSpace(req.GetRunStatus()),
+		RunID:                    runID,
+		Phase:                    phase,
+		JobName:                  strings.TrimSpace(req.GetJobName()),
+		JobNamespace:             strings.TrimSpace(req.GetJobNamespace()),
+		RuntimeMode:              strings.TrimSpace(req.GetRuntimeMode()),
+		Namespace:                strings.TrimSpace(req.GetNamespace()),
+		TriggerKind:              strings.TrimSpace(req.GetTriggerKind()),
+		PromptLocale:             strings.TrimSpace(req.GetPromptLocale()),
+		Model:                    strings.TrimSpace(req.GetModel()),
+		ReasoningEffort:          strings.TrimSpace(req.GetReasoningEffort()),
+		RunStatus:                strings.TrimSpace(req.GetRunStatus()),
 		CodexAuthVerificationURL: strings.TrimSpace(req.GetCodexAuthVerificationUrl()),
 		CodexAuthUserCode:        strings.TrimSpace(req.GetCodexAuthUserCode()),
-		Deleted:         req.GetDeleted(),
-		AlreadyDeleted:  req.GetAlreadyDeleted(),
+		Deleted:                  req.GetDeleted(),
+		AlreadyDeleted:           req.GetAlreadyDeleted(),
 	})
 	if err != nil {
 		s.logger.Error("upsert run status comment via grpc failed", "run_id", runID, "phase", phase, "err", err)
@@ -1821,6 +1821,8 @@ func parseRunStatusPhase(value string) (runstatusdomain.Phase, error) {
 	switch strings.TrimSpace(value) {
 	case string(runstatusdomain.PhaseCreated):
 		return runstatusdomain.PhaseCreated, nil
+	case string(runstatusdomain.PhasePreparingRuntime):
+		return runstatusdomain.PhasePreparingRuntime, nil
 	case string(runstatusdomain.PhaseStarted):
 		return runstatusdomain.PhaseStarted, nil
 	case string(runstatusdomain.PhaseAuthRequired):

--- a/services/jobs/worker/internal/domain/worker/run_status.go
+++ b/services/jobs/worker/internal/domain/worker/run_status.go
@@ -7,6 +7,7 @@ type RunStatusPhase string
 
 const (
 	RunStatusPhaseCreated          RunStatusPhase = "created"
+	RunStatusPhasePreparingRuntime RunStatusPhase = "preparing_runtime"
 	RunStatusPhaseStarted          RunStatusPhase = "started"
 	RunStatusPhaseFinished         RunStatusPhase = "finished"
 	RunStatusPhaseNamespaceDeleted RunStatusPhase = "namespace_deleted"

--- a/services/jobs/worker/internal/domain/worker/service_test.go
+++ b/services/jobs/worker/internal/domain/worker/service_test.go
@@ -33,6 +33,7 @@ func TestTickLaunchesPendingRun(t *testing.T) {
 	events := &fakeFlowEvents{}
 	launcher := &fakeLauncher{states: map[string]JobState{}}
 	mcpTokens := &fakeMCPTokenIssuer{token: "token-run-1"}
+	runStatus := &fakeRunStatusNotifier{}
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 
 	svc := NewService(Config{
@@ -47,6 +48,7 @@ func TestTickLaunchesPendingRun(t *testing.T) {
 		Events:         events,
 		Launcher:       launcher,
 		MCPTokenIssuer: mcpTokens,
+		RunStatus:      runStatus,
 		Logger:         logger,
 	})
 	svc.now = func() time.Time { return time.Date(2026, 2, 9, 10, 0, 0, 0, time.UTC) }
@@ -72,6 +74,12 @@ func TestTickLaunchesPendingRun(t *testing.T) {
 	}
 	if events.inserted[1].EventType != floweventdomain.EventTypeRunStarted {
 		t.Fatalf("expected second event run.started, got %s", events.inserted[1].EventType)
+	}
+	if len(runStatus.upserts) < 1 {
+		t.Fatalf("expected run status upserts, got %d", len(runStatus.upserts))
+	}
+	if runStatus.upserts[0].Phase != RunStatusPhasePreparingRuntime {
+		t.Fatalf("expected first run status phase %q, got %q", RunStatusPhasePreparingRuntime, runStatus.upserts[0].Phase)
 	}
 }
 
@@ -493,6 +501,7 @@ func TestTickFinalizesFullEnvRunSkipsCleanupForDebugLabel(t *testing.T) {
 	}
 	events := &fakeFlowEvents{}
 	launcher := &fakeLauncher{states: map[string]JobState{"run-5": JobStateSucceeded}}
+	runStatus := &fakeRunStatusNotifier{}
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 
 	svc := NewService(Config{
@@ -505,10 +514,11 @@ func TestTickFinalizesFullEnvRunSkipsCleanupForDebugLabel(t *testing.T) {
 		CleanupFullEnvNamespace: true,
 		RunDebugLabel:           "run:debug",
 	}, Dependencies{
-		Runs:     runs,
-		Events:   events,
-		Launcher: launcher,
-		Logger:   logger,
+		Runs:      runs,
+		Events:    events,
+		Launcher:  launcher,
+		RunStatus: runStatus,
+		Logger:    logger,
 	})
 	svc.now = func() time.Time { return time.Date(2026, 2, 11, 12, 0, 0, 0, time.UTC) }
 
@@ -531,6 +541,18 @@ func TestTickFinalizesFullEnvRunSkipsCleanupForDebugLabel(t *testing.T) {
 	}
 	if !strings.Contains(string(events.inserted[1].Payload), "debug_label_present") {
 		t.Fatalf("expected cleanup_skipped payload to include debug reason, got %s", string(events.inserted[1].Payload))
+	}
+	if len(runStatus.upserts) != 2 {
+		t.Fatalf("expected finished + namespace cleanup skipped run status upserts, got %d", len(runStatus.upserts))
+	}
+	if runStatus.upserts[1].Phase != RunStatusPhaseNamespaceDeleted {
+		t.Fatalf("expected second run status phase %q, got %q", RunStatusPhaseNamespaceDeleted, runStatus.upserts[1].Phase)
+	}
+	if runStatus.upserts[1].Deleted {
+		t.Fatalf("expected namespace cleanup skipped marker to keep Deleted=false")
+	}
+	if runStatus.upserts[1].AlreadyDeleted {
+		t.Fatalf("expected namespace cleanup skipped marker to keep AlreadyDeleted=false")
 	}
 }
 
@@ -602,6 +624,15 @@ type fakeRuntimePreparer struct {
 	prepared []PrepareRunEnvironmentParams
 	result   PrepareRunEnvironmentResult
 	err      error
+}
+
+type fakeRunStatusNotifier struct {
+	upserts []RunStatusCommentParams
+}
+
+func (f *fakeRunStatusNotifier) UpsertRunStatusComment(_ context.Context, params RunStatusCommentParams) (RunStatusCommentResult, error) {
+	f.upserts = append(f.upserts, params)
+	return RunStatusCommentResult{CommentID: int64(len(f.upserts))}, nil
 }
 
 func (f *fakeRuntimePreparer) PrepareRunEnvironment(_ context.Context, params PrepareRunEnvironmentParams) (PrepareRunEnvironmentResult, error) {


### PR DESCRIPTION
## Что сделано

Реализовано усиление обратной связи при запуске run по trigger-лейблу:

- добавлена ранняя фаза run-status `preparing_runtime`;
- при постановке `run:dev`/`run:*` на issue теперь сразу публикуется/обновляется статус-комментарий в фазе «👀 Планируется запуск агента»;
- для issue при ранних фазах выполняется best-effort постановка реакции `:eyes:` (если её ещё нет);
- тот же комментарий последовательно обновляется по фазам подготовки окружения, запуска и завершения;
- в worker добавлен отдельный апдейт статуса на фазе подготовки runtime до старта job;
- исправлен сценарий debug cleanup skip: в комментарии явно отображается, что namespace не удалён, и что удалить его можно из страницы запуска (run details);
- расширен GitHub adapter (list/create issue reactions) и MCP-domain DTO для реакций;
- обновлены RU/EN шаблоны run-status комментария и таймлайн;
- обновлена документация продукта и архитектуры по новому поведению.

## Изменённые области

- `services/internal/control-plane/internal/domain/runstatus/*`
- `services/internal/control-plane/internal/domain/webhook/service.go`
- `services/jobs/worker/internal/domain/worker/*`
- `services/internal/control-plane/internal/clients/github/client.go`
- `services/internal/control-plane/internal/domain/mcp/{github_params.go,model.go}`
- `docs/product/labels_and_trigger_policy.md`
- `docs/architecture/agent_runtime_rbac.md`

## Проверки

Запущено:

- `go test ./services/internal/control-plane/internal/clients/github ./services/internal/control-plane/internal/domain/runstatus ./services/internal/control-plane/internal/domain/webhook ./services/internal/control-plane/internal/transport/grpc ./services/jobs/worker/internal/domain/worker`
- `make lint-go`
- `make dupl-go`

Результат:

- `go test` — успешно;
- `make lint-go` — успешно;
- `make dupl-go` — падает на существующих исторических дубликатах в репозитории (вне scope задачи), новых дубликатов по текущему change-set не добавлялось.

## Self-check

- `docs/design-guidelines/common/check_list.md` — релевантные пункты проверены, выполнены;
- `docs/design-guidelines/go/check_list.md` — релевантные пункты проверены, выполнены.

Closes #68
