### PR TITLE
Исправить подмену trigger_kind на dev в статус-комментариях run

### DIFF
--- a/services/internal/control-plane/internal/domain/runstatus/helpers.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers.go
@@ -24,6 +24,14 @@ func normalizeTriggerKind(value string) string {
 	return string(webhookdomain.NormalizeTriggerKind(value))
 }
 
+func resolveUpsertTriggerKind(explicit string, fallback string) string {
+	trimmedExplicit := strings.TrimSpace(explicit)
+	if trimmedExplicit != "" {
+		return normalizeTriggerKind(trimmedExplicit)
+	}
+	return normalizeTriggerKind(fallback)
+}
+
 func normalizeTriggerSource(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case triggerSourcePullRequestReview:

--- a/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
@@ -96,3 +96,17 @@ func TestPhaseOrder_PreparingRuntimeBetweenCreatedAndStarted(t *testing.T) {
 		t.Fatalf("expected preparing phase order to be less than started: preparing=%d started=%d", gotPreparing, gotStarted)
 	}
 }
+
+func TestResolveUpsertTriggerKind(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveUpsertTriggerKind("design", "dev"); got != "design" {
+		t.Fatalf("resolveUpsertTriggerKind(design, dev) = %q, want %q", got, "design")
+	}
+	if got := resolveUpsertTriggerKind("", "design"); got != "design" {
+		t.Fatalf("resolveUpsertTriggerKind(empty, design) = %q, want %q", got, "design")
+	}
+	if got := resolveUpsertTriggerKind("  ", ""); got != "dev" {
+		t.Fatalf("resolveUpsertTriggerKind(blank, empty) = %q, want %q", got, "dev")
+	}
+}

--- a/services/internal/control-plane/internal/domain/runstatus/service.go
+++ b/services/internal/control-plane/internal/domain/runstatus/service.go
@@ -74,15 +74,16 @@ func (s *Service) UpsertRunStatusComment(ctx context.Context, params UpsertComme
 		(params.Phase == PhaseCreated || params.Phase == PhasePreparingRuntime) {
 		_ = s.ensureIssueWatchingReactionForRunContext(ctx, runCtx)
 	}
+	effectiveTriggerKind := resolveUpsertTriggerKind(params.TriggerKind, runCtx.triggerKind)
 
 	currentState := commentState{
 		RunID:                    runID,
 		Phase:                    params.Phase,
 		JobName:                  strings.TrimSpace(params.JobName),
 		JobNamespace:             strings.TrimSpace(params.JobNamespace),
-		RuntimeMode:              normalizeRuntimeMode(params.RuntimeMode, params.TriggerKind),
+		RuntimeMode:              normalizeRuntimeMode(params.RuntimeMode, effectiveTriggerKind),
 		Namespace:                strings.TrimSpace(params.Namespace),
-		TriggerKind:              normalizeTriggerKind(params.TriggerKind),
+		TriggerKind:              effectiveTriggerKind,
 		PromptLocale:             normalizeLocale(params.PromptLocale, s.cfg.DefaultLocale),
 		Model:                    strings.TrimSpace(params.Model),
 		ReasoningEffort:          strings.TrimSpace(params.ReasoningEffort),


### PR DESCRIPTION
## Проблема
На issue `#57` запуск был корректно создан по `run:design` (`trigger.kind=design`, `agent.key=sa` в `agent_runs.run_payload`), но статус-комментарий в GitHub показывал `trigger_kind=dev`.

## Причина
`runstatus.UpsertRunStatusComment` нормализовал `params.TriggerKind` на каждом апдейте.
Для фаз, где worker не передает `trigger_kind` (например `finished`, `namespace_deleted`), пустое значение превращалось в `dev` и перезаписывало ранее корректный `design` в state marker комментария.

## Что изменено
- добавлен helper `resolveUpsertTriggerKind(explicit, fallback)`;
- в `UpsertRunStatusComment` теперь используется fallback на trigger из `run_payload` (`runCtx.triggerKind`), если в текущем апдейте `trigger_kind` не передан;
- добавлен unit-тест `TestResolveUpsertTriggerKind`.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runstatus`
- `go test ./services/internal/control-plane/internal/domain/webhook`
- `make lint-go`
- `make dupl-go` (падает на существующих дублях репозитория, вне этого PR)

## Чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты выполнены
- `docs/design-guidelines/go/check_list.md` — релевантные пункты выполнены
