### PR TITLE
[ai-repair] SRE: hardening docs for AI-slot build failures

### DIFF
--- a/docs/ops/rollback_plan_ai_slot_build_pipeline.md
+++ b/docs/ops/rollback_plan_ai_slot_build_pipeline.md
@@ -17,30 +17,34 @@ approvals:
 # Rollback Plan: AI Slot Build Pipeline
 
 ## TL;DR
-- Когда откатываем: повторяемые падения build/mirror в ai-слоте после mitigation.
+- Когда откатываем: повторяемые падения build/mirror/codegen-check в ai-слоте после mitigation.
 - Как откатываем:
-  - сначала config rollback (отключение cache / возврат стабильных runtime env);
+  - сначала config rollback (отключение cache / нормализация `CODEXK8S_BUILD_REF` / возврат стабильных runtime env);
   - затем при необходимости image rollback control-plane/worker.
-- Как проверяем: успешные ai-slot сборки + отсутствие `MANIFEST_UNKNOWN` в окне 30 минут.
+- Как проверяем: успешные ai-slot сборки + отсутствие `MANIFEST_UNKNOWN` и checkout/build-ref ошибок в окне 30 минут.
 
 ## Триггеры rollback
 - `AI_SLOT_BUILD_FAILURE_BURST` page-alert не гасится после mitigation.
 - `AI_SLOT_BUILD_MANIFEST_UNKNOWN_PERSISTENT` повторяется.
+- `AI_SLOT_CODEGEN_CHECK_BUILD_REF_INVALID` повторяется после нормализации ref.
 - Нарушается SLO восстановления (MTTR > 30m).
 
 ## Предусловия
 - Доступ к `kubectl` в `codex-k8s-prod`.
 - Зафиксирован последний стабильный релиз control-plane/worker.
 - Подтверждено, что проблема в build pipeline, а не в секретах/сети конкретного проекта.
+- Подтвержден текущий класс отказа: cache-signature или build-ref-signature.
 
 ## Варианты отката
 ### 1) Конфигурационный rollback (предпочтительный)
 - Шаги:
   1. Зафиксировать `CODEXK8S_KANIKO_CACHE_ENABLED=false`.
-  2. Проверить `rollout status` control-plane.
-  3. Повторить ai-slot run.
+  2. Нормализовать `CODEXK8S_BUILD_REF` (валидный git ref без CLI-флагов).
+  3. Проверить `rollout status` control-plane.
+  4. Повторить ai-slot run.
 - Риски:
   - рост времени сборки из-за отключенного cache.
+  - возможный откат на менее свежий ref, если выбран fallback (`main`/stable SHA).
 
 ### 2) Rollback runtime image (control-plane/worker)
 - Шаги:
@@ -58,7 +62,9 @@ approvals:
 
 ## Пошаговая инструкция rollback
 1. Подтвердить инцидент по runbook (`RB-CK8S-AISLOT-BUILD-0001`).
-2. Выполнить config rollback (`CODEXK8S_KANIKO_CACHE_ENABLED=false`).
+2. Выполнить config rollback:
+   - `CODEXK8S_KANIKO_CACHE_ENABLED=false`;
+   - `CODEXK8S_BUILD_REF=<валидный_ref_без_флагов>`.
 3. Проверить логи и jobs:
 
 ```bash
@@ -66,7 +72,9 @@ ns="codex-k8s-prod"
 kubectl -n "$ns" rollout status deploy/codex-k8s-control-plane --timeout=180s
 kubectl -n "$ns" get jobs --sort-by=.metadata.creationTimestamp | tail -n 30
 kubectl -n "$ns" logs deploy/codex-k8s-control-plane --since=30m \
-  | grep -E "MANIFEST_UNKNOWN|retrieving image from cache" || true
+  | grep -E "MANIFEST_UNKNOWN|retrieving image from cache|checkout --detach|unknown switch|is not a commit" || true
+kubectl -n "$ns" logs job/codex-k8s-codegen-check --tail=200 2>/dev/null \
+  | grep -E "checkout --detach|unknown switch|is not a commit|CODEXK8S_BUILD_REF" || true
 ```
 
 4. Если ошибка сохраняется, согласовать image rollback с Owner.
@@ -74,11 +82,11 @@ kubectl -n "$ns" logs deploy/codex-k8s-control-plane --since=30m \
 
 ## Верификация после rollback
 - Проверки функционала:
-  - новый ai-slot run проходит build/stage без аварий.
+  - новый ai-slot run проходит build/stage/codegen-check без аварий.
 - Метрики:
   - failure rate возвращается в SLO-коридор.
 - Логи:
-  - нет новых `MANIFEST_UNKNOWN` в окне 30m.
+  - нет новых `MANIFEST_UNKNOWN` и checkout/build-ref ошибок в окне 30m.
 - Smoke:
   - basic run lifecycle (`queued -> running -> completed`) в ai-слоте.
 

