### PR TITLE
Сделать запуск reviewer по need:reviewer идемпотентным

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-github/v82 v82.0.0
 	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/labstack/echo/v5 v5.0.3
 	github.com/modelcontextprotocol/go-sdk v1.3.0
@@ -40,7 +41,6 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/services/internal/control-plane/internal/domain/webhook/model.go
+++ b/services/internal/control-plane/internal/domain/webhook/model.go
@@ -161,15 +161,16 @@ type githubPullRequestRef struct {
 }
 
 type githubPullRequestRecord struct {
-	ID      int64                 `json:"id"`
-	Number  int64                 `json:"number"`
-	Title   string                `json:"title"`
-	HTMLURL string                `json:"html_url"`
-	State   string                `json:"state"`
-	Labels  []githubLabelRecord   `json:"labels"`
-	Head    githubPullRequestHead `json:"head"`
-	User    githubActorRecord     `json:"user"`
-	Base    githubPullRequestBase `json:"base"`
+	ID        int64                 `json:"id"`
+	Number    int64                 `json:"number"`
+	Title     string                `json:"title"`
+	HTMLURL   string                `json:"html_url"`
+	State     string                `json:"state"`
+	UpdatedAt string                `json:"updated_at"`
+	Labels    []githubLabelRecord   `json:"labels"`
+	Head      githubPullRequestHead `json:"head"`
+	User      githubActorRecord     `json:"user"`
+	Base      githubPullRequestBase `json:"base"`
 }
 
 type githubPullRequestHead struct {


### PR DESCRIPTION
## Что сделано
- Добавлена детерминированная стратегия `correlation_id` для webhook-события `pull_request:labeled` с лейблом `need:reviewer`.
- Для построения ключа идемпотентности используется подпись из `repository + pull_request.number + action + label + pull_request.updated_at`.
- В `githubPullRequestRecord` добавлено поле `updated_at` для чтения timestamp из payload.
- Весь ingest-flow (создание run, flow events, payload/run result) переведён на `effective correlation_id`, чтобы дубли с разными `delivery_id` не создавали второй run.
- Добавлены тесты:
  - дедупликация при двух delivery с одинаковым `updated_at`;
  - создание нового run при изменении `updated_at` (повторный осознанный запуск остаётся возможным).

## Зачем
На практике один `need:reviewer` мог запускать два reviewer-рана (два разных `delivery_id`).
Изменение делает запуск идемпотентным на уровне бизнес-события, а не только по `delivery_id`.

## Риски и ограничения
- Если в payload отсутствует `pull_request.updated_at`, сервис откатывается к исходному `correlation_id` (старое поведение).
- `make dupl-go` в репозитории падает на исторических дубликатах в незатронутых файлах (baseline), новых дубликатов в рамках этой задачи не добавлено.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/webhook/...`
- `go test ./services/internal/control-plane/internal/app/...`
- `go test ./libs/go/domain/webhook/...`
- `go mod tidy`
- `make lint-go`
- `make dupl-go` (ожидаемо не зелёный из-за существующих baseline-дубликатов)

## Чек-листы
- [x] `docs/design-guidelines/common/check_list.md` (релевантные пункты выполнены)
- [x] `docs/design-guidelines/go/check_list.md` (релевантные пункты выполнены)

Closes #177
