### PR TITLE
Исправить подмену ссылки задачи ссылкой PR в run:dev:revise

### DIFF
--- a/services/internal/control-plane/internal/domain/webhook/service.go
+++ b/services/internal/control-plane/internal/domain/webhook/service.go
@@ -311,6 +311,8 @@ func (s *Service) IngestGitHubWebhook(ctx context.Context, cmd IngestCommand) (I
 		Trigger:           triggerPtr(trigger, hasIssueRunTrigger),
 		Agent:             agent,
 		ProfileHints:      profileHints,
+		ResolvedIssueNo:   reviewMeta.ResolvedIssueNumber,
+		ResolvedIssueURL:  buildGitHubIssueURL(strings.TrimSpace(envelope.Repository.FullName), reviewMeta.ResolvedIssueNumber),
 		RuntimeMode:       runtimeMode,
 		RuntimeSource:     runtimeModeSource,
 		RuntimeTargetEnv:  runtimeTargetEnv,

--- a/services/internal/control-plane/internal/domain/webhook/service_test.go
+++ b/services/internal/control-plane/internal/domain/webhook/service_test.go
@@ -1323,8 +1323,8 @@ func TestIngestGitHubWebhook_PullRequestReviewChangesRequested_WithRunDevReviseL
 	if runPayload.Trigger.Label != webhookdomain.DefaultRunDevReviseLabel {
 		t.Fatalf("unexpected trigger label: %#v", runPayload.Trigger.Label)
 	}
-	if runPayload.Issue == nil || runPayload.Issue.Number != 200 {
-		t.Fatalf("expected issue payload with number=200, got %#v", runPayload.Issue)
+	if runPayload.Issue != nil {
+		t.Fatalf("expected no issue payload when linked issue is not resolved, got %#v", runPayload.Issue)
 	}
 	if runPayload.PullRequest == nil || runPayload.PullRequest.Number != 200 {
 		t.Fatalf("expected pull_request payload with number=200, got %#v", runPayload.PullRequest)
@@ -1499,6 +1499,12 @@ func TestIngestGitHubWebhook_PullRequestReviewChangesRequested_ResolvesFromIssue
 	if runPayload.Trigger.Label != webhookdomain.DefaultRunPlanReviseLabel {
 		t.Fatalf("unexpected trigger label: %q", runPayload.Trigger.Label)
 	}
+	if runPayload.Issue == nil || runPayload.Issue.Number != 95 {
+		t.Fatalf("expected resolved issue payload with number=95, got %#v", runPayload.Issue)
+	}
+	if runPayload.Issue.HTMLURL != "https://github.com/codex-k8s/codex-k8s/issues/95" {
+		t.Fatalf("unexpected resolved issue url: %q", runPayload.Issue.HTMLURL)
+	}
 	if runPayload.ProfileHints == nil {
 		t.Fatal("expected profile hints in run payload")
 	}
@@ -1587,6 +1593,12 @@ func TestIngestGitHubWebhook_PullRequestReviewChangesRequested_ResolvesFromLastR
 	}
 	if runPayload.Trigger.Label != webhookdomain.DefaultRunDesignReviseLabel {
 		t.Fatalf("unexpected trigger label: %q", runPayload.Trigger.Label)
+	}
+	if runPayload.Issue == nil || runPayload.Issue.Number != 96 {
+		t.Fatalf("expected resolved issue payload with number=96, got %#v", runPayload.Issue)
+	}
+	if runPayload.Issue.HTMLURL != "https://github.com/codex-k8s/codex-k8s/issues/96" {
+		t.Fatalf("unexpected resolved issue url: %q", runPayload.Issue.HTMLURL)
 	}
 }
 


### PR DESCRIPTION
## Что сделано
- Исправил формирование `run_payload.issue` в webhook-обработке:
  - удалил ошибочный fallback, который при `pull_request_review` подставлял в `issue` данные PR;
  - добавил корректное заполнение `issue` только если:
    - в webhook есть реальный `issue`, или
    - `resolvedIssue` детерминированно найден resolver'ом из истории запусков.
- Для `resolvedIssue` добавил построение canonical URL вида `https://github.com/<repo>/issues/<number>`.
- Обновил/дополнил тесты `webhook/service_test.go`:
  - проверка, что без найденного issue поле `run_payload.issue` не заполняется PR-данными;
  - проверка, что при resolved issue из истории проставляются корректные `issue.number` и `issue.html_url`.

## Почему это важно
Ранее при запуске revise по PR платформа могла заполнять поле задачи (`issue_url`) ссылкой на pull request, что путало контекст задачи в UI и диагностике.

## Риски
- Низкие: изменение локализовано в webhook payload-caster и покрыто тестами на `pull_request_review` сценарии.
- Для сценариев без однозначно связанного issue теперь `issue` остаётся пустым (вместо неверной подстановки PR).

## Проверки
- `go test ./services/internal/control-plane/internal/domain/webhook`
- `make lint-go`
- `make dupl-go` — падает на существующих дублях в других частях репозитория (не связано с данным изменением).

## Чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты выполнены.
- `docs/design-guidelines/go/check_list.md` — релевантные пункты выполнены.

Closes #167
