### PR TITLE
Убрать фронтовый вывод «Ошибка платформы» и пометить backend-ручки TODO

### DIFF
--- a/services/external/api-gateway/internal/transport/http/server.go
+++ b/services/external/api-gateway/internal/transport/http/server.go
@@ -110,6 +110,8 @@ func NewServer(initCtx context.Context, cfg ServerConfig, cp *controlplane.Clien
 	staffGroup.GET("/runs/:run_id/learning-feedback", staffH.ListRunLearningFeedback)
 	staffGroup.GET("/runtime-deploy/tasks", staffH.ListRuntimeDeployTasks)
 	staffGroup.GET("/runtime-deploy/tasks/:run_id", staffH.GetRuntimeDeployTask)
+	// TODO(codex-k8s#81): Staff UI no longer renders "platform error" alerts.
+	// Revisit runtime-errors endpoints usage and decide whether to keep, repurpose, or remove them.
 	staffGroup.GET("/runtime-errors", staffH.ListRuntimeErrors)
 	staffGroup.POST("/runtime-errors/:runtime_error_id/viewed", staffH.MarkRuntimeErrorViewed)
 	staffGroup.GET("/runtime-deploy/images", staffH.ListRegistryImages)

--- a/services/external/api-gateway/internal/transport/http/staff_handler.go
+++ b/services/external/api-gateway/internal/transport/http/staff_handler.go
@@ -518,6 +518,8 @@ func (h *staffHandler) GetRuntimeDeployTask(c *echo.Context) error {
 	return getByPathResp(c, "run_id", h.getRuntimeDeployTaskCall, casters.RuntimeDeployTask)
 }
 
+// TODO(codex-k8s#81): This endpoint is temporarily unused after staff UI removed
+// "platform error" alerts. Decide later whether to keep, repurpose, or remove it.
 func (h *staffHandler) ListRuntimeErrors(c *echo.Context) error {
 	return withPrincipalAndResolved(c, resolveRuntimeErrorsListFilters(5), func(principal *controlplanev1.Principal, arg runtimeErrorsListArg) error {
 		resp, err := h.listRuntimeErrorsCall(c.Request().Context(), principal, arg)
@@ -528,6 +530,8 @@ func (h *staffHandler) ListRuntimeErrors(c *echo.Context) error {
 	})
 }
 
+// TODO(codex-k8s#81): This endpoint is temporarily unused after staff UI removed
+// "platform error" alerts. Decide later whether to keep, repurpose, or remove it.
 func (h *staffHandler) MarkRuntimeErrorViewed(c *echo.Context) error {
 	return getByPathResp(c, "runtime_error_id", h.markRuntimeErrorViewedCall, casters.RuntimeError)
 }

--- a/services/internal/control-plane/internal/transport/grpc/server.go
+++ b/services/internal/control-plane/internal/transport/grpc/server.go
@@ -1012,6 +1012,8 @@ func (s *Server) GetRuntimeDeployTask(ctx context.Context, req *controlplanev1.G
 	return runtimeDeployTaskToProto(item), nil
 }
 
+// TODO(codex-k8s#81): This RPC is temporarily unused after staff UI removed
+// "platform error" alerts. Decide later whether to keep, repurpose, or remove it.
 func (s *Server) ListRuntimeErrors(ctx context.Context, req *controlplanev1.ListRuntimeErrorsRequest) (*controlplanev1.ListRuntimeErrorsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
@@ -1038,6 +1040,8 @@ func (s *Server) ListRuntimeErrors(ctx context.Context, req *controlplanev1.List
 	return &controlplanev1.ListRuntimeErrorsResponse{Items: out}, nil
 }
 
+// TODO(codex-k8s#81): This RPC is temporarily unused after staff UI removed
+// "platform error" alerts. Decide later whether to keep, repurpose, or remove it.
 func (s *Server) MarkRuntimeErrorViewed(ctx context.Context, req *controlplanev1.MarkRuntimeErrorViewedRequest) (*controlplanev1.RuntimeError, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")


### PR DESCRIPTION
## Что сделано
- Полностью удалён фронтовый вывод алертов «Ошибка платформы» из `services/staff/web-console/src/app/App.vue`.
- Убран polling runtime-errors и связанные действия dismiss/open на уровне главного приложения.
- Добавлены англоязычные TODO-комментарии в backend-ручки runtime-errors (HTTP и gRPC), что они временно не используются и требуют отдельного решения по дальнейшей судьбе.

## Изменённые файлы
- `services/staff/web-console/src/app/App.vue`
- `services/external/api-gateway/internal/transport/http/server.go`
- `services/external/api-gateway/internal/transport/http/staff_handler.go`
- `services/internal/control-plane/internal/transport/grpc/server.go`

## Проверки
- `go test ./services/external/api-gateway/internal/transport/http/...`
- `go test ./services/internal/control-plane/internal/transport/grpc/...`
- `npm --prefix services/staff/web-console run build` (после `npm ci`)

## Риски и замечания
- API и доменная часть runtime-errors сохранены, но фронт больше их не использует.
- TODO-комментарии оставлены в точках входа backend, чтобы отдельно принять решение: удалить, переиспользовать или оставить эти ручки.

## Self-check
- `docs/design-guidelines/common/check_list.md`: релевантные пункты выполнены.
- `docs/design-guidelines/go/check_list.md`: релевантные пункты выполнены.
- `docs/design-guidelines/vue/check_list.md`: релевантные пункты выполнены.

Closes #81
