### PR TITLE
fix(web-console): восстановление realtime в build/deploy после mobile suspend

### DIFF
--- a/services/staff/web-console/src/shared/ws/lifecycle.ts
+++ b/services/staff/web-console/src/shared/ws/lifecycle.ts
@@ -1,0 +1,35 @@
+type RealtimePageLifecycleHandlers = {
+  onResume: () => void;
+  onSuspend?: () => void;
+};
+
+export function bindRealtimePageLifecycle(handlers: RealtimePageLifecycleHandlers): () => void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return () => undefined;
+  }
+
+  const handleResume = (): void => {
+    if (document.hidden) return;
+    handlers.onResume();
+  };
+
+  const handleVisibilityChange = (): void => {
+    if (document.hidden) {
+      handlers.onSuspend?.();
+      return;
+    }
+    handlers.onResume();
+  };
+
+  window.addEventListener("focus", handleResume);
+  window.addEventListener("online", handleResume);
+  window.addEventListener("pageshow", handleResume);
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return () => {
+    window.removeEventListener("focus", handleResume);
+    window.removeEventListener("online", handleResume);
+    window.removeEventListener("pageshow", handleResume);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  };
+}


### PR DESCRIPTION
## Что сделано
- Добавил общий helper `src/shared/ws/lifecycle.ts` для обработки lifecycle страницы (`visibilitychange`, `focus`, `online`, `pageshow`) в realtime-сценариях.
- Подключил lifecycle-binding в `RuntimeDeployTasksPage`:
  - при уходе страницы в background останавливаются realtime-подписки;
  - при возврате страницы в foreground подписки пересоздаются и выполняется принудительная подгрузка данных.
- Подключил lifecycle-binding в `RuntimeDeployTaskDetailsPage`:
  - при suspend останавливается realtime и fallback polling;
  - при resume выполняется повторная загрузка задачи и рестарт realtime-подписки.

## Почему это исправляет Issue #114
На планшетах (особенно Safari/WebView) WebSocket после background/foreground может оставаться в «подключённом» состоянии без фактической доставки событий. Теперь при возврате страницы подписка принудительно перезапускается, поэтому события в build/deploy приходят без ручного refresh.

## Проверки
- `npm --prefix services/staff/web-console run build`

## Риски и ограничения
- Возможны дополнительные reconnect при переключении вкладок/возврате в приложение (ожидаемое поведение ради устойчивости realtime).
- Изменения ограничены build/deploy экранами; API/контракты и backend не менялись.

## Чек-листы
- `docs/design-guidelines/common/check_list.md`: релевантные пункты выполнены.
- `docs/design-guidelines/vue/check_list.md`: релевантные пункты выполнены.

Closes #114
