### PR TITLE
fix: устранить conflict value/valueFrom для kaniko env

### DIFF
--- a/deploy/base/codex-k8s/app.yaml.tpl
+++ b/deploy/base/codex-k8s/app.yaml.tpl
@@ -194,23 +194,11 @@ spec:
             - name: CODEXK8S_REPOSITORY_ROOT
               value: /repo-cache
             - name: CODEXK8S_KANIKO_CACHE_ENABLED
-              valueFrom:
-                secretKeyRef:
-                  name: codex-k8s-runtime
-                  key: CODEXK8S_KANIKO_CACHE_ENABLED
-                  optional: true
+              value: '{{ envOr "CODEXK8S_KANIKO_CACHE_ENABLED" "false" }}'
             - name: CODEXK8S_KANIKO_CACHE_REPO
-              valueFrom:
-                secretKeyRef:
-                  name: codex-k8s-runtime
-                  key: CODEXK8S_KANIKO_CACHE_REPO
-                  optional: true
+              value: '{{ envOr "CODEXK8S_KANIKO_CACHE_REPO" "" }}'
             - name: CODEXK8S_KANIKO_CACHE_TTL
-              valueFrom:
-                secretKeyRef:
-                  name: codex-k8s-runtime
-                  key: CODEXK8S_KANIKO_CACHE_TTL
-                  optional: true
+              value: '{{ envOr "CODEXK8S_KANIKO_CACHE_TTL" "" }}'
             - name: CODEXK8S_PRODUCTION_DOMAIN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Проблема
Runtime deploy падал на apply `codex-k8s-control-plane` с ошибкой валидации env:
- `may not be specified when value is not empty` для `CODEXK8S_KANIKO_CACHE_ENABLED|REPO|TTL`.

Это происходило при переходе существующих env-переменных (заданных как `value`) на `valueFrom`.

## Что исправлено
- В `deploy/base/codex-k8s/app.yaml.tpl` для:
  - `CODEXK8S_KANIKO_CACHE_ENABLED`
  - `CODEXK8S_KANIKO_CACHE_REPO`
  - `CODEXK8S_KANIKO_CACHE_TTL`

  возвращён `value: {{ envOr ... }}` вместо `valueFrom.secretKeyRef`.

## Почему так
Это безопасный и совместимый способ для rolling apply в уже живом deployment, где эти env могли быть выставлены через `kubectl set env`.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy/...` ✅
- `make lint-go` ✅

## Чек-листы
- `docs/design-guidelines/common/check_list.md` — выполнен (релевантные пункты)
- `docs/design-guidelines/go/check_list.md` — выполнен (релевантные пункты)
