### PR TITLE
Исправить handover runtime-deploy задач при rollout control-plane

### DIFF
--- a/services/internal/control-plane/cmd/runtime-deploy/noop_runtime_deploy_task_repository.go
+++ b/services/internal/control-plane/cmd/runtime-deploy/noop_runtime_deploy_task_repository.go
@@ -35,6 +35,10 @@ func (noopRuntimeDeployTaskRepository) RenewLease(_ context.Context, _ runtimede
 	return false, fmt.Errorf("runtime deploy queue is not available in one-shot mode")
 }
 
+func (noopRuntimeDeployTaskRepository) Requeue(_ context.Context, _ runtimedeploytaskrepo.RequeueParams) (bool, error) {
+	return false, fmt.Errorf("runtime deploy queue is not available in one-shot mode")
+}
+
 func (noopRuntimeDeployTaskRepository) ListRecent(_ context.Context, _ runtimedeploytaskrepo.ListFilter) ([]runtimedeploytaskrepo.Task, error) {
 	return nil, fmt.Errorf("runtime deploy queue is not available in one-shot mode")
 }

--- a/services/internal/control-plane/internal/domain/repository/runtimedeploytask/repository.go
+++ b/services/internal/control-plane/internal/domain/repository/runtimedeploytask/repository.go
@@ -14,6 +14,7 @@ type (
 	MarkSucceededParams = querytypes.RuntimeDeployTaskMarkSucceededParams
 	MarkFailedParams    = querytypes.RuntimeDeployTaskMarkFailedParams
 	RenewLeaseParams    = querytypes.RuntimeDeployTaskRenewLeaseParams
+	RequeueParams       = querytypes.RuntimeDeployTaskRequeueParams
 	ListFilter          = querytypes.RuntimeDeployTaskListFilter
 	AppendLogParams     = querytypes.RuntimeDeployTaskAppendLogParams
 )
