### PR TITLE
fix: reviewer-run отображается в списке запусков

### DIFF
--- a/services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go
@@ -1,0 +1,24 @@
+package staffrun
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunListQueriesIncludeReviewerTriggerLabel(t *testing.T) {
+	t.Parallel()
+
+	queries := map[string]string{
+		"list_all":      queryListAll,
+		"list_for_user": queryListForUser,
+	}
+
+	for name, query := range queries {
+		if !strings.Contains(query, "ILIKE 'run:%'") {
+			t.Fatalf("%s query must keep run trigger filter", name)
+		}
+		if !strings.Contains(query, "ILIKE 'need:reviewer'") {
+			t.Fatalf("%s query must include reviewer trigger filter", name)
+		}
+	}
+}

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql
@@ -103,6 +103,9 @@ LEFT JOIN LATERAL (
     ORDER BY ags.updated_at DESC
     LIMIT 1
 ) ws ON true
-WHERE COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'run:%'
+WHERE (
+        COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'run:%'
+        OR COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'need:reviewer'
+    )
 ORDER BY created_at DESC
 LIMIT $1;

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql
@@ -105,6 +105,9 @@ LEFT JOIN LATERAL (
 ) ws ON true
 WHERE pm.user_id = $1::uuid
   AND ar.project_id IS NOT NULL
-  AND COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'run:%'
+  AND (
+        COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'run:%'
+        OR COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'need:reviewer'
+      )
 ORDER BY ar.created_at DESC
 LIMIT $2;


### PR DESCRIPTION
## Что сделано
- Исправлен фильтр в SQL для списка запусков (`staffrun/sql/list_all.sql`, `staffrun/sql/list_for_user.sql`): теперь в выдачу попадают не только `run:*`, но и reviewer-запуски с trigger label `need:reviewer`.
- Добавлен регрессионный тест `repository_queries_test.go`, который фиксирует требование по поддержке обоих триггеров (`run:*` и `need:reviewer`) в запросах списка запусков.

## Почему это нужно
Reviewer-run создаётся по PR label `need:reviewer`, поэтому прежний фильтр `ILIKE 'run:%'` исключал такие записи из общего списка запусков, хотя сам запуск существовал и открывался по `run_id`.

## Проверки
- `go test ./services/internal/control-plane/internal/repository/postgres/staffrun`
- `make lint-go`
- `make dupl-go` — падает на существующих дублях в репозитории, не связанных с этой правкой.

## Риски
- Низкий риск: изменение точечное, затрагивает только критерий отбора в list-запросах staff run repository.

## Чек-листы
- `docs/design-guidelines/common/check_list.md` — выполнено (релевантные пункты).
- `docs/design-guidelines/go/check_list.md` — выполнено (релевантные пункты).

Closes #179
