### PR TITLE
Unblock services schema validation on current runtime

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -105,16 +105,6 @@ spec:
       prd: code-only
       prd_revise: code-only
       self_improve: code-only
-    defaultNamespaceTTL: 24h
-    namespaceTTLByRole:
-      pm: 24h
-      sa: 24h
-      em: 24h
-      dev: 24h
-      reviewer: 24h
-      qa: 24h
-      sre: 24h
-      km: 24h
   secretResolution:
     environmentAliases:
       production: [prod]


### PR DESCRIPTION
## Проблема
После merge `#94` пайплайн падал на `load services config` с ошибкой schema validation:
- `unexpected additional properties ["defaultNamespaceTTL" "namespaceTTLByRole"]`

## Причина
Текущий runtime, который выполняет deploy/build, работает на более старой версии с embedded `services.schema.json`, где этих полей в `spec.webhookRuntime` еще нет.

## Что сделано
- Удалены поля из `services.yaml`:
  - `spec.webhookRuntime.defaultNamespaceTTL`
  - `spec.webhookRuntime.namespaceTTLByRole`

Это возвращает конфиг к формату, который понимает текущий продовый runtime, и разблокирует дальнейший build/deploy цикл.

## Важно
- Функционально остается поведение по default TTL (`24h`) из runtime policy.
- После обновления control-plane/worker до версии с новой схемой эти поля можно вернуть отдельным PR.

## Проверка
- `go test ./libs/go/servicescfg/...`

## Checklist
Чек-лист выполнен, релевантные пункты проверены.
