### PR TITLE
fix: finalize code-only run status comments

### DIFF
--- a/services/jobs/worker/internal/domain/worker/service.go
+++ b/services/jobs/worker/internal/domain/worker/service.go
@@ -703,18 +703,16 @@ func (s *Service) finishRun(ctx context.Context, params finishRunParams) error {
 		return fmt.Errorf("insert finish event: %w", err)
 	}
 
-	if params.Execution.RuntimeMode == agentdomain.RuntimeModeFullEnv {
-		if _, err := s.runStatus.UpsertRunStatusComment(ctx, RunStatusCommentParams{
-			RunID:        params.Run.RunID,
-			Phase:        RunStatusPhaseFinished,
-			JobName:      params.Ref.Name,
-			JobNamespace: params.Ref.Namespace,
-			RuntimeMode:  string(params.Execution.RuntimeMode),
-			Namespace:    params.Execution.Namespace,
-			RunStatus:    string(params.Status),
-		}); err != nil {
-			s.logger.Warn("upsert run status comment (finished) failed", "run_id", params.Run.RunID, "err", err)
-		}
+	if _, err := s.runStatus.UpsertRunStatusComment(ctx, RunStatusCommentParams{
+		RunID:        params.Run.RunID,
+		Phase:        RunStatusPhaseFinished,
+		JobName:      params.Ref.Name,
+		JobNamespace: params.Ref.Namespace,
+		RuntimeMode:  string(params.Execution.RuntimeMode),
+		Namespace:    params.Execution.Namespace,
+		RunStatus:    string(params.Status),
+	}); err != nil {
+		s.logger.Warn("upsert run status comment (finished) failed", "run_id", params.Run.RunID, "err", err)
 	}
 
 	if params.Run.LearningMode && s.feedback != nil {


### PR DESCRIPTION
## Что исправлено
- worker теперь всегда отправляет финальный `run status comment` при завершении run, включая `code-only` режим
- добавлен unit-тест на `code-only` completion с проверкой `RunStatusPhaseFinished`

## Проверки
- `go test ./services/jobs/worker/internal/domain/worker -count=1`
- `go test ./services/jobs/worker/... -count=1`

Контекст: issue #118, устранение рассинхрона `run.succeeded` в БД и `running` в сервисном GitHub-комментарии.