### PR TITLE
fix: общий repo-cache PVC для run-пода и сервисов full-env

### DIFF
--- a/libs/go/k8s/joblauncher/launcher.go
+++ b/libs/go/k8s/joblauncher/launcher.go
@@ -25,6 +25,9 @@ const (
 	runContainerName          = "run"
 	aiRepairKeepaliveName     = "keepalive"
 	aiRepairComponentLabelVal = "ai-repair"
+	runRepoCacheVolumeName    = "repo-cache"
+	runRepoCacheClaimName     = "codex-k8s-repo-cache"
+	runRepoCacheMountPath     = "/workspace"
 )
 
 // JobState is a current Kubernetes Job execution state.
@@ -293,10 +296,16 @@ func (l *Launcher) Launch(ctx context.Context, spec JobSpec) (JobRef, error) {
 	}
 
 	container := buildRunContainer(spec, jobImage, l.cfg.Command)
+	if shouldMountRepoCache(spec) {
+		container = withRepoCacheVolumeMount(container)
+	}
 
 	podSpec := corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyNever,
 		Containers:    []corev1.Container{container},
+	}
+	if shouldMountRepoCache(spec) {
+		podSpec.Volumes = append(podSpec.Volumes, repoCacheVolume())
 	}
 
 	serviceAccountName := strings.TrimSpace(spec.ServiceAccountName)
@@ -355,10 +364,17 @@ func (l *Launcher) launchAIRepairPod(ctx context.Context, ref JobRef, spec JobSp
 		Image:   jobImage,
 		Command: []string{"/bin/sh", "-c", "trap : TERM INT; while true; do sleep 3600; done"},
 	}
+	if shouldMountRepoCache(spec) {
+		runContainer = withRepoCacheVolumeMount(runContainer)
+		keepaliveContainer = withRepoCacheVolumeMount(keepaliveContainer)
+	}
 
 	podSpec := corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyNever,
 		Containers:    []corev1.Container{runContainer, keepaliveContainer},
+	}
+	if shouldMountRepoCache(spec) {
+		podSpec.Volumes = append(podSpec.Volumes, repoCacheVolume())
 	}
 	serviceAccountName := strings.TrimSpace(spec.ServiceAccountName)
 	if serviceAccountName != "" {
@@ -432,6 +448,32 @@ func buildRunContainerEnv(spec JobSpec) []corev1.EnvVar {
 		{Name: "CODEXK8S_GIT_BOT_TOKEN", Value: strings.TrimSpace(spec.GitBotToken)},
 		{Name: "CODEXK8S_GIT_BOT_USERNAME", Value: strings.TrimSpace(spec.GitBotUsername)},
 		{Name: "CODEXK8S_GIT_BOT_MAIL", Value: strings.TrimSpace(spec.GitBotMail)},
+	}
+}
+
+func shouldMountRepoCache(spec JobSpec) bool {
+	if isAIRepairTriggerKind(spec.TriggerKind) {
+		return true
+	}
+	return spec.RuntimeMode == agentdomain.RuntimeModeFullEnv
+}
+
+func withRepoCacheVolumeMount(container corev1.Container) corev1.Container {
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      runRepoCacheVolumeName,
+		MountPath: runRepoCacheMountPath,
+	})
+	return container
+}
+
+func repoCacheVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: runRepoCacheVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: runRepoCacheClaimName,
+			},
+		},
 	}
 }
 

