### PR TITLE
fix: ограничить trigger labels только human actor

### DIFF
--- a/docs/product/labels_and_trigger_policy.md
+++ b/docs/product/labels_and_trigger_policy.md
@@ -110,6 +110,9 @@ approvals:
 ### Trigger/deploy (`run:*`)
 - Если лейбл инициирует агент, требуется апрув Owner до фактического применения.
 - Если лейбл инициирует человек с правами admin/owner, применяется по правам GitHub и политике репозитория.
+- Webhook guard для `issues:labeled` принимает trigger только от human-actor (`sender.type=User`);
+  события от `Bot`/`App` блокируются с диагностикой в `flow_events` и warning-comment.
+- Для human-actor дополнительно обязателен RBAC-check в проекте: platform owner/admin или project member с ролью `admin`/`read_write`.
 - Любая операция с `run:*` логируется в `flow_events`.
 - Для всех `run:*` обязателен review gate перед финальным Owner review:
   - pre-review от системного `reviewer` для технических артефактов;

--- a/services/internal/control-plane/internal/domain/webhook/model.go
+++ b/services/internal/control-plane/internal/domain/webhook/model.go
@@ -153,6 +153,7 @@ type githubLabelRecord struct {
 type githubActorRecord struct {
 	Login string `json:"login"`
 	ID    int64  `json:"id"`
+	Type  string `json:"type"`
 }
 
 type githubPullRequestRef struct {


### PR DESCRIPTION
## Что сделано
- В webhook-домене (`control-plane`) усилена авторизация trigger-лейблов `run:*`:
  - добавлена проверка `sender.type` из GitHub payload;
  - trigger принимается только для human actor (`sender.type=User`);
  - события от `Bot`/`App` игнорируются с reason `sender_type_<type>_not_permitted`.
- Сохранена существующая RBAC-проверка для human actor:
  - platform owner/admin или project member с ролью `admin`/`read_write`.
- Добавлен регрессионный тест:
  - `TestIngestGitHubWebhook_IssueRunDev_DeniesBotSenderEvenWhenUserIsProjectMember`.
- Обновлена продуктовая документация:
  - `docs/product/labels_and_trigger_policy.md` — явно зафиксирован webhook guard по `sender.type` и RBAC-check.

## Зачем
Issue #193: нужно исключить несанкционированный запуск цепочек задач через auto-labeling агентами. Теперь `run:*` trigger из webhook не срабатывает для bot/app actor.

## Риски
- Если в webhook payload не будет `sender.type`, применяется текущая совместимая логика (проверка по login/RBAC).
- Изменение затрагивает только ветку `issues:labeled` для trigger-лейблов.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/webhook/...` ✅
- `go test ./services/internal/control-plane/internal/domain/runstatus/...` ✅
- `make lint-go` ✅
- `make dupl-go` ⚠️ падает на существующем дубле вне scope этой задачи:
  - `services/internal/control-plane/internal/domain/runstatus/trigger_conflict_render.go:51-64`
  - `services/internal/control-plane/internal/domain/webhook/service.go:720-733`

## Чек-листы
- `docs/design-guidelines/common/check_list.md` — выполнено, релевантные пункты проверены.
- `docs/design-guidelines/go/check_list.md` — выполнено, релевантные пункты проверены.
