### PR TITLE
fix: support PR branch refs in ai-slot build jobs

### DIFF
--- a/deploy/base/codex-k8s/codegen-check-job.yaml.tpl
+++ b/deploy/base/codex-k8s/codegen-check-job.yaml.tpl
@@ -46,7 +46,11 @@ spec:
 
               git clone "https://x-access-token:${GIT_TOKEN}@github.com/${CODEXK8S_GITHUB_REPO}.git" /workspace
               cd /workspace
-              git checkout --detach "${CODEXK8S_BUILD_REF}"
+              checkout_ref="$CODEXK8S_BUILD_REF"
+              if git rev-parse --verify -q "origin/$CODEXK8S_BUILD_REF^{commit}" >/dev/null 2>&1; then
+                checkout_ref="origin/$CODEXK8S_BUILD_REF"
+              fi
+              git checkout --detach "$checkout_ref"
 
               npm --prefix services/staff/web-console ci
               make gen-openapi

--- a/deploy/base/kaniko/kaniko-build-job.yaml.tpl
+++ b/deploy/base/kaniko/kaniko-build-job.yaml.tpl
@@ -46,7 +46,11 @@ spec:
               # Use shell runtime variables from container env (set above via secret refs).
               git clone "https://x-access-token:$GIT_TOKEN@github.com/$CODEXK8S_GITHUB_REPO.git" /workspace
               cd /workspace
-              git checkout --detach "$CODEXK8S_BUILD_REF"
+              checkout_ref="$CODEXK8S_BUILD_REF"
+              if git rev-parse --verify -q "origin/$CODEXK8S_BUILD_REF^{commit}" >/dev/null 2>&1; then
+                checkout_ref="origin/$CODEXK8S_BUILD_REF"
+              fi
+              git checkout --detach "$checkout_ref"
           volumeMounts:
             - name: workspace
               mountPath: /workspace


### PR DESCRIPTION
## Что исправлено
- В  исправлен checkout build ref: теперь branch ref () предварительно резолвится в , затем выполняется .
- В  применен тот же безопасный паттерн, чтобы не падать на branch ref.

## Почему падало
 на удаленной ветке без локальной может попытаться неявно создать tracking-ветку (), что конфликтует с .

## Ожидаемый эффект
- AI-слоты с привязкой к PR ветке собираются на ветке PR, а не падают в init-контейнере clone.
- Поведение консистентно между repo-sync, kaniko-build и codegen-check.
