### PR TITLE
Fix control-plane MCP panic and prevent parallel runtime deploy claims

### DIFF
--- a/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/claim_next.sql
+++ b/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/claim_next.sql
@@ -1,19 +1,31 @@
 -- name: runtimedeploytask__claim_next :one
 WITH candidate AS (
-    SELECT run_id
-    FROM runtime_deploy_tasks
-    WHERE status = 'pending'
-       OR (
-           status = 'running'
-           AND lease_until IS NOT NULL
-           AND lease_until < NOW()
-       )
-       OR (
-           status = 'running'
-           AND lease_until IS NOT NULL
-           AND updated_at < NOW() - INTERVAL '2 minutes'
-       )
-    ORDER BY updated_at ASC
+    SELECT t.run_id
+    FROM runtime_deploy_tasks t
+    WHERE (
+        t.status = 'pending'
+        OR (
+            t.status = 'running'
+            AND t.lease_until IS NOT NULL
+            AND t.lease_until < NOW()
+        )
+        OR (
+            t.status = 'running'
+            AND t.lease_until IS NOT NULL
+            AND t.updated_at < NOW() - INTERVAL '2 minutes'
+        )
+    )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM runtime_deploy_tasks active
+          WHERE active.run_id <> t.run_id
+            AND active.status = 'running'
+            AND active.lease_until IS NOT NULL
+            AND active.lease_until >= NOW()
+            AND active.namespace = t.namespace
+            AND active.target_env = t.target_env
+      )
+    ORDER BY t.updated_at ASC
     FOR UPDATE SKIP LOCKED
     LIMIT 1
 )

--- a/services/internal/control-plane/internal/transport/mcp/tools_test.go
+++ b/services/internal/control-plane/internal/transport/mcp/tools_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	mcpdomain "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/mcp"
+)
+
+type testToolInput struct {
+	Status string `json:"status"`
+}
+
+type testToolOutput struct {
+	OK bool `json:"ok"`
+}
+
+func TestAddTool_DoesNotPanicOnNilInputSchema(t *testing.T) {
+	t.Parallel()
+
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	run := func(_ context.Context, _ mcpdomain.SessionContext, _ testToolInput) (testToolOutput, error) {
+		return testToolOutput{OK: true}, nil
+	}
+
+	mustNotPanic(t, func() {
+		addTool(server, mcpdomain.ToolName("test.tool.nil-schema"), "test", run)
+	})
+}
+
+func TestAddToolWithInputSchema_DoesNotPanicOnTypedNilSchema(t *testing.T) {
+	t.Parallel()
+
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	run := func(_ context.Context, _ mcpdomain.SessionContext, _ testToolInput) (testToolOutput, error) {
+		return testToolOutput{OK: true}, nil
+	}
+
+	var typedNilSchema *jsonschema.Schema
+	mustNotPanic(t, func() {
+		addToolWithInputSchema(server, mcpdomain.ToolName("test.tool.typed-nil-schema"), "test", typedNilSchema, run)
+	})
+}
+
+func mustNotPanic(t *testing.T, fn func()) {
+	t.Helper()
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("unexpected panic: %v", recovered)
+		}
+	}()
+	fn()
+}


### PR DESCRIPTION
## Что сделано

1. Исправлен panic в `control-plane` при старте MCP handler.
- Файл: `services/internal/control-plane/internal/transport/mcp/tools.go`
- Причина: в `sdkmcp.Tool.InputSchema` передавался typed-nil `*jsonschema.Schema`, что для `interface{}` считалось «не nil», и `go-sdk` пытался резолвить nil-схему.
- Исправление: `InputSchema` теперь задаётся только когда `inputSchema != nil`.

2. Добавлен regression-тест на отсутствие panic.
- Файл: `services/internal/control-plane/internal/transport/mcp/tools_test.go`
- Покрывает оба сценария: `addTool(..., nil)` и `addToolWithInputSchema(..., typed-nil)`.

3. Добавлена сериализация runtime-deploy claim по окружению/namespace.
- Файл: `services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/claim_next.sql`
- Теперь новый task не клеймится, если уже есть активный `running` task с валидным lease для той же пары `namespace + target_env`.
- Это предотвращает одновременный запуск нескольких production deploy задач в один namespace.

## Проверки

- `go test ./services/internal/control-plane/internal/transport/mcp ./services/internal/control-plane/internal/repository/postgres/runtimedeploytask ./services/internal/control-plane/internal/domain/runtimedeploy`
- `make lint-go`
- `make dupl-go` (падает на уже существующих дублях в репозитории, вне этого PR)

## Контекст инцидента

В проде был зафиксирован crash-loop нового `control-plane` pod из-за panic при регистрации MCP tools.
Это блокировало rollout `codex-k8s-app`, и несколько deploy-only run застряли в `running` на стадии `Apply unit codex-k8s-app started`.