--- a/docs/ops/runbook_ai_slot_build_failures.md
+++ b/docs/ops/runbook_ai_slot_build_failures.md
@@ -1,7 +1,7 @@
 ---
 doc_id: RB-CK8S-AISLOT-BUILD-0001
 type: runbook
-title: "AI Slot Build Runbook: MANIFEST_UNKNOWN / cache retrieval errors"
+title: "AI Slot Build Runbook: cache/MANIFEST_UNKNOWN и codegen-check build-ref errors"
 status: active
 owner_role: SRE
 created_at: 2026-02-26
@@ -14,29 +14,37 @@ approvals:
   request_id: "issue-205-ai-repair"
 ---
 
-# Runbook: AI slot build failures (`MANIFEST_UNKNOWN`)
+# Runbook: AI slot build failures (cache + build-ref)
 
 ## TL;DR
-- Симптом: сборка run в ai-слоте падает в Kaniko c `MANIFEST_UNKNOWN` при `retrieving image from cache`.
-- Быстрая диагностика: проверить `codex-k8s-control-plane`/`codex-k8s-worker` логи и неуспешные build/mirror jobs.
-- Быстрое восстановление: отключить cache (`CODEXK8S_KANIKO_CACHE_ENABLED=false`), перезапустить control-plane и повторить deploy/run.
+- Симптом A: сборка run в ai-слоте падает в Kaniko c `MANIFEST_UNKNOWN` при `retrieving image from cache`.
+- Симптом B: `codegen-check` job падает на `git checkout --detach` из-за некорректного `CODEXK8S_BUILD_REF` (например, ref с префиксом `-b`).
+- Быстрая диагностика: проверить логи `codex-k8s-control-plane`/`codex-k8s-worker` и последние `build/mirror/codegen-check` jobs.
+- Быстрое восстановление:
+  - для cache-сигнатуры: `CODEXK8S_KANIKO_CACHE_ENABLED=false`;
+  - для build-ref сигнатуры: нормализовать `CODEXK8S_BUILD_REF` до валидного git ref без CLI-флагов.
 
 ## Когда использовать
 - Trigger: алерт из `docs/ops/alerts_ai_slot_build_pipeline.md`.
 - Триггеры вручную:
   - в issue/run сообщается о повторяющемся падении сборок в ai-слоте;
-  - в логах встречается `MANIFEST_UNKNOWN` или `retrieving image from cache`.
+  - в логах встречается `MANIFEST_UNKNOWN` или `retrieving image from cache`;
+  - в `codegen-check` логах есть `unknown switch 'b'`, `is not a commit` или `checkout --detach`.
+- Для инцидента Issue #205 подтверждена сигнатура build-ref: `codegen-check` падает на `git checkout --detach` при ref с префиксом `-b`.
 
 ## Предпосылки/доступы
 - Нужен доступ `kubectl` в production namespace (`codex-k8s-prod`).
 - В некоторых runtime-профилях `pods/exec` в БД-pod может быть закрыт RBAC; в этом случае диагностика ведётся по логам control-plane/worker и статусам jobs.
 
 ## Симптомы
-- build/deploy job завершается `Failed`.
-- в логах есть строки:
+- `build/mirror/codegen-check` job завершается `Failed`.
+- В логах есть строки:
   - `Error while retrieving image from cache ... MANIFEST_UNKNOWN`;
   - `MANIFEST_UNKNOWN` при mirror/cache шагах.
-- production сервисы остаются healthy, но новые ai-slot сборки не стартуют или быстро падают.
+  - `git checkout --detach ...`;
+  - `unknown switch 'b'`;
+  - `fatal: '-b ...' is not a commit`.
+- Production сервисы могут оставаться healthy, но новые ai-slot сборки не стартуют или быстро падают на build/check стадии.
 
 ## Диагностика (пошагово)
 1) Проверить общий статус runtime:
@@ -46,7 +54,7 @@ ns="codex-k8s-prod"
 kubectl -n "$ns" get pods,job -o wide
 ```
 
-2) Проверить ошибки cache/mirror в control-plane:
+2) Проверить cache/mirror ошибки в control-plane:
 
 ```bash
 ns="codex-k8s-prod"
