### PR TITLE
fix: strengthen mirror health check for platform-specific manifests

### DIFF
--- a/docs/ops/production_runbook.md
+++ b/docs/ops/production_runbook.md
@@ -165,6 +165,6 @@ kubectl -n "$ns" get jobs -l app.kubernetes.io/name=codex-k8s-registry-gc
   - убедиться, что `codex-k8s-control-plane` подтянул значение после rollout;
   - повторить deploy.
 - Дополнительно:
-  - mirror шаг выполняет health-check и ремонтирует stale mirror;
+  - mirror шаг выполняет platform-aware health-check (`--platform linux/amd64`) и ремонтирует stale mirror;
   - mirror выполняется в single-arch режиме (`CODEXK8S_IMAGE_MIRROR_PLATFORM=linux/amd64`), чтобы не оставлять multi-arch index с отсутствующими дочерними манифестами;
   - при cache-related `MANIFEST_UNKNOWN` build автоматически ретраится без cache.


### PR DESCRIPTION
## Что сделано
- В `deploy/base/kaniko/mirror-image-job.yaml.tpl` изменён health-check mirror:
  - раньше проверялся только digest тега (`crane digest` + `crane manifest repo@digest`);
  - теперь проверяется platform-манифест: `crane manifest --platform "$MIRROR_PLATFORM" "$TARGET_IMAGE"`.
- Если platform-манифест не читается, mirror принудительно пересинхронизируется (`crane copy --platform ...`).
- Обновлён runbook (`docs/ops/production_runbook.md`) с уточнением platform-aware проверки.

## Почему это важно
Был сценарий, когда tag digest существует, но дочерний platform digest отсутствует в registry (stale multi-arch index). Старый health-check считал mirror "здоровым", а kaniko затем падал с `MANIFEST_UNKNOWN`.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy/...` ✅
- `make lint-go` ✅
- `make dupl-go` ⚠️ падает на предсуществующих дублях вне текущего diff

## Чек-листы
- `docs/design-guidelines/common/check_list.md` — выполнен (релевантные пункты)
- `docs/design-guidelines/go/check_list.md` — выполнен (релевантные пункты)
