### PR TITLE
Смягчить валидацию services.yaml для forward-compatible расширений

### DIFF
--- a/docs/architecture/multi_repo_mode_design.md
+++ b/docs/architecture/multi_repo_mode_design.md
@@ -187,7 +187,7 @@ spec:
    - explicit `rootRepository`, либо
    - virtual root (service repos ordered by deterministic key).
 3. Загрузить `services.yaml` root и все `imports` (repo/path/ref).
-4. Построить `effective manifest` (typed merge + cycle detection + strict validation).
+4. Построить `effective manifest` (typed merge + cycle detection + schema/domain validation с forward-compatible unknown fields).
 5. Сформировать execution-plan (deploy order и зависимости).
 6. Сформировать repo checkout plan для worker/agent-runner:
    - только нужные repo/path;

--- a/libs/go/servicescfg/schema/services.schema.json
+++ b/libs/go/servicescfg/schema/services.schema.json
@@ -56,7 +56,7 @@
                 }
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "imports": {
@@ -106,10 +106,10 @@
           "$ref": "#/$defs/orchestration"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "$defs": {
     "importRef": {
       "oneOf": [
@@ -126,7 +126,7 @@
               "minLength": 1
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         }
       ]
     },
@@ -142,7 +142,7 @@
           "$ref": "#/$defs/serviceDefaults"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "serviceDefaults": {
       "type": "object",
@@ -160,7 +160,7 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "environment": {
       "type": "object",
@@ -178,7 +178,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "webhookRuntime": {
       "type": "object",
@@ -202,7 +202,7 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "secretResolution": {
       "type": "object",
@@ -230,7 +230,7 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "secretKeyOverride": {
       "type": "object",
@@ -249,7 +249,7 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "secretPattern": {
       "type": "object",
@@ -284,7 +284,7 @@
           "minLength": 1
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "projectDocRef": {
       "type": "object",
@@ -312,7 +312,7 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "runtimeMode": {
       "type": "string",
@@ -354,7 +354,7 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "infrastructureItem": {
       "type": "object",
@@ -380,7 +380,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "service": {
       "type": "object",
@@ -424,7 +424,7 @@
           "$ref": "#/$defs/serviceImage"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "codeUpdateStrategy": {
       "type": "string",
@@ -443,7 +443,7 @@
           "minLength": 1
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "serviceImage": {
       "type": "object",
@@ -455,7 +455,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "orchestration": {
       "type": "object",
@@ -470,7 +470,7 @@
           "$ref": "#/$defs/cleanupPolicy"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "cleanupPolicy": {
       "type": "object",
@@ -479,7 +479,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
## Что сделано
- Смягчена JSON Schema для `services.yaml`: во всех объектных секциях `additionalProperties` переключен в `true`, чтобы новые поля не ломали deploy на старом рантайме.
- Сохранена типовая проверка структуры и обязательных полей (например, `apiVersion`, `kind`, `metadata`, `spec`, типы массивов/объектов).
- Обновлены тесты `libs/go/servicescfg/load_test.go`:
  - удален кейс, который ожидал падение на неизвестном поле сервиса;
  - добавлен позитивный тест `TestLoadFromYAML_UnknownFieldsAreForwardCompatible`, подтверждающий, что неизвестные поля игнорируются и загрузка проходит.
- Синхронизирована архитектурная заметка в `docs/architecture/multi_repo_mode_design.md` (формулировка про forward-compatible валидацию).

## Почему
- В активной разработке в `services.yaml` регулярно появляются новые ключи.
- Строгая схема (`additionalProperties: false`) приводила к падению валидации и блокировала прод-деплой до синхронного обновления схемы/миграций.
- Новая политика валидации делает конфиг эволюционным: старый рантайм продолжает работать с известной частью контракта, не падая на добавленных полях.

## Риски и ограничения
- Опечатки в новых/существующих полях теперь не будут ловиться на schema-слое как `unknown property`.
- Компенсация: доменная/типовая валидация и unit-тесты по критичным разделам сохраняются.

## Проверки
- `go test ./libs/go/servicescfg/...`
- `go test ./cmd/codex-bootstrap/internal/cli/...`
- `make lint-go`
- `make dupl-go` (падает на уже существующих дубликатах в других пакетах, вне области изменений этого PR)

## Self-check
- `docs/design-guidelines/common/check_list.md` — выполнено, релевантные пункты соблюдены.
- `docs/design-guidelines/go/check_list.md` — выполнено, релевантные пункты соблюдены.

Closes #162