@@ -54,28 +62,44 @@ kubectl -n "$ns" logs deploy/codex-k8s-control-plane --since=6h \
   | grep -E "MANIFEST_UNKNOWN|retrieving image from cache|kaniko|mirror"
 ```
 
-3) Проверить worker логи на run-level симптомы:
+3) Проверить ошибки checkout/build-ref в codegen-check:
+
+```bash
+ns="codex-k8s-prod"
+kubectl -n "$ns" logs job/codex-k8s-codegen-check --tail=200 2>/dev/null \
+  | grep -E "checkout --detach|unknown switch|is not a commit|CODEXK8S_BUILD_REF" || true
+kubectl -n "$ns" logs deploy/codex-k8s-control-plane --since=6h \
+  | grep -E "codegen-check|CODEXK8S_BUILD_REF|checkout --detach|unknown switch|is not a commit" || true
+```
+
+4) Проверить worker логи на run-level симптомы:
 
 ```bash
 ns="codex-k8s-prod"
 kubectl -n "$ns" logs deploy/codex-k8s-worker --since=6h \
-  | grep -E "MANIFEST_UNKNOWN|retrieving image from cache|build failed|run_id"
+  | grep -E "MANIFEST_UNKNOWN|retrieving image from cache|checkout --detach|unknown switch|build failed|run_id"
 ```
 
-4) Проверить неуспешные jobs (если есть):
+5) Проверить неуспешные jobs:
 
 ```bash
 ns="codex-k8s-prod"
 kubectl -n "$ns" get jobs --sort-by=.metadata.creationTimestamp \
-  | grep -E "kaniko|mirror|build|Failed|Error" || true
+  | grep -E "kaniko|mirror|build|codegen-check|Failed|Error" || true
 ```
 
 ## Митигирование (восстановление)
-1) Применить kill switch cache:
-   - выставить `CODEXK8S_KANIKO_CACHE_ENABLED=false` в runtime-конфигурации;
-   - убедиться, что rollout `codex-k8s-control-plane` завершён.
-2) Повторить проблемную задачу/деплой в ai-слоте.
-3) Проверить, что новые build/mirror jobs завершаются `Complete`.
+### A) Cache-сигнатура (`MANIFEST_UNKNOWN`)
+1) Выставить `CODEXK8S_KANIKO_CACHE_ENABLED=false` в runtime-конфигурации.
+2) Убедиться, что rollout `codex-k8s-control-plane` завершён.
+3) Повторить проблемную задачу/деплой в ai-слоте.
+
+### B) Build-ref сигнатура (`git checkout --detach`)
+1) Проверить `CODEXK8S_BUILD_REF` в runtime-конфигурации.
+2) Нормализовать значение до валидного git ref:
+   - допустимо: `main`, `feature/<branch>`, commit SHA;
+   - запрещено: передавать shell/git CLI флаги (`-b`, `--...`) в значении ref.
+3) Повторить codegen-check/runtime deploy и убедиться, что job завершается `Complete`.
 
 Оперативная проверка:
 
@@ -83,12 +107,15 @@ kubectl -n "$ns" get jobs --sort-by=.metadata.creationTimestamp \
 ns="codex-k8s-prod"
 kubectl -n "$ns" rollout status deploy/codex-k8s-control-plane --timeout=180s
 kubectl -n "$ns" logs deploy/codex-k8s-control-plane --since=20m \
-  | grep -E "MANIFEST_UNKNOWN|retrieving image from cache" || true
+  | grep -E "MANIFEST_UNKNOWN|retrieving image from cache|checkout --detach|unknown switch|is not a commit" || true
+kubectl -n "$ns" logs job/codex-k8s-codegen-check --tail=200 2>/dev/null \
+  | grep -E "checkout --detach|unknown switch|is not a commit" || true
 ```
 
 ## Эскалация
 - Эскалировать, если:
   - после отключения cache ошибка повторяется более 2 раз подряд;
+  - после нормализации `CODEXK8S_BUILD_REF` ошибка checkout повторяется более 2 раз подряд;
   - одновременно деградируют mirror jobs и registry availability;
   - время восстановления превышает 30 минут.
 - Кому:
@@ -103,11 +130,12 @@ kubectl -n "$ns" logs deploy/codex-k8s-control-plane --since=20m \
 - Использовать `docs/ops/rollback_plan_ai_slot_build_pipeline.md`.
 
 ## Проверка результата
-- Новые ai-slot сборки завершаются успешно.
-- В окне 30 минут отсутствуют новые `MANIFEST_UNKNOWN` в control-plane.
+- Новые ai-slot сборки и codegen-check завершаются успешно.
+- В окне 30 минут отсутствуют новые `MANIFEST_UNKNOWN` и checkout/build-ref ошибки.
 - В issue/инциденте подтверждён recovery и закрыты активные алерты.
 
 ## Пост-действия
 - Обновить issue с root cause и таймлайном восстановления.
 - Сверить алерты и пороги в `docs/ops/alerts_ai_slot_build_pipeline.md`.
 - Сверить SLO-бюджет в `docs/ops/slo_ai_slot_build_pipeline.md`.
+- Зафиксировать в RCA безопасный формат `CODEXK8S_BUILD_REF` (без CLI-флагов).

