### PR TITLE
fix: dedupe duplicate run status comments

### DIFF
--- a/services/internal/control-plane/internal/clients/github/client.go
+++ b/services/internal/control-plane/internal/clients/github/client.go
@@ -274,6 +274,12 @@ func (c *Client) EditIssueComment(ctx context.Context, params mcpdomain.GitHubEd
 	return c.mutateIssueComment(ctx, newEditIssueCommentMutationParams(params))
 }
 
+func (c *Client) DeleteIssueComment(ctx context.Context, params mcpdomain.GitHubDeleteIssueCommentParams) error {
+	client := c.clientWithToken(params.Token)
+	_, err := client.Issues.DeleteComment(ctx, params.Owner, params.Repository, params.CommentID)
+	return err
+}
+
 type issueCommentMutationParams struct {
 	Token       string
 	Owner       string

--- a/services/internal/control-plane/internal/domain/mcp/github_params.go
+++ b/services/internal/control-plane/internal/domain/mcp/github_params.go
@@ -92,6 +92,14 @@ type GitHubEditIssueCommentParams struct {
 	Body       string
 }
 
+// GitHubDeleteIssueCommentParams describes issue/PR comment delete operation in adapter.
+type GitHubDeleteIssueCommentParams struct {
+	Token      string
+	Owner      string
+	Repository string
+	CommentID  int64
+}
+
 // GitHubCreateIssueReactionParams describes issue reaction create operation in adapter.
 type GitHubCreateIssueReactionParams struct {
 	Token       string

--- a/services/internal/control-plane/internal/domain/mcp/service.go
+++ b/services/internal/control-plane/internal/domain/mcp/service.go
@@ -54,6 +54,7 @@ type GitHubClient interface {
 	EnsureBranch(ctx context.Context, params GitHubEnsureBranchParams) (GitHubBranch, error)
 	UpsertPullRequest(ctx context.Context, params GitHubUpsertPullRequestParams) (GitHubPullRequest, error)
 	CreateIssueComment(ctx context.Context, params GitHubCreateIssueCommentParams) (GitHubIssueComment, error)
+	DeleteIssueComment(ctx context.Context, params GitHubDeleteIssueCommentParams) error
 	AddLabels(ctx context.Context, params GitHubMutateLabelsParams) ([]GitHubLabel, error)
 	RemoveLabels(ctx context.Context, params GitHubMutateLabelsParams) ([]GitHubLabel, error)
 	UpsertRepositorySecret(ctx context.Context, params GitHubUpsertRepositorySecretParams) error

--- a/services/internal/control-plane/internal/domain/runstatus/model.go
+++ b/services/internal/control-plane/internal/domain/runstatus/model.go
@@ -164,6 +164,7 @@ type GitHubClient interface {
 	ListIssueComments(ctx context.Context, params mcpdomain.GitHubListIssueCommentsParams) ([]mcpdomain.GitHubIssueComment, error)
 	CreateIssueComment(ctx context.Context, params mcpdomain.GitHubCreateIssueCommentParams) (mcpdomain.GitHubIssueComment, error)
 	EditIssueComment(ctx context.Context, params mcpdomain.GitHubEditIssueCommentParams) (mcpdomain.GitHubIssueComment, error)
+	DeleteIssueComment(ctx context.Context, params mcpdomain.GitHubDeleteIssueCommentParams) error
 	ListIssueReactions(ctx context.Context, params mcpdomain.GitHubListIssueReactionsParams) ([]mcpdomain.GitHubIssueReaction, error)
 	CreateIssueReaction(ctx context.Context, params mcpdomain.GitHubCreateIssueReactionParams) (mcpdomain.GitHubIssueReaction, error)
 }


### PR DESCRIPTION
## Что сделано
- Добавлен GitHub delete-comment adapter (`DeleteIssueComment`).
- В runstatus после upsert добавлен best-effort dedupe run-status комментариев по `run_id` (с retry для `finished` фазы).
- Если из-за гонки появилось несколько marker-комментариев, сервис удаляет старые и оставляет один актуальный.

## Проверки
- `go test ./services/internal/control-plane/... -count=1`
