### PR TITLE
fix: prevent duplicate github run status comments

### DIFF
--- a/services/internal/control-plane/internal/clients/github/client.go
+++ b/services/internal/control-plane/internal/clients/github/client.go
@@ -79,8 +79,12 @@ func (c *Client) GetAuthenticatedUserLogin(ctx context.Context, token string) (s
 func (c *Client) ListIssueComments(ctx context.Context, params mcpdomain.GitHubListIssueCommentsParams) ([]mcpdomain.GitHubIssueComment, error) {
 	client := c.clientWithToken(params.Token)
 	limit := clampLimit(params.Limit, defaultPageSize, maxPageSize)
+	sortByUpdated := "updated"
+	sortDirectionDesc := "desc"
 
 	items, _, err := client.Issues.ListComments(ctx, params.Owner, params.Repository, params.IssueNumber, &gh.IssueListCommentsOptions{
+		Sort:        &sortByUpdated,
+		Direction:   &sortDirectionDesc,
 		ListOptions: gh.ListOptions{PerPage: limit},
 	})
 	if err != nil {


### PR DESCRIPTION
## Что исправлено
- Для `ListIssueComments` включена сортировка `updated desc`, чтобы всегда брать самые свежие комментарии.
- В `runstatus.UpsertRunStatusComment` добавлен короткий retry-поиск существующего комментария перед созданием нового (защита от гонки webhook/worker и eventual consistency GitHub API).
- `findRunStatusComment` теперь:
  - игнорирует поврежденные маркеры,
  - выбирает самый свежий комментарий (по максимальному `comment_id`) при дублях.
- Добавлены unit-тесты на выбор свежего комментария и игнор malformed маркера.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runstatus -count=1`
- `go test ./services/internal/control-plane/internal/clients/github -count=1`
- `go test ./services/internal/control-plane/... -count=1`