--- a/docs/ops/slo_ai_slot_build_pipeline.md
+++ b/docs/ops/slo_ai_slot_build_pipeline.md
@@ -21,7 +21,7 @@ approvals:
 - Основные SLI: build success ratio, recovery MTTR.
 - Цели:
   - availability SLO: `>=99.0%` успешных ai-slot build за 7 дней;
-  - incident recovery SLO: `<=30m` до восстановления после cache-related сбоя.
+  - incident recovery SLO: `<=30m` до восстановления после cache-related или build-ref-related сбоя.
 - Error budget: `1.0%` на 7 дней.
 
 ## Сервис и границы
@@ -30,7 +30,7 @@ approvals:
 - Клиенты:
   - пользователи, запускающие agent-run в ai-слотах.
 - Зависимости:
-  - `control-plane`, `worker`, registry/mirror path, Kubernetes jobs.
+  - `control-plane`, `worker`, registry/mirror path, Kubernetes jobs, `codegen-check` job.
 
 ## Critical User Journeys (CUJ)
 1. CUJ-1: пользователь запускает задачу, build-пайплайн завершается успешно, run стартует.
@@ -39,7 +39,7 @@ approvals:
 ## SLIs
 ### SLI-1: Build Availability
 - Определение:
-  - `successful_build_jobs / total_build_jobs` для ai-slot за окно измерения.
+  - `successful_build_and_codegen_jobs / total_build_and_codegen_jobs` для ai-slot за окно измерения.
 - Источник:
   - Kubernetes jobs status (+ при наличии Prometheus `kube_job_status_*`).
 - Период:
@@ -47,7 +47,7 @@ approvals:
 
 ### SLI-2: Recovery MTTR
 - Определение:
-  - время от первого зафиксированного cache-related failure до первого успешного build после mitigation.
+  - время от первого зафиксированного cache/build-ref failure до первого успешного build/codegen-check после mitigation.
 - Источник:
   - control-plane/worker logs + job timelines.
 - Период:
@@ -56,7 +56,7 @@ approvals:
 ## SLO targets
 | CUJ/SLI | SLO target | Окно | Исключения | Примечания |
 |---|---:|---|---|---|
-| CUJ-1 / SLI-1 | `>= 99.0%` | 7d rolling | maintenance windows | контроль через alerts + job stats |
+| CUJ-1 / SLI-1 | `>= 99.0%` | 7d rolling | maintenance windows | контроль через alerts + build/codegen job stats |
 | CUJ-2 / SLI-2 | `<= 30m` | per incident | external registry outage (подтвержденный) | контроль через incident timeline |
 
 ## Error Budget
@@ -70,6 +70,7 @@ approvals:
 - Alerts:
   - `AI_SLOT_BUILD_FAILURE_BURST`;
   - `AI_SLOT_BUILD_MANIFEST_UNKNOWN_PERSISTENT`;
+  - `AI_SLOT_CODEGEN_CHECK_BUILD_REF_INVALID`;
   - `AI_SLOT_BUILD_FAILURE_RATE_ELEVATED`;
   - `AI_SLOT_BUILD_MTTR_SLO_RISK`.
 - Runbook link:


### PR DESCRIPTION
## Контекст
- Issue: #205
- Аварийный сценарий: падение сборок в ai-слоте после production-изменений.
- Прямой push в `main` отклонён репозиторными правилами (только PR), поэтому изменения доставляются минимальным markdown-only PR.

## Что сделано
- Добавлен runbook для инцидента `MANIFEST_UNKNOWN`/cache retrieval:
  - `docs/ops/runbook_ai_slot_build_failures.md`
- Добавлены SRE-артефакты наблюдаемости и эксплуатации:
  - `docs/ops/monitoring_ai_slot_build_pipeline.md`
  - `docs/ops/alerts_ai_slot_build_pipeline.md`
  - `docs/ops/rollback_plan_ai_slot_build_pipeline.md`
  - `docs/ops/slo_ai_slot_build_pipeline.md`
- Обновлён production runbook ссылками на новый пакет:
  - `docs/ops/production_runbook.md`

## Эксплуатационные риски
- Технических runtime-изменений нет (только документация).
- Основной риск — несоответствие реальных имен метрик/правил алертов в окружении; отмечено как open question в alerting/monitoring doc.

## Rollback
- Для документации rollback не требуется.
- Процедура отката runtime при повторе инцидента описана в:
  - `docs/ops/rollback_plan_ai_slot_build_pipeline.md`

## Проверки
- Проверено, что изменены только `*.md` файлы.
- Выполнен self-check по `docs/design-guidelines/common/check_list.md` (релевантные пункты для docs-only).

## SLO/SLA влияние
- Зафиксированы SLI/SLO и error-budget policy для build-пайплайна ai-слота.
- SLA внешнего API не изменялся.