@@ -32,6 +33,8 @@ type Repository interface {
 	MarkFailed(ctx context.Context, params MarkFailedParams) (bool, error)
 	// RenewLease extends active lease for one running task.
 	RenewLease(ctx context.Context, params RenewLeaseParams) (bool, error)
+	// Requeue returns one running task back to pending for another reconciler instance.
+	Requeue(ctx context.Context, params RequeueParams) (bool, error)
 	// ListRecent returns recent runtime deploy tasks ordered by update time.
 	ListRecent(ctx context.Context, filter ListFilter) ([]Task, error)
 	// AppendLog appends one task log line and keeps latest MaxLines entries.

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_reconcile.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_reconcile.go
@@ -21,10 +21,14 @@ func (s *Service) ReconcileNext(ctx context.Context, leaseOwner string, leaseTTL
 		leaseTTL = time.Second
 	}
 
+	renewInterval := runtimeDeployLeaseRenewInterval(leaseTTL)
+	staleRunningTimeout := runtimeDeployStaleRunningTimeout(renewInterval)
 	leaseTTLString := fmt.Sprintf("%d seconds", int64(leaseTTL.Seconds()))
+	staleRunningTimeoutString := fmt.Sprintf("%d seconds", int64(staleRunningTimeout.Seconds()))
 	task, ok, err := s.tasks.ClaimNext(ctx, runtimedeploytaskrepo.ClaimParams{
-		LeaseOwner: leaseOwner,
-		LeaseTTL:   leaseTTLString,
+		LeaseOwner:          leaseOwner,
+		LeaseTTL:            leaseTTLString,
+		StaleRunningTimeout: staleRunningTimeoutString,
 	})
 	if err != nil {
 		return false, fmt.Errorf("claim runtime deploy task: %w", err)
@@ -41,15 +45,7 @@ func (s *Service) ReconcileNext(ctx context.Context, leaseOwner string, leaseTTL
 
 		// Keep the lease short for fast recovery when the reconciler dies during self-deploy,
 		// but renew it while we are actively processing the task.
-		interval := leaseTTL / 2
-		if interval > 30*time.Second {
-			interval = 30 * time.Second
-		}
-		if interval < time.Second {
-			interval = time.Second
-		}
-
-		ticker := time.NewTicker(interval)
+		ticker := time.NewTicker(renewInterval)
 		defer ticker.Stop()
 
 		for {
@@ -91,7 +87,22 @@ func (s *Service) ReconcileNext(ctx context.Context, leaseOwner string, leaseTTL
 		s.appendTaskLogBestEffort(ctx, task.RunID, "reconcile", "error", "Task failed: "+runErr.Error())
 		if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
 			if ctx.Err() != nil {
-				return true, runErr
+				requeueMessage := "Reconciler shutdown detected while task was running; requeued for another instance"
+				s.appendTaskLogBestEffort(ctx, task.RunID, "reconcile", "warning", requeueMessage)
+				requeueCtx, cancelRequeue := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+				requeued, requeueErr := s.tasks.Requeue(requeueCtx, runtimedeploytaskrepo.RequeueParams{
+					RunID:      task.RunID,
+					LeaseOwner: leaseOwner,
+					LastError:  requeueMessage,
+				})
+				cancelRequeue()
+				if requeueErr != nil {
+					return true, fmt.Errorf("requeue runtime deploy task %s after shutdown: %w", task.RunID, requeueErr)
+				}
+				if !requeued {
+					s.logger.Warn("runtime deploy task requeue skipped after shutdown (lease lost)", "run_id", task.RunID, "lease_owner", leaseOwner)
+				}
+				return true, nil
 			}
 		}
 		lastError := strings.TrimSpace(runErr.Error())
@@ -126,6 +137,28 @@ func (s *Service) ReconcileNext(ctx context.Context, leaseOwner string, leaseTTL
 	}
 	s.appendTaskLogBestEffort(ctx, task.RunID, "reconcile", "info", "Task succeeded for namespace "+result.Namespace+" env "+result.TargetEnv)
 	return true, nil
+}
+
+func runtimeDeployLeaseRenewInterval(leaseTTL time.Duration) time.Duration {
+	interval := leaseTTL / 2
+	if interval > 30*time.Second {
+		interval = 30 * time.Second
+	}
+	if interval < time.Second {
+		interval = time.Second
+	}
+	return interval
+}
+
+func runtimeDeployStaleRunningTimeout(renewInterval time.Duration) time.Duration {
+	timeout := renewInterval*2 + 5*time.Second
+	if timeout < 30*time.Second {
+		return 30 * time.Second
+	}
+	if timeout > 2*time.Minute {
+		return 2 * time.Minute
+	}
+	return timeout
 }
 
 // applyDesiredState builds images and applies infrastructure/services for one runtime target namespace.

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_reconcile_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_reconcile_test.go
@@ -1,0 +1,30 @@
+package runtimedeploy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRuntimeDeployLeaseTiming(t *testing.T) {
+	t.Parallel()
+
+	if got := runtimeDeployLeaseRenewInterval(10 * time.Minute); got != 30*time.Second {
+		t.Fatalf("runtimeDeployLeaseRenewInterval(10m) = %s, want %s", got, 30*time.Second)
+	}
+	if got := runtimeDeployLeaseRenewInterval(20 * time.Second); got != 10*time.Second {
+		t.Fatalf("runtimeDeployLeaseRenewInterval(20s) = %s, want %s", got, 10*time.Second)
+	}
+	if got := runtimeDeployLeaseRenewInterval(500 * time.Millisecond); got != time.Second {
+		t.Fatalf("runtimeDeployLeaseRenewInterval(500ms) = %s, want %s", got, time.Second)
+	}
+
+	if got := runtimeDeployStaleRunningTimeout(30 * time.Second); got != 65*time.Second {
+		t.Fatalf("runtimeDeployStaleRunningTimeout(30s) = %s, want %s", got, 65*time.Second)
+	}
+	if got := runtimeDeployStaleRunningTimeout(10 * time.Second); got != 30*time.Second {
+		t.Fatalf("runtimeDeployStaleRunningTimeout(10s) = %s, want %s", got, 30*time.Second)
+	}
+	if got := runtimeDeployStaleRunningTimeout(2 * time.Minute); got != 2*time.Minute {
+		t.Fatalf("runtimeDeployStaleRunningTimeout(2m) = %s, want %s", got, 2*time.Minute)
+	}
+}

--- a/services/internal/control-plane/internal/domain/types/query/runtime_deploy_task.go
+++ b/services/internal/control-plane/internal/domain/types/query/runtime_deploy_task.go
@@ -15,8 +15,9 @@ type RuntimeDeployTaskUpsertDesiredParams struct {
 
 // RuntimeDeployTaskClaimParams describes one runtime deploy lease claim request.
 type RuntimeDeployTaskClaimParams struct {
-	LeaseOwner string
-	LeaseTTL   string
+	LeaseOwner          string
+	LeaseTTL            string
+	StaleRunningTimeout string
 }
 
 // RuntimeDeployTaskMarkSucceededParams describes one successful deployment completion.
@@ -39,6 +40,13 @@ type RuntimeDeployTaskRenewLeaseParams struct {
 	RunID      string
 	LeaseOwner string
 	LeaseTTL   string
+}
+
+// RuntimeDeployTaskRequeueParams describes one running task requeue request for graceful handover.
+type RuntimeDeployTaskRequeueParams struct {
+	RunID      string
+	LeaseOwner string
+	LastError  string
 }
 
 // RuntimeDeployTaskListFilter describes optional task list filters.

--- a/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/repository.go
+++ b/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/repository.go
@@ -2,8 +2,8 @@ package runtimedeploytask
 
 import (
 	"context"
-	"encoding/json"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -33,6 +33,8 @@ var (
 	queryMarkFailed string
 	//go:embed sql/renew_lease.sql
 	queryRenewLease string
+	//go:embed sql/requeue_running.sql
+	queryRequeueRunning string
 	//go:embed sql/list_recent.sql
 	queryListRecent string
 	//go:embed sql/append_log.sql
@@ -117,14 +119,18 @@ func (r *Repository) GetByRunID(ctx context.Context, runID string) (domainrepo.T
 func (r *Repository) ClaimNext(ctx context.Context, params domainrepo.ClaimParams) (domainrepo.Task, bool, error) {
 	leaseOwner := strings.TrimSpace(params.LeaseOwner)
 	leaseTTL := strings.TrimSpace(params.LeaseTTL)
+	staleRunningTimeout := strings.TrimSpace(params.StaleRunningTimeout)
 	if leaseOwner == "" {
 		return domainrepo.Task{}, false, fmt.Errorf("claim runtime deploy task: lease_owner is required")
 	}
 	if leaseTTL == "" {
 		return domainrepo.Task{}, false, fmt.Errorf("claim runtime deploy task: lease_ttl is required")
 	}
+	if staleRunningTimeout == "" {
+		staleRunningTimeout = "2 minutes"
+	}
 
-	row := r.db.QueryRow(ctx, queryClaimNext, leaseOwner, leaseTTL)
+	row := r.db.QueryRow(ctx, queryClaimNext, leaseOwner, leaseTTL, staleRunningTimeout)
 	task, err := scanTask(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -201,6 +207,29 @@ func (r *Repository) RenewLease(ctx context.Context, params domainrepo.RenewLeas
 			return false, nil
 		}
 		return false, fmt.Errorf("renew runtime deploy task lease for run %s: %w", runID, err)
+	}
+	return strings.TrimSpace(returnedRunID) != "", nil
+}
+
+// Requeue returns one running task lease back to pending for a new reconciler.
+func (r *Repository) Requeue(ctx context.Context, params domainrepo.RequeueParams) (bool, error) {
+	runID := strings.TrimSpace(params.RunID)
+	leaseOwner := strings.TrimSpace(params.LeaseOwner)
+	lastError := strings.TrimSpace(params.LastError)
+	if runID == "" {
+		return false, fmt.Errorf("requeue runtime deploy task: run_id is required")
+	}
+	if leaseOwner == "" {
+		return false, fmt.Errorf("requeue runtime deploy task: lease_owner is required")
+	}
+
+	var returnedRunID string
+	err := r.db.QueryRow(ctx, queryRequeueRunning, runID, leaseOwner, lastError).Scan(&returnedRunID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("requeue runtime deploy task %s: %w", runID, err)
 	}
 	return strings.TrimSpace(returnedRunID) != "", nil
 }

--- a/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/claim_next.sql
+++ b/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/claim_next.sql
@@ -12,7 +12,7 @@ WITH candidate AS (
         OR (
             t.status = 'running'
             AND t.lease_until IS NOT NULL
-            AND t.updated_at < NOW() - INTERVAL '2 minutes'
+            AND t.updated_at < NOW() - ($3::text)::interval
         )
     )
       -- Serialize claims by resolved namespace when it is known.

--- a/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/requeue_running.sql
+++ b/services/internal/control-plane/internal/repository/postgres/runtimedeploytask/sql/requeue_running.sql
@@ -1,0 +1,13 @@
+-- name: runtimedeploytask__requeue_running :one
+UPDATE runtime_deploy_tasks
+SET
+    status = 'pending',
+    lease_owner = NULL,
+    lease_until = NULL,
+    last_error = $3,
+    finished_at = NULL,
+    updated_at = NOW()
+WHERE run_id = $1::uuid
+  AND status = 'running'
+  AND lease_owner = $2
+RETURNING run_id::text;


### PR DESCRIPTION
## Что сделано
- добавил **graceful handover** для runtime-deploy задачи при остановке `control-plane`:
  - в `ReconcileNext` при `context canceled` во время выполнения задача теперь переводится обратно в `pending` через новый репозиторный метод `Requeue`;
  - lease (`lease_owner`, `lease_until`) очищается сразу, без ожидания TTL.
- ускорил fallback-подхват при нештатном падении pod (когда graceful requeue не успел выполниться):
  - в `claim_next.sql` hardcoded порог stale-running заменен на параметр;
  - в домене введен расчет `staleRunningTimeout` от интервала renew lease (по умолчанию получается ~65s вместо 2m).
- добавил SQL `requeue_running.sql` и метод `Repository.Requeue`.
- расширил контракт `RuntimeDeployTaskClaimParams` полем `StaleRunningTimeout`.
- добавил unit-тест на расчет интервалов renew/stale.

## Почему это решает проблему
При rollout `control-plane` текущий pod больше не оставляет задачу в `running` до истечения lease TTL. Новый pod подхватывает очередь сразу после graceful requeue. Если pod упал аварийно, задача все равно подхватится заметно быстрее за счет уменьшенного stale-running окна.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy ./services/internal/control-plane/internal/repository/postgres/runtimedeploytask ./services/internal/control-plane/cmd/runtime-deploy ./services/internal/control-plane/internal/app`
- `go test ./services/internal/control-plane/...`
- `make lint-go`
- `make dupl-go` — падает на существующих в репозитории дублях в незатронутых файлах (новых дублей этим PR не добавлено).

Чек-лист выполнен, релевантно 12 пунктов, все выполнены.
