### PR TITLE
fix: stabilize ai-slot detached checkout and bump control-plane on template changes

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -83,6 +83,8 @@ spec:
       value: "0.1.49"
       bumpOn:
         - services/internal/control-plane
+        - deploy/base/kaniko
+        - deploy/base/codex-k8s/codegen-check-job.yaml.tpl
         - libs/go
         - proto
     worker:

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_build.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_build.go
@@ -66,6 +66,7 @@ func (s *Service) buildImages(ctx context.Context, repositoryRoot string, params
 		vars["CODEXK8S_BUILD_REF"],
 		vars["CODEXK8S_AGENT_BASE_BRANCH"],
 	)
+	checkoutBuildRef := normalizeRuntimeBuildCheckoutRef(buildRef)
 	vars["CODEXK8S_BUILD_REF"] = buildRef
 
 	runToken := sanitizeNameToken(params.RunID, 12)
@@ -107,7 +108,7 @@ func (s *Service) buildImages(ctx context.Context, repositoryRoot string, params
 		if codegenErr != nil {
 			return fmt.Errorf("read codegen check template %s: %w", codegenTemplatePath, codegenErr)
 		}
-		if err := s.runCodegenCheck(ctx, namespace, repositoryFullName, buildRef, runToken, runID, vars, codegenTemplatePath, codegenTemplateRaw); err != nil {
+		if err := s.runCodegenCheck(ctx, namespace, repositoryFullName, checkoutBuildRef, runToken, runID, vars, codegenTemplatePath, codegenTemplateRaw); err != nil {
 			return err
 		}
 	}
@@ -140,7 +141,7 @@ func (s *Service) buildImages(ctx context.Context, repositoryRoot string, params
 			}
 			defer func() { <-sem }()
 
-			result, runErr := s.runKanikoBuild(ctxBuild, namespace, repositoryFullName, buildRef, runToken, runID, entry, vars, kanikoTemplatePath, kanikoTemplateRaw)
+			result, runErr := s.runKanikoBuild(ctxBuild, namespace, repositoryFullName, checkoutBuildRef, runToken, runID, entry, vars, kanikoTemplatePath, kanikoTemplateRaw)
 			if runErr != nil {
 				errCh <- runErr
 				cancel()

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_helpers.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_helpers.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 )
 
-var runtimeBuildRefAllowedPattern = regexp.MustCompile(`^[A-Za-z0-9._/@+-]+$`)
+var (
+	runtimeBuildRefAllowedPattern = regexp.MustCompile(`^[A-Za-z0-9._/@+-]+$`)
+	gitCommitRefPattern           = regexp.MustCompile(`(?i)^[0-9a-f]{7,64}$`)
+)
 
 func sanitizeNameToken(value string, max int) string {
 	normalized := strings.ToLower(strings.TrimSpace(value))
@@ -69,6 +72,17 @@ func resolveRuntimeBuildRef(candidates ...string) string {
 		}
 	}
 	return "main"
+}
+
+func normalizeRuntimeBuildCheckoutRef(buildRef string) string {
+	resolved := resolveRuntimeBuildRef(buildRef)
+	if strings.HasPrefix(resolved, "refs/") {
+		return resolved
+	}
+	if gitCommitRefPattern.MatchString(resolved) {
+		return resolved
+	}
+	return "origin/" + strings.TrimPrefix(resolved, "origin/")
 }
 
 func normalizeRuntimeBuildRef(raw string) string {

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_helpers_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_helpers_test.go
@@ -46,6 +46,33 @@ func TestResolveRuntimeBuildRef(t *testing.T) {
 	}
 }
 
+func TestNormalizeRuntimeBuildCheckoutRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "main branch", ref: "main", want: "origin/main"},
+		{name: "feature branch", ref: "codex/issue-199", want: "origin/codex/issue-199"},
+		{name: "already origin", ref: "origin/codex/dev", want: "origin/codex/dev"},
+		{name: "commit sha", ref: "748abae3b2c58d512b675858437129a87e14a690", want: "748abae3b2c58d512b675858437129a87e14a690"},
+		{name: "tag ref", ref: "refs/tags/v1.2.3", want: "refs/tags/v1.2.3"},
+		{name: "fallback default", ref: "", want: "origin/main"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeRuntimeBuildCheckoutRef(tt.ref); got != tt.want {
+				t.Fatalf("normalizeRuntimeBuildCheckoutRef(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizePrepareParamsBuildRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Что сделано
- Добавлена нормализация checkout ref для runtime build jobs: в kaniko/codegen теперь передается safe ref для detached checkout.
- Для branch ref используется формат origin/<branch>, для commit SHA и refs/* сохраняется исходный вид.
- Добавлены unit-тесты для новой нормализации build ref.
- В services.yaml расширен bumpOn для control-plane: изменения в deploy/base/kaniko и deploy/base/codex-k8s/codegen-check-job.yaml.tpl теперь автоматически поднимают версию control-plane.

## Почему это нужно
- Рантаймы AI-слотов падали на init-контейнере clone с ошибкой detached checkout для branch ref.
- Фикс только в шаблонах недостаточен, если ран использует старую ветку проекта или если control-plane не пересобрался после template-only изменений.

## Ожидаемый эффект
- Build в AI-слотах с PR/branch ref проходит стабильно.
- Template-only изменения для runtime build pipeline автоматически приводят к обновлению control-plane в production.
