### PR TITLE
Issue #154: launch profiles и fallback UX для stage/label flow

### DIFF
--- a/docs/delivery/delivery_plan.md
+++ b/docs/delivery/delivery_plan.md
@@ -6,7 +6,7 @@ status: active
 owner_role: EM
 created_at: 2026-02-06
 updated_at: 2026-02-24
-related_issues: [1, 19, 74, 100, 106, 112]
+related_issues: [1, 19, 74, 100, 106, 112, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -45,6 +45,8 @@ approvals:
 - Epic S3 catalog: `docs/delivery/epics/s3/epic_s3.md`
 - Sprint S4 plan: `docs/delivery/sprints/s4/sprint_s4_multi_repo_federation.md`
 - Epic S4 catalog: `docs/delivery/epics/s4/epic_s4.md`
+- Sprint S5 plan: `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md`
+- Epic S5 catalog: `docs/delivery/epics/s5/epic_s5.md`
 - Sprint index: `docs/delivery/sprints/README.md`
 - Epic index: `docs/delivery/epics/README.md`
 - E2E master plan: `docs/delivery/e2e_mvp_master_plan.md`
@@ -96,6 +98,10 @@ approvals:
 - Day 1 (completed): execution foundation для federated multi-repo composition и docs federation (`docs/delivery/epics/s4/epic-s4-day1-multi-repo-composition-and-docs-federation.md`).
 - Результат Day 1: формальный execution-plan (stories + quality-gates + owner decisions) для перехода в `run:dev`.
 - Следующие day-эпики S4 формируются после Owner review Day 1 и закрытия зависимостей по S3 Day20.
+
+### Sprint S5: Stage entry and label UX orchestration (Issue #154)
+- Day 1 (planned): launch profiles + deterministic next-step actions (`docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md`).
+- Результат Day 1 (ожидаемый): owner-ready execution package для устранения ручных ошибок label-flow и нерабочих next-step ссылок.
 
 ### Daily delivery contract (обязательный)
 - Каждый день задачи дня влиты в `main`.

--- a/docs/delivery/epics/README.md
+++ b/docs/delivery/epics/README.md
@@ -6,7 +6,7 @@ status: active
 owner_role: EM
 created_at: 2026-02-24
 updated_at: 2026-02-24
-related_issues: [112]
+related_issues: [112, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -17,7 +17,7 @@ approvals:
 # Epic Index
 
 ## TL;DR
-- Все day-эпики сгруппированы по папкам спринтов (`s1`, `s2`, `s3`, `s4`).
+- Все day-эпики сгруппированы по папкам спринтов (`s1`, `s2`, `s3`, `s4`, `s5`).
 - Каталог эпиков каждого спринта размещён в той же папке.
 - Это устраняет смешение day-эпиков разных спринтов в одном каталоге.
 
@@ -29,6 +29,7 @@ approvals:
 | `docs/delivery/epics/s2/` | Day0..Day7 (+ Day3.5/Day4.5) + каталог Sprint S2 | `docs/delivery/epics/s2/epic_s2.md` |
 | `docs/delivery/epics/s3/` | Day1..Day20 + каталог Sprint S3 | `docs/delivery/epics/s3/epic_s3.md` |
 | `docs/delivery/epics/s4/` | Day1 + каталог Sprint S4 | `docs/delivery/epics/s4/epic_s4.md` |
+| `docs/delivery/epics/s5/` | Day1 + каталог Sprint S5 | `docs/delivery/epics/s5/epic_s5.md` |
 
 ## Проверка консистентности
 - Для каждого `s<номер>` должны существовать:

--- a/docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md
+++ b/docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md
@@ -1,0 +1,89 @@
+---
+doc_id: EPC-CK8S-S5-D1
+type: epic
+title: "Epic S5 Day 1: Launch profiles and deterministic next-step actions (Issue #154)"
+status: planned
+owner_role: PM
+created_at: 2026-02-24
+updated_at: 2026-02-24
+related_issues: [154]
+related_prs: []
+approvals:
+  required: ["Owner"]
+  status: pending
+  request_id: "owner-2026-02-24-issue-154-day1"
+---
+
+# Epic S5 Day 1: Launch profiles and deterministic next-step actions (Issue #154)
+
+## TL;DR
+- Проблема: текущий label-driven flow неудобен для ручного управления; пользователи забывают порядок этапов, а часть быстрых ссылок не работает.
+- Цель Day1: формализовать profile-driven процесс запуска и задать приемочные критерии для стабильного next-step UX.
+- Результат Day1: подготовлен owner-ready execution package для `run:dev` без изменения архитектурных границ.
+
+## Priority
+- `P0`.
+
+## Scope
+### In scope
+- Ввести launch profiles:
+  - `quick-fix` для минимальных исправлений;
+  - `feature` для функциональных доработок;
+  - `new-service` для полного цикла с архитектурной проработкой.
+- Зафиксировать mapping profile -> обязательные стадии -> условия эскалации.
+- Формализовать deterministic next-step actions:
+  - primary: staff web-console deep-link;
+  - fallback: текстовая команда label transition (`gh`/MCP path) для copy-paste.
+- Сформировать acceptance matrix для UX и policy поведения.
+
+### Out of scope
+- Реализация UI/Backend кода.
+- Пересмотр базовых label-классов и security policy.
+- Изменения процесса ревью вне связки stage launch / stage transition.
+
+## Stories (handover в `run:dev`)
+- Story-1: Profile Registry
+  - хранение и выдача канонических профилей;
+  - валидация допустимых переходов между profile-режимами.
+- Story-2: Next-step Action Contract
+  - единый contract для action cards с primary/fallback каналами;
+  - обязательная диагностика при невалидном deep-link.
+- Story-3: Service-message Rendering
+  - profile-aware описание шага и следующего действия;
+  - явный fallback-блок с безопасной командой без секретов.
+- Story-4: Governance Guardrails
+  - запрещение silent-skip этапов;
+  - автоматическая постановка `need:input` при ambiguity profile/stage.
+- Story-5: Traceability Sync
+  - синхронизация `issue_map`, `requirements_traceability`, sprint/epic артефактов.
+
+## Quality gates
+- Planning gate:
+  - FR-053/FR-054 отражены в продуктовых документах;
+  - launch profile matrix согласована с `stage_process_model`.
+- Contract gate:
+  - next-step action contract детерминирован и допускает только policy-safe transitions.
+- UX gate:
+  - сценарий broken/dead link не блокирует owner-flow;
+  - fallback-путь выполняется в один шаг (copy-paste).
+- Security gate:
+  - fallback-команды не содержат секретов;
+  - любой transition сохраняет audit trail.
+- Traceability gate:
+  - изменения отражены в `issue_map` и `requirements_traceability`.
+
+## Acceptance criteria
+- [ ] Для каждого профиля (`quick-fix`, `feature`, `new-service`) определены вход, выход и эскалация.
+- [ ] Каждая next-step подсказка включает `primary + fallback` и не блокирует переход при отказе primary.
+- [ ] В ambiguous-сценариях платформа не делает best-guess переход, а требует `need:input`.
+- [ ] Подготовлен список рисков и продуктовых допущений для `run:dev` этапа.
+
+## Открытые риски
+- Риск UX-перегрузки: слишком много действий в service-comment снижает читаемость.
+- Риск policy-drift: profile shortcut может быть использован для обхода обязательных этапов.
+- Риск интеграции: fallback-команды могут расходиться с фактической policy, если не централизовать шаблон.
+
+## Продуктовые допущения
+- Launch profiles не заменяют канонический stage-pipeline, а задают управляемые “траектории входа”.
+- Primary канал (`web-console`) может временно быть недоступен; fallback обязан быть достаточным для продолжения процесса.
+- Для P0/P1 инициатив Owner может принудительно переводить задачу в `new-service` траекторию независимо от исходного профиля.

--- a/docs/delivery/epics/s5/epic_s5.md
+++ b/docs/delivery/epics/s5/epic_s5.md
@@ -1,0 +1,34 @@
+---
+doc_id: EPC-CK8S-0005
+type: epic
+title: "Epic Catalog: Sprint S5 (Stage entry and label UX orchestration)"
+status: planned
+owner_role: EM
+created_at: 2026-02-24
+updated_at: 2026-02-24
+related_issues: [154]
+related_prs: []
+approvals:
+  required: ["Owner"]
+  status: pending
+  request_id: "owner-2026-02-24-issue-154-epic-catalog"
+---
+
+# Epic Catalog: Sprint S5 (Stage entry and label UX orchestration)
+
+## TL;DR
+- Sprint S5 фокусируется на управляемом UX запуска stage-процессов и снижении ручных ошибок в label-flow.
+- Базовый deliverable: Day1 execution package для launch profiles и deterministic next-step actions.
+
+## Контекст
+- Product source of truth: `docs/product/requirements_machine_driven.md` (FR-053, FR-054).
+- Stage policy source of truth: `docs/product/labels_and_trigger_policy.md`, `docs/product/stage_process_model.md`.
+- Delivery process source of truth: `docs/delivery/development_process_requirements.md`.
+
+## Эпики Sprint S5
+- Day 1: `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md`
+
+## Критерии успеха Sprint S5 (выжимка)
+- [ ] Launch profiles покрывают минимум три сценария (`quick-fix`, `feature`, `new-service`) и имеют понятные guardrails.
+- [ ] Service-message next-step actions дают рабочий primary + fallback path.
+- [ ] Для Owner устранён ручной “по памяти” выбор порядка label-переходов.

--- a/docs/delivery/issue_map.md
+++ b/docs/delivery/issue_map.md
@@ -34,6 +34,7 @@ approvals:
 | #100 | `docs/delivery/issue_map.md` + `docs/delivery/requirements_traceability.md` + `docs/delivery/sprints/s4/sprint_s4_multi_repo_federation.md` + `docs/delivery/epics/s4/epic_s4.md` + `docs/delivery/epics/s4/epic-s4-day1-multi-repo-composition-and-docs-federation.md` | `docs/product/requirements_machine_driven.md` + `docs/product/brief.md` | `docs/architecture/multi_repo_mode_design.md`, `docs/architecture/data_model.md`, `docs/architecture/api_contract.md`, `docs/architecture/prompt_templates_policy.md`, `docs/architecture/adr/ADR-0007-multi-repo-composition-and-docs-federation.md` | `ADR-0007` | Completed (Issue #106): execution package для federated multi-repo runtime и docs federation финализирован (кейсы A..F, Story-1..Story-7, quality-gates, rollout `preview -> enforced`) | TBD | TBD | completed (day1) |
 | #107 | `docs/delivery/issue_map.md` + `docs/delivery/requirements_traceability.md` + `docs/delivery/sprints/s3/sprint_s3_mvp_completion.md` + `docs/delivery/epics/s3/epic_s3.md` + `docs/delivery/epics/s3/epic-s3-day19.6-staff-realtime-subscriptions-and-ui.md` | `docs/product/requirements_machine_driven.md` + `docs/product/labels_and_trigger_policy.md` + `docs/product/stage_process_model.md` | `docs/architecture/api_contract.md` + `services/external/api-gateway/api/server/asyncapi.yaml` + `docs/design-guidelines/vue/frontend_data_and_state.md` | `ADR-0001..0006` | RuntimeDeployTasks/RuntimeDeployTaskDetails переведены на WebSocket-подписки через `run realtime` endpoint; ручной refresh убран на realtime-экранах, добавлены realtime-индикаторы и fallback polling | Проверки frontend: `npm --prefix services/staff/web-console run build` | TBD | TBD | in-progress |
 | #112 | `docs/delivery/issue_map.md` + `docs/delivery/requirements_traceability.md` + `docs/delivery/delivery_plan.md` + `docs/delivery/e2e_mvp_master_plan.md` + `docs/delivery/sprints/README.md` + `docs/delivery/epics/README.md` | `docs/product/requirements_machine_driven.md` + `docs/product/labels_and_trigger_policy.md` + `docs/product/stage_process_model.md` | `docs/architecture/mcp_approval_and_audit_flow.md`, `docs/architecture/prompt_templates_policy.md` | `ADR-0001..0007` | Выполнена нормализация структуры sprint/epic по папкам, синхронизированы ссылки и подготовлен полный E2E master-plan для MVP c label coverage | `docs/delivery/e2e_mvp_master_plan.md` | TBD | TBD | in-progress |
+| #154 | `docs/delivery/issue_map.md` + `docs/delivery/requirements_traceability.md` + `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md` + `docs/delivery/epics/s5/epic_s5.md` + `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md` | `docs/product/requirements_machine_driven.md` + `docs/product/labels_and_trigger_policy.md` + `docs/product/stage_process_model.md` | `docs/product/labels_and_trigger_policy.md`, `docs/product/stage_process_model.md` | `ADR-0006` | Intake-этап зафиксировал profile-driven модель запуска (`quick-fix/feature/new-service`) и обязательный fallback для next-step действий при нерабочих web-ссылках | Acceptance matrix S5 Day1 (planned), fallback/broken-link и ambiguity сценарии включены | TBD | TBD | in-progress |
 
 ## Требования и трассировка
 - Source of truth требований: `docs/product/requirements_machine_driven.md`.
@@ -68,6 +69,12 @@ approvals:
 - Epic catalog: `docs/delivery/epics/s4/epic_s4.md`.
 - Epic docs: `docs/delivery/epics/s4/epic-s4-day1-multi-repo-composition-and-docs-federation.md`.
 - Факт на 2026-02-23: Day1 epic для Issue #100 закрыт в Issue #106; execution-plan зафиксирован и handover в `run:dev` подготовлен.
+
+## Sprint S5 артефакты
+- Sprint plan: `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md`.
+- Epic catalog: `docs/delivery/epics/s5/epic_s5.md`.
+- Epic docs: `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md`.
+- Факт на 2026-02-24: Intake-пакет для Issue #154 подготовлен; следующий этап — `run:vision`/`run:prd` для уточнения product scope перед `run:dev`.
 
 ## Нормализованная структура Delivery (Issue #112)
 - Sprint index: `docs/delivery/sprints/README.md`.

--- a/docs/delivery/requirements_traceability.md
+++ b/docs/delivery/requirements_traceability.md
@@ -6,7 +6,7 @@ status: active
 owner_role: EM
 created_at: 2026-02-06
 updated_at: 2026-02-24
-related_issues: [1, 19, 74, 90, 100, 112]
+related_issues: [1, 19, 74, 90, 100, 112, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -78,6 +78,8 @@ approvals:
 | FR-050 | Prompt context docs tree + role-aware capabilities | `docs/product/requirements_machine_driven.md`, `docs/architecture/prompt_templates_policy.md`, `docs/delivery/epics/s3/epic-s3-day15-mvp-closeout-and-handover.md` | covered |
 | FR-051 | GitHub run service messages v2 + slot URL for full-env | `docs/product/requirements_machine_driven.md`, `docs/architecture/api_contract.md`, `docs/delivery/epics/s3/epic-s3-day15-mvp-closeout-and-handover.md` | covered |
 | FR-052 | Review-driven revise resolver + stage-aware next-step action cards | `docs/product/requirements_machine_driven.md`, `docs/product/labels_and_trigger_policy.md`, `docs/product/stage_process_model.md`, `docs/architecture/mcp_approval_and_audit_flow.md`, `docs/architecture/adr/ADR-0006-review-driven-revise-and-next-step-ux.md` | covered |
+| FR-053 | Launch profiles для разных типов инициатив (`quick-fix`, `feature`, `new-service`) | `docs/product/requirements_machine_driven.md`, `docs/product/stage_process_model.md`, `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md`, `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md` | covered |
+| FR-054 | Next-step actions: primary deep-link + fallback-команда | `docs/product/requirements_machine_driven.md`, `docs/product/labels_and_trigger_policy.md`, `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md`, `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md` | covered |
 | NFR-001 | Security baseline | `docs/product/requirements_machine_driven.md`, `docs/product/constraints.md`, `AGENTS.md` | covered |
 | NFR-002 | Multi-pod consistency | `docs/product/requirements_machine_driven.md`, `docs/architecture/c4_container.md`, `docs/architecture/data_model.md` | covered |
 | NFR-003 | No event outbox on MVP | `docs/product/requirements_machine_driven.md`, `docs/architecture/data_model.md`, `docs/product/constraints.md` | covered |

--- a/docs/delivery/sprints/README.md
+++ b/docs/delivery/sprints/README.md
@@ -6,7 +6,7 @@ status: active
 owner_role: EM
 created_at: 2026-02-24
 updated_at: 2026-02-24
-related_issues: [112]
+related_issues: [112, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -29,6 +29,7 @@ approvals:
 | S2 | `docs/delivery/sprints/s2/sprint_s2_dogfooding.md` | `docs/delivery/epics/s2/epic_s2.md` | completed | Dogfooding + governance baseline закрыты. |
 | S3 | `docs/delivery/sprints/s3/sprint_s3_mvp_completion.md` | `docs/delivery/epics/s3/epic_s3.md` | in-progress | Финальный e2e и closeout выполняются по Day20. |
 | S4 | `docs/delivery/sprints/s4/sprint_s4_multi_repo_federation.md` | `docs/delivery/epics/s4/epic_s4.md` | completed (day1) | Execution foundation по multi-repo зафиксирован. |
+| S5 | `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md` | `docs/delivery/epics/s5/epic_s5.md` | planned | UX-упрощение stage/label запуска и deterministic next-step actions (Issue #154). |
 
 ## Правила структуры
 - Sprint-plan: `docs/delivery/sprints/s<номер>/sprint_s<номер>_<name>.md`.

--- a/docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md
+++ b/docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md
@@ -1,0 +1,59 @@
+---
+doc_id: SPR-CK8S-0005
+type: sprint-plan
+title: "Sprint S5: Stage entry and label UX orchestration (Issue #154)"
+status: planned
+owner_role: EM
+created_at: 2026-02-24
+updated_at: 2026-02-24
+related_issues: [154]
+related_prs: []
+approvals:
+  required: ["Owner"]
+  status: pending
+  request_id: "owner-2026-02-24-issue-154-sprint-plan"
+---
+
+# Sprint S5: Stage entry and label UX orchestration (Issue #154)
+
+## TL;DR
+- Цель спринта: убрать ручную сложность управления `run:*` лейблами и дать Owner детерминированный UX переходов по этапам.
+- Основной результат: profile-driven stage launch (`quick-fix`, `feature`, `new-service`) + рабочие next-step action paths с fallback без зависимости от web-link.
+- Sprint S5 стартует после review intake-артефактов по Issue #154.
+
+## Scope спринта
+### In scope
+- Формализация и реализация launch profiles с явной матрицей этапов.
+- Обновление service-message UX:
+  - profile-aware next-step cards;
+  - fallback-команды для запуска без web-console.
+- Валидация и guardrails для переходов между профилями (эскалация в full pipeline).
+- Полная трассируемость `issue -> requirements -> stage policy -> acceptance`.
+
+### Out of scope
+- Изменение базовой taxonomy `run:* / state:* / need:*`.
+- Изменение RBAC-модели доступа к production runtime.
+- Изменение multi-repo architecture из Sprint S4.
+
+## План эпиков по дням
+
+| День | Эпик | Priority | Документ | Статус |
+|---|---|---|---|---|
+| Day 1 | Launch profiles и deterministic next-step actions | P0 | `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md` | planned |
+
+## Daily gate (обязательно)
+- Любой переход stage должен иметь audit запись и детерминированный fallback.
+- Изменения policy/docs синхронно отражаются в `requirements_traceability` и `issue_map`.
+- Для каждого profile зафиксированы критерии входа/выхода и условия эскалации.
+
+## Completion критерии спринта
+- [ ] Launch profiles закреплены как продуктовый стандарт и связаны с stage policy.
+- [ ] Next-step action UX не зависит от единственного web-link канала.
+- [ ] Для каждого profile определены acceptance scenarios и failure modes.
+- [ ] Подготовлен handover в `run:dev` с приоритетами реализации и рисками.
+
+## Handover после завершения Sprint S5 Day1
+- `dev`: реализовать profile resolver, service-message fallback и policy проверки.
+- `qa`: подготовить сценарии UX-валидации (happy-path + broken-link + wrong-profile).
+- `sre`: проверить аудит/наблюдаемость и отсутствие обходов governance.
+- `km`: поддерживать трассируемость и синхронизацию продуктовой документации.

--- a/docs/product/labels_and_trigger_policy.md
+++ b/docs/product/labels_and_trigger_policy.md
@@ -5,8 +5,8 @@ title: "codex-k8s — Labels and Trigger Policy"
 status: active
 owner_role: PM
 created_at: 2026-02-11
-updated_at: 2026-02-21
-related_issues: [1, 19, 74, 90, 95]
+updated_at: 2026-02-24
+related_issues: [1, 19, 74, 90, 95, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -237,6 +237,18 @@ approvals:
 - Action-link из GitHub service-comment открывает staff web-console для перехода этапа (`/governance/labels-stages?...`).
 - На фронте выполняется RBAC-проверка (platform admin guard) и показывается confirm-модалка перехода.
 - После подтверждения backend выполняет label transition на Issue: снимает текущие `run:*` и ставит целевой `run:*`.
+
+### Planned UX hardening for launch/transition (Issue #154)
+- Проблема текущего UX: ссылки для быстрого добавления лейблов могут быть нерабочими в зависимости от контекста comment/web/session и блокируют owner-flow.
+- Норматив:
+  - next-step action-card обязан содержать два канала запуска:
+    - validated deep-link в staff web-console (primary);
+    - fallback-команду в текстовом виде (copy-paste для `gh`/label transition) без открытия UI.
+  - сервисные сообщения должны публиковать не только next-step label, но и выбранный launch profile (`quick-fix`, `feature`, `new-service`) с краткой расшифровкой stage-пути.
+  - если primary deep-link недоступен (invalid host/RBAC/session), run не блокируется: owner может завершить переход через fallback-команду.
+- Ограничения безопасности:
+  - fallback-команды не содержат секретов/токенов;
+  - любой transition остаётся в policy/audit контуре (`flow_events` + actor + correlation_id).
 
 ## Оркестрационный flow для `run:self-improve`
 

--- a/docs/product/requirements_machine_driven.md
+++ b/docs/product/requirements_machine_driven.md
@@ -6,7 +6,7 @@ status: active
 owner_role: PM
 created_at: 2026-02-06
 updated_at: 2026-02-24
-related_issues: [1, 74, 90, 112]
+related_issues: [1, 74, 90, 112, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -84,6 +84,8 @@ approvals:
 | FR-050 | Prompt context включает docs tree и role-aware capability блоки (policy-governed), чтобы агент получал релевантный контекст по роли и stage. |
 | FR-051 | GitHub service messages v2 должны отражать run lifecycle и давать прямые ссылки на следующий операционный шаг (включая slot URL для full-env при наличии host). |
 | FR-052 | Для review-driven revise обязателен детерминированный stage resolver (`PR labels -> Issue labels -> run context -> flow_events`) и stage-aware next-step action cards; при ambiguity revise-run не запускается, ставится `need:input`. |
+| FR-053 | Для управления stage-переходами поддерживаются role-aware launch profiles (минимум: `quick-fix`, `feature`, `new-service`) с явной матрицей обязательных/опциональных этапов и детерминированными правилами эскалации в полный pipeline при росте риска/сложности. |
+| FR-054 | Любая next-step подсказка в service-message должна иметь как минимум два операционных канала: рабочий deep-link в staff web-console и текстовый fallback (копируемая label-команда/transition action), чтобы переходы не блокировались при недоступности UI-ссылок. |
 
 ## Non-Functional Requirements (NFR)
 
@@ -177,6 +179,8 @@ approvals:
 - `docs/delivery/sprints/s3/sprint_s3_mvp_completion.md`
 - `docs/delivery/epics/s3/epic_s3.md`
 - `docs/delivery/e2e_mvp_master_plan.md`
+- `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md`
+- `docs/delivery/epics/s5/epic_s5.md`
 - `docs/delivery/issue_map.md`
 - `docs/delivery/development_process_requirements.md`
 - `docs/design-guidelines/AGENTS.md`

--- a/docs/product/stage_process_model.md
+++ b/docs/product/stage_process_model.md
@@ -5,8 +5,8 @@ title: "codex-k8s — Stage Process Model"
 status: active
 owner_role: EM
 created_at: 2026-02-11
-updated_at: 2026-02-21
-related_issues: [1, 19, 90, 95]
+updated_at: 2026-02-24
+related_issues: [1, 19, 90, 95, 154]
 related_prs: []
 approvals:
   required: ["Owner"]
@@ -73,6 +73,21 @@ approvals:
   - обычно 2 действия (`revise` + канонический `next-stage`);
   - для `design` дополнительно публикуется fast-track `run:dev` вместе с `run:plan`.
 - Реализованный UX: next-step action-link открывает staff web-console, где frontend проверяет RBAC и подтверждает переход через модалку, а backend выполняет label transition на Issue.
+
+## Preset stage trajectories (planned, Issue #154)
+
+Цель: убрать ручной “памятный” выбор следующего stage и стандартизовать разные типы задач без разрыва traceability.
+
+| Профиль | Обязательная траектория | Когда применять | Эскалация в full pipeline |
+|---|---|---|---|
+| `quick-fix` | `intake -> plan -> dev -> qa -> release -> postdeploy -> ops` | точечные исправления без изменения доменной/архитектурной модели | при появлении cross-service impact или новых интеграций обязателен переход в `feature`/`new-service` путь |
+| `feature` | `intake -> prd -> design -> plan -> dev -> qa -> release -> postdeploy -> ops` | функциональные доработки в существующих сервисах | при архитектурных рисках/NFR-изменениях добавляется `arch` и при необходимости `vision` |
+| `new-service` | `intake -> vision -> prd -> arch -> design -> plan -> dev -> qa -> release -> postdeploy -> ops` | новые сервисы/крупные инициативы с изменением системного контура | сокращение этапов не допускается без явного owner-решения в audit trail |
+
+Правила применения:
+- launch profile выбирается явно и фиксируется в service-message и traceability артефактах;
+- пропуск этапа возможен только при наличии правила в профиле или через явное owner-решение с записью в аудит;
+- при ambiguity по профилю выставляется `need:input`, запуск следующего stage блокируется.
 
 ## Вход/выход этапа
 


### PR DESCRIPTION
## Что сделано
- Формализованы новые продуктовые требования:
  - `FR-053`: launch profiles для разных типов инициатив (`quick-fix`, `feature`, `new-service`);
  - `FR-054`: обязательный fallback для next-step действий (primary deep-link + текстовая команда).
- Обновлены продуктовые политики stage/label-процесса для Issue #154:
  - `docs/product/labels_and_trigger_policy.md`;
  - `docs/product/stage_process_model.md`.
- Добавлен delivery-контур следующего инкремента:
  - Sprint S5 plan;
  - Epic catalog S5;
  - S5 Day1 epic с декомпозицией, quality-gates и acceptance criteria.
- Синхронизирована трассируемость:
  - `docs/delivery/requirements_traceability.md`;
  - `docs/delivery/issue_map.md`;
  - индексы sprint/epic и delivery plan.
- Создан follow-up issue следующего этапа: #155.

## Трассируемость
- Issue: #154
- Requirements: `FR-053`, `FR-054`
- Delivery artifacts:
  - `docs/delivery/sprints/s5/sprint_s5_stage_entry_and_label_ux.md`
  - `docs/delivery/epics/s5/epic_s5.md`
  - `docs/delivery/epics/s5/epic-s5-day1-launch-profiles-and-stage-launcher-ux.md`

## Acceptance criteria (intake)
- [x] Зафиксированы требования для удобного управления process/labels.
- [x] Подготовлена декомпозиция на исполняемый следующий инкремент.
- [x] Обновлена матрица трассируемости issue -> requirements -> delivery.
- [x] Зафиксированы открытые риски и продуктовые допущения.

## Открытые риски
- Перегрузка service-comment действиями может снизить UX.
- Профили запуска могут использоваться для обхода обязательных этапов без строгих guardrails.
- Fallback-команды должны централизованно шаблонизироваться, чтобы не расходиться с policy.

## Продуктовые допущения
- Launch profiles задают управляемые траектории, но не отменяют канонический stage pipeline.
- При недоступности web-console fallback path должен быть достаточен для продолжения процесса.
- Owner может принудительно эскалировать инициативу в полный pipeline.

## Проверки
- `git diff --check`.
- Проверено, что изменены только markdown-файлы (`*.md`).
- Выполнен self-check по `docs/design-guidelines/common/check_list.md` (релевантные для doc-only пункты).