--- a/libs/go/k8s/joblauncher/launcher_status_test.go
+++ b/libs/go/k8s/joblauncher/launcher_status_test.go
@@ -128,6 +128,81 @@ func TestLauncher_Launch_AIRepairCreatesPod(t *testing.T) {
 	if got, want := len(pod.Spec.Containers), 2; got != want {
 		t.Fatalf("expected %d containers, got %d", want, got)
 	}
+	if got, want := len(pod.Spec.Volumes), 1; got != want {
+		t.Fatalf("expected %d volume, got %d", want, got)
+	}
+	if got, want := pod.Spec.Volumes[0].Name, runRepoCacheVolumeName; got != want {
+		t.Fatalf("expected volume name %q, got %q", want, got)
+	}
+	if pod.Spec.Volumes[0].PersistentVolumeClaim == nil {
+		t.Fatalf("expected pvc volume for %q", runRepoCacheVolumeName)
+	}
+	if got, want := pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName, runRepoCacheClaimName; got != want {
+		t.Fatalf("expected pvc claim %q, got %q", want, got)
+	}
+	for _, container := range pod.Spec.Containers {
+		if len(container.VolumeMounts) != 1 {
+			t.Fatalf("expected one volume mount in container %q, got %d", container.Name, len(container.VolumeMounts))
+		}
+		if got, want := container.VolumeMounts[0].Name, runRepoCacheVolumeName; got != want {
+			t.Fatalf("expected mount volume name %q in container %q, got %q", want, container.Name, got)
+		}
+		if got, want := container.VolumeMounts[0].MountPath, runRepoCacheMountPath; got != want {
+			t.Fatalf("expected mount path %q in container %q, got %q", want, container.Name, got)
+		}
+	}
+}
+
+func TestLauncher_Launch_FullEnvMountsRepoCachePVC(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := fake.NewClientset()
+	l := NewForClient(Config{Namespace: "ns", Image: "busybox:1.36"}, client)
+
+	spec := JobSpec{
+		RunID:         "run-full-env",
+		CorrelationID: "corr-full-env",
+		ProjectID:     "project-1",
+		Namespace:     "codex-k8s-dev-1",
+		RuntimeMode:   "full-env",
+	}
+
+	ref, err := l.Launch(ctx, spec)
+	if err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+
+	job, err := client.BatchV1().Jobs(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected job %s/%s, got error: %v", ref.Namespace, ref.Name, err)
+	}
+
+	podSpec := job.Spec.Template.Spec
+	if got, want := len(podSpec.Volumes), 1; got != want {
+		t.Fatalf("expected %d volume, got %d", want, got)
+	}
+	if got, want := podSpec.Volumes[0].Name, runRepoCacheVolumeName; got != want {
+		t.Fatalf("expected volume name %q, got %q", want, got)
+	}
+	if podSpec.Volumes[0].PersistentVolumeClaim == nil {
+		t.Fatalf("expected pvc volume for %q", runRepoCacheVolumeName)
+	}
+	if got, want := podSpec.Volumes[0].PersistentVolumeClaim.ClaimName, runRepoCacheClaimName; got != want {
+		t.Fatalf("expected pvc claim %q, got %q", want, got)
+	}
+	if got, want := len(podSpec.Containers), 1; got != want {
+		t.Fatalf("expected %d container, got %d", want, got)
+	}
+	if got, want := len(podSpec.Containers[0].VolumeMounts), 1; got != want {
+		t.Fatalf("expected %d mount in run container, got %d", want, got)
+	}
+	if got, want := podSpec.Containers[0].VolumeMounts[0].Name, runRepoCacheVolumeName; got != want {
+		t.Fatalf("expected mount volume name %q, got %q", want, got)
+	}
+	if got, want := podSpec.Containers[0].VolumeMounts[0].MountPath, runRepoCacheMountPath; got != want {
+		t.Fatalf("expected mount path %q, got %q", want, got)
+	}
 }
 
 func TestLauncher_Status_AIRepairPodRunContainerSucceeded(t *testing.T) {

--- a/services/jobs/agent-runner/internal/runner/service.go
+++ b/services/jobs/agent-runner/internal/runner/service.go
@@ -25,13 +25,19 @@ func (s *Service) Run(ctx context.Context) (err error) {
 	if codexHomeDir == "" {
 		codexHomeDir = filepath.Join(homeDir, ".codex")
 	}
+	runtimeMode := normalizeRuntimeMode(s.cfg.RuntimeMode)
+
+	repoDir := filepath.Join("/workspace", "repo")
+	if runtimeMode == runtimeModeFullEnv {
+		repoDir = "/workspace"
+	}
 
 	state := codexState{
 		homeDir:      homeDir,
 		codexDir:     codexHomeDir,
 		sessionsDir:  filepath.Join(codexHomeDir, "sessions"),
 		workspaceDir: "/workspace",
-		repoDir:      filepath.Join("/workspace", "repo"),
+		repoDir:      repoDir,
 	}
 
 	if mkErr := os.MkdirAll(state.sessionsDir, 0o755); mkErr != nil {
@@ -40,10 +46,14 @@ func (s *Service) Run(ctx context.Context) (err error) {
 	if mkErr := os.MkdirAll(state.workspaceDir, 0o755); mkErr != nil {
 		return fmt.Errorf("create workspace dir: %w", mkErr)
 	}
+	gitAuthDir := filepath.Join(os.TempDir(), "codex-k8s-agent-runner-auth")
+	if mkErr := os.MkdirAll(gitAuthDir, 0o755); mkErr != nil {
+		return fmt.Errorf("create git auth dir: %w", mkErr)
+	}
 	if mkErr := os.MkdirAll(selfImproveSessionsDir, 0o755); mkErr != nil {
 		return fmt.Errorf("create self-improve sessions dir: %w", mkErr)
 	}
-	cleanupGitAuthEnv, err := s.configureGitAuthEnvironment(state.workspaceDir)
+	cleanupGitAuthEnv, err := s.configureGitAuthEnvironment(gitAuthDir)
 	if err != nil {
 		return fmt.Errorf("configure git auth environment: %w", err)
 	}
@@ -57,7 +67,6 @@ func (s *Service) Run(ctx context.Context) (err error) {
 	targetBranch := buildTargetBranch(s.cfg.RunTargetBranch, s.cfg.RunID, s.cfg.IssueNumber, s.cfg.TriggerKind, s.cfg.AgentBaseBranch)
 	triggerKind := normalizeTriggerKind(s.cfg.TriggerKind)
 	templateKind := normalizeTemplateKind(s.cfg.PromptTemplateKind, triggerKind)
-	runtimeMode := normalizeRuntimeMode(s.cfg.RuntimeMode)
 	sensitiveValues := s.sensitiveValues()
 
 	runStartedAt := time.Now().UTC()
@@ -348,33 +357,92 @@ func (s *Service) restoreLatestSession(ctx context.Context, branch string, sessi
 }
 
 func (s *Service) prepareRepository(ctx context.Context, result runResult, state codexState) error {
-	if err := os.RemoveAll(state.repoDir); err != nil {
-		return fmt.Errorf("cleanup repo dir: %w", err)
-	}
-
 	repoURL := fmt.Sprintf("https://github.com/%s.git", s.cfg.RepositoryFullName)
-	if err := runCommandQuiet(ctx, "", "git", "clone", repoURL, state.repoDir); err != nil {
-		return fmt.Errorf("git clone failed")
+	if err := ensureRepoDirCheckout(ctx, state.repoDir, repoURL); err != nil {
+		return err
 	}
 
 	_ = runCommandQuiet(ctx, state.repoDir, "git", "config", "user.name", s.cfg.AgentDisplayName)
 	_ = runCommandQuiet(ctx, state.repoDir, "git", "config", "user.email", s.cfg.GitBotMail)
-	_ = runCommandQuiet(ctx, state.repoDir, "git", "fetch", "origin", s.cfg.AgentBaseBranch, "--depth=50")
+	if err := runCommandQuiet(ctx, state.repoDir, "git", "fetch", "--prune", "--tags", "origin"); err != nil {
+		return fmt.Errorf("git fetch failed")
+	}
 
 	branchExists := runCommandQuiet(ctx, state.repoDir, "git", "ls-remote", "--exit-code", "--heads", "origin", result.targetBranch) == nil
 	if branchExists {
 		if err := runCommandQuiet(ctx, state.repoDir, "git", "checkout", "-B", result.targetBranch, "origin/"+result.targetBranch); err != nil {
 			return fmt.Errorf("checkout existing branch failed")
 		}
+	} else {
+		if webhookdomain.IsReviseTriggerKind(webhookdomain.NormalizeTriggerKind(result.triggerKind)) {
+			return s.failRevisePRNotFound(ctx, result, state, "branch_not_found")
+		}
+		if err := runCommandQuiet(ctx, state.repoDir, "git", "checkout", "-B", result.targetBranch, "origin/"+s.cfg.AgentBaseBranch); err != nil {
+			return fmt.Errorf("checkout base branch failed")
+		}
+	}
+
+	if err := runCommandQuiet(ctx, state.repoDir, "git", "reset", "--hard"); err != nil {
+		return fmt.Errorf("git reset failed")
+	}
+	if err := runCommandQuiet(ctx, state.repoDir, "git", "clean", "-fdx"); err != nil {
+		return fmt.Errorf("git clean failed")
+	}
+
+	return nil
+}
+
+func ensureRepoDirCheckout(ctx context.Context, repoDir string, repoURL string) error {
+	repoDir = strings.TrimSpace(repoDir)
+	repoURL = strings.TrimSpace(repoURL)
+	if repoDir == "" {
+		return fmt.Errorf("repo dir is required")
+	}
+	if repoURL == "" {
+		return fmt.Errorf("repo url is required")
+	}
+
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		return fmt.Errorf("create repo dir: %w", err)
+	}
+
+	if runCommandQuiet(ctx, repoDir, "git", "rev-parse", "--is-inside-work-tree") != nil {
+		if err := cleanupDirectoryContents(repoDir); err != nil {
+			return fmt.Errorf("cleanup repo dir contents: %w", err)
+		}
+		if err := runCommandQuiet(ctx, repoDir, "git", "init"); err != nil {
+			return fmt.Errorf("git init failed")
+		}
+		if err := runCommandQuiet(ctx, repoDir, "git", "remote", "add", "origin", repoURL); err != nil {
+			return fmt.Errorf("configure git origin failed")
+		}
 		return nil
 	}
 
-	if webhookdomain.IsReviseTriggerKind(webhookdomain.NormalizeTriggerKind(result.triggerKind)) {
-		return s.failRevisePRNotFound(ctx, result, state, "branch_not_found")
+	if err := runCommandQuiet(ctx, repoDir, "git", "remote", "set-url", "origin", repoURL); err == nil {
+		return nil
 	}
+	if err := runCommandQuiet(ctx, repoDir, "git", "remote", "add", "origin", repoURL); err == nil {
+		return nil
+	}
+	if err := runCommandQuiet(ctx, repoDir, "git", "remote", "remove", "origin"); err != nil {
+		return fmt.Errorf("remove stale git origin failed")
+	}
+	if err := runCommandQuiet(ctx, repoDir, "git", "remote", "add", "origin", repoURL); err != nil {
+		return fmt.Errorf("reconfigure git origin failed")
+	}
+	return nil
+}
 
-	if err := runCommandQuiet(ctx, state.repoDir, "git", "checkout", "-B", result.targetBranch, "origin/"+s.cfg.AgentBaseBranch); err != nil {
-		return fmt.Errorf("checkout base branch failed")
+func cleanupDirectoryContents(path string) error {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(path, entry.Name())); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Что сделано
- В `libs/go/k8s/joblauncher/launcher.go` добавлено монтирование `repo-cache` PVC (`codex-k8s-repo-cache`) в run workload:
  - для `full-env` run job;
  - для `ai-repair` pod (оба контейнера: `run` и `keepalive`).
- Mount path унифицирован с сервисами слота: `/workspace`.
- В `services/jobs/agent-runner/internal/runner/service.go` изменён путь репозитория для `full-env`:
  - теперь runner работает прямо в `/workspace` (общий PVC), а не в `/workspace/repo`.
- Логика `prepareRepository` переработана под persistent workspace:
  - безопасная инициализация/переиспользование git-репозитория в целевой директории;
  - перенастройка origin;
  - fetch + checkout нужной ветки;
  - reset/clean для детерминированного состояния.
- Скрипт `GIT_ASKPASS` вынесен во временный каталог (`/tmp`), чтобы очистка workspace не затрагивала auth-окружение.

## Почему это фикс
Ранее сервисы full-env читали код из PVC (`/workspace`), а run-под агента запускался без этого PVC и работал с отдельной файловой системой (`/workspace/repo` внутри контейнера). Из-за этого правки агента не попадали в hot-reload сервисов слота. Теперь run-под и сервисы используют один и тот же PVC и один путь рабочего дерева.

## Проверки
- `go test ./libs/go/k8s/joblauncher`
- `go test ./services/jobs/agent-runner/internal/runner`
- `go test ./services/jobs/worker/internal/...`

Дополнительно запускались:
- `make lint-go` — падает на уже существующих проблемах вне текущего diff:
  - `services/external/api-gateway/internal/transport/http/staff_realtime_handler.go` (`errcheck`)
  - `libs/go/servicescfg/load_validation.go` (`staticcheck`)
- `make dupl-go` — показывает уже существующий дубль между:
  - `libs/go/k8s/joblauncher/launcher.go`
  - `services/internal/control-plane/internal/clients/kubernetes/client.go`
