### PR TITLE
fix: ускорить runtime deploy и переиспользовать образы между prod/ai

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -241,31 +241,31 @@ spec:
     api-gateway:
       type: build
       repository: '{{ envOr "CODEXK8S_INTERNAL_REGISTRY_HOST" "127.0.0.1:5000" }}/{{ envOr "CODEXK8S_API_GATEWAY_INTERNAL_IMAGE_REPOSITORY" "codex-k8s/api-gateway" }}'
-      tagTemplate: '{{ .Env }}-{{ index .Versions "api-gateway" }}'
+      tagTemplate: '{{ index .Versions "api-gateway" }}'
       dockerfile: services/external/api-gateway/Dockerfile
       context: .
     control-plane:
       type: build
       repository: '{{ envOr "CODEXK8S_INTERNAL_REGISTRY_HOST" "127.0.0.1:5000" }}/{{ envOr "CODEXK8S_CONTROL_PLANE_INTERNAL_IMAGE_REPOSITORY" "codex-k8s/control-plane" }}'
-      tagTemplate: '{{ .Env }}-{{ index .Versions "control-plane" }}'
+      tagTemplate: '{{ index .Versions "control-plane" }}'
       dockerfile: services/internal/control-plane/Dockerfile
       context: .
     worker:
       type: build
       repository: '{{ envOr "CODEXK8S_INTERNAL_REGISTRY_HOST" "127.0.0.1:5000" }}/{{ envOr "CODEXK8S_WORKER_INTERNAL_IMAGE_REPOSITORY" "codex-k8s/worker" }}'
-      tagTemplate: '{{ .Env }}-{{ index .Versions "worker" }}'
+      tagTemplate: '{{ index .Versions "worker" }}'
       dockerfile: services/jobs/worker/Dockerfile
       context: .
     agent-runner:
       type: build
       repository: '{{ envOr "CODEXK8S_INTERNAL_REGISTRY_HOST" "127.0.0.1:5000" }}/{{ envOr "CODEXK8S_AGENT_RUNNER_INTERNAL_IMAGE_REPOSITORY" "codex-k8s/agent-runner" }}'
-      tagTemplate: '{{ .Env }}-{{ index .Versions "agent-runner" }}'
+      tagTemplate: '{{ index .Versions "agent-runner" }}'
       dockerfile: services/jobs/agent-runner/Dockerfile
       context: .
     web-console:
       type: '{{ ternary (eq .Env "ai") "build" "skip" }}'
       repository: '{{ envOr "CODEXK8S_INTERNAL_REGISTRY_HOST" "127.0.0.1:5000" }}/{{ envOr "CODEXK8S_WEB_CONSOLE_INTERNAL_IMAGE_REPOSITORY" "codex-k8s/web-console" }}'
-      tagTemplate: '{{ .Env }}-{{ index .Versions "web-console" }}'
+      tagTemplate: '{{ index .Versions "web-console" }}'
       dockerfile: services/staff/web-console/Dockerfile
       context: services/staff/web-console
   orchestration:

--- a/services/internal/control-plane/internal/clients/githubmgmt/repo_files.go
+++ b/services/internal/control-plane/internal/clients/githubmgmt/repo_files.go
@@ -129,6 +129,72 @@ func (c *Client) ListChangedFilesBetweenCommits(ctx context.Context, token strin
 	return changed, nil
 }
 
+func (c *Client) ResolveRefToCommitSHA(ctx context.Context, token string, owner string, repo string, ref string) (string, error) {
+	client := c.clientWithToken(token)
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	ref = strings.TrimSpace(ref)
+	if owner == "" || repo == "" {
+		return "", fmt.Errorf("owner and repository are required")
+	}
+	if ref == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+
+	normalizedRef := strings.TrimPrefix(strings.TrimPrefix(ref, "refs/heads/"), "origin/")
+	normalizedRef = strings.TrimSpace(normalizedRef)
+	if normalizedRef == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+
+	if len(normalizedRef) >= 7 && len(normalizedRef) <= 64 {
+		isHex := true
+		for _, ch := range strings.ToLower(normalizedRef) {
+			if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') {
+				continue
+			}
+			isHex = false
+			break
+		}
+		if isHex {
+			return normalizedRef, nil
+		}
+	}
+
+	resolved := ""
+	tryResolve := func(refPath string) error {
+		result, _, err := client.Git.GetRef(ctx, owner, repo, refPath)
+		if err != nil {
+			return err
+		}
+		sha := strings.TrimSpace(result.GetObject().GetSHA())
+		if sha == "" {
+			return fmt.Errorf("github ref %s has empty sha", refPath)
+		}
+		resolved = sha
+		return nil
+	}
+
+	for _, candidate := range []string{
+		"refs/heads/" + normalizedRef,
+		normalizedRef,
+	} {
+		if err := tryResolve(candidate); err == nil {
+			return resolved, nil
+		}
+	}
+
+	branch, _, err := client.Repositories.GetBranch(ctx, owner, repo, normalizedRef, 0)
+	if err != nil {
+		return "", fmt.Errorf("github resolve ref %s in %s/%s: %w", normalizedRef, owner, repo, err)
+	}
+	sha := strings.TrimSpace(branch.GetCommit().GetSHA())
+	if sha == "" {
+		return "", fmt.Errorf("github branch %s has empty commit sha", normalizedRef)
+	}
+	return sha, nil
+}
+
 var errGitHubContentNeedsDownload = errors.New("github content needs download")
 
 func decodeRepositoryContent(content *gh.RepositoryContent) (string, error) {

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_build.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_build.go
@@ -48,6 +48,18 @@ func (s *Service) buildImages(ctx context.Context, repositoryRoot string, params
 	}
 	sort.Slice(buildEntries, func(i, j int) bool { return buildEntries[i].Name < buildEntries[j].Name })
 
+	prebuilt, allPrebuilt, err := s.resolveReusableBuildImages(ctx, buildEntries, vars, runID)
+	if err != nil {
+		return err
+	}
+	if allPrebuilt {
+		for _, result := range prebuilt {
+			applyBuiltImageResult(vars, result.Name, result.ImageRef)
+		}
+		s.appendTaskLogBestEffort(ctx, runID, "build", "info", "All build images already exist in registry, skipping mirror/codegen/kaniko stages")
+		return nil
+	}
+
 	githubPAT := strings.TrimSpace(s.cfg.GitHubPAT)
 	if githubPAT == "" {
 		githubPAT = strings.TrimSpace(vars["CODEXK8S_GITHUB_PAT"])
@@ -637,4 +649,40 @@ func trimLogForError(logs string) string {
 		return trimmed[:500] + "..."
 	}
 	return trimmed
+}
+
+func (s *Service) resolveReusableBuildImages(ctx context.Context, buildEntries []buildImageEntry, vars map[string]string, runID string) ([]buildImageResult, bool, error) {
+	if len(buildEntries) == 0 {
+		return nil, true, nil
+	}
+	if s.registry == nil {
+		return nil, false, nil
+	}
+
+	results := make([]buildImageResult, 0, len(buildEntries))
+	for _, entry := range buildEntries {
+		repository := strings.TrimSpace(entry.Image.Repository)
+		if repository == "" {
+			return nil, false, fmt.Errorf("image %q repository is required for build type", entry.Name)
+		}
+		tag := sanitizeImageTag(strings.TrimSpace(entry.Image.TagTemplate))
+		if tag == "" {
+			tag = "latest"
+		}
+
+		shouldSkip, err := s.shouldSkipKanikoBuild(ctx, repository, tag, vars, runID, entry.Name)
+		if err != nil {
+			return nil, false, err
+		}
+		if !shouldSkip {
+			return nil, false, nil
+		}
+
+		results = append(results, buildImageResult{
+			Name:       entry.Name,
+			ImageRef:   repository + ":" + tag,
+			Repository: repository,
+		})
+	}
+	return results, len(results) == len(buildEntries), nil
 }

--- a/services/internal/control-plane/internal/domain/webhook/model.go
+++ b/services/internal/control-plane/internal/domain/webhook/model.go
@@ -176,6 +176,7 @@ type githubPullRequestRecord struct {
 
 type githubPullRequestHead struct {
 	Ref string `json:"ref"`
+	SHA string `json:"sha"`
 }
 
 type githubPullRequestBase struct {

--- a/services/internal/control-plane/internal/domain/webhook/payload_casters.go
+++ b/services/internal/control-plane/internal/domain/webhook/payload_casters.go
@@ -140,6 +140,7 @@ func buildRunPayload(input runPayloadInput) (json.RawMessage, error) {
 			State:   input.Envelope.PullRequest.State,
 			Head: githubRunPRRef{
 				Ref: input.Envelope.PullRequest.Head.Ref,
+				SHA: input.Envelope.PullRequest.Head.SHA,
 			},
 			Base: githubRunPRRef{
 				Ref: input.Envelope.PullRequest.Base.Ref,

--- a/services/internal/control-plane/internal/domain/webhook/payload_models.go
+++ b/services/internal/control-plane/internal/domain/webhook/payload_models.go
@@ -85,6 +85,7 @@ type githubRunPRPayload struct {
 
 type githubRunPRRef struct {
 	Ref string `json:"ref"`
+	SHA string `json:"sha,omitempty"`
 }
 
 type githubIssueTriggerPayload struct {

--- a/services/internal/control-plane/internal/domain/webhook/runtime_build_ref_resolver.go
+++ b/services/internal/control-plane/internal/domain/webhook/runtime_build_ref_resolver.go
@@ -19,6 +19,7 @@ type normalizedRunPayloadPullRequest struct {
 
 type normalizedRunPayloadPullRequestRef struct {
 	Ref string `json:"ref"`
+	SHA string `json:"sha"`
 }
 
 type rawRunPayloadBuildRef struct {
@@ -30,39 +31,37 @@ func (s *Service) resolveRuntimeBuildRefForIssueTrigger(ctx context.Context, pro
 	if !strings.EqualFold(strings.TrimSpace(string(runtimeMode)), string(agentdomain.RuntimeModeFullEnv)) {
 		return resolved
 	}
-	if s.agentRuns == nil {
-		return resolved
-	}
 
 	normalizedProjectID := strings.TrimSpace(projectID)
 	repositoryFullName := strings.TrimSpace(envelope.Repository.FullName)
 	issueNumber := envelope.Issue.Number
-	if normalizedProjectID == "" || repositoryFullName == "" || issueNumber <= 0 {
-		return resolved
-	}
-
-	items, err := s.agentRuns.SearchRecentByProjectIssueOrPullRequest(ctx, normalizedProjectID, repositoryFullName, issueNumber, 0, 50)
-	if err != nil {
-		return resolved
-	}
-	for _, item := range items {
-		runID := strings.TrimSpace(item.RunID)
-		if runID == "" {
-			continue
-		}
-		runItem, found, runErr := s.agentRuns.GetByID(ctx, runID)
-		if runErr != nil || !found {
-			continue
-		}
-		if ref := extractPullRequestHeadRefFromNormalizedRunPayload(runItem.RunPayload); ref != "" {
-			return ref
+	if s.agentRuns != nil && normalizedProjectID != "" && repositoryFullName != "" && issueNumber > 0 {
+		items, err := s.agentRuns.SearchRecentByProjectIssueOrPullRequest(ctx, normalizedProjectID, repositoryFullName, issueNumber, 0, 50)
+		if err == nil {
+			for _, item := range items {
+				runID := strings.TrimSpace(item.RunID)
+				if runID == "" {
+					continue
+				}
+				runItem, found, runErr := s.agentRuns.GetByID(ctx, runID)
+				if runErr != nil || !found {
+					continue
+				}
+				if ref := extractPullRequestHeadBuildRefFromNormalizedRunPayload(runItem.RunPayload); ref != "" {
+					return ref
+				}
+			}
 		}
 	}
-
+	if ref := strings.TrimSpace(resolved); ref != "" {
+		if resolvedSHA := s.resolveRepositoryRefToSHA(ctx, repositoryFullName, ref); resolvedSHA != "" {
+			return resolvedSHA
+		}
+	}
 	return resolved
 }
 
-func extractPullRequestHeadRefFromNormalizedRunPayload(runPayload json.RawMessage) string {
+func extractPullRequestHeadBuildRefFromNormalizedRunPayload(runPayload json.RawMessage) string {
 	if len(runPayload) == 0 {
 		return ""
 	}
@@ -73,6 +72,9 @@ func extractPullRequestHeadRefFromNormalizedRunPayload(runPayload json.RawMessag
 	}
 
 	if normalized.PullRequest != nil {
+		if sha := strings.TrimSpace(normalized.PullRequest.Head.SHA); sha != "" {
+			return sha
+		}
 		if ref := strings.TrimSpace(normalized.PullRequest.Head.Ref); ref != "" {
 			return ref
 		}
@@ -89,5 +91,35 @@ func extractPullRequestHeadRefFromNormalizedRunPayload(runPayload json.RawMessag
 	if raw.PullRequest == nil {
 		return ""
 	}
+	if sha := strings.TrimSpace(raw.PullRequest.Head.SHA); sha != "" {
+		return sha
+	}
 	return strings.TrimSpace(raw.PullRequest.Head.Ref)
+}
+
+func (s *Service) resolveRepositoryRefToSHA(ctx context.Context, repositoryFullName string, ref string) string {
+	repositoryFullName = strings.TrimSpace(repositoryFullName)
+	ref = strings.TrimSpace(ref)
+	if repositoryFullName == "" || ref == "" {
+		return ""
+	}
+	if s.githubMgmt == nil || strings.TrimSpace(s.githubToken) == "" {
+		return ""
+	}
+
+	owner, repo, ok := strings.Cut(repositoryFullName, "/")
+	if !ok {
+		return ""
+	}
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	if owner == "" || repo == "" {
+		return ""
+	}
+
+	sha, err := s.githubMgmt.ResolveRefToCommitSHA(ctx, strings.TrimSpace(s.githubToken), owner, repo, ref)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(sha)
 }

--- a/services/internal/control-plane/internal/domain/webhook/runtime_build_ref_resolver_test.go
+++ b/services/internal/control-plane/internal/domain/webhook/runtime_build_ref_resolver_test.go
@@ -9,21 +9,30 @@ import (
 	agentrunrepo "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/repository/agentrun"
 )
 
-func TestExtractPullRequestHeadRefFromNormalizedRunPayload(t *testing.T) {
+func TestExtractPullRequestHeadBuildRefFromNormalizedRunPayload(t *testing.T) {
 	t.Parallel()
 
 	payload := json.RawMessage(`{"pull_request":{"head":{"ref":"feature/from-normalized"}}}`)
-	if got, want := extractPullRequestHeadRefFromNormalizedRunPayload(payload), "feature/from-normalized"; got != want {
-		t.Fatalf("extractPullRequestHeadRefFromNormalizedRunPayload() = %q, want %q", got, want)
+	if got, want := extractPullRequestHeadBuildRefFromNormalizedRunPayload(payload), "feature/from-normalized"; got != want {
+		t.Fatalf("extractPullRequestHeadBuildRefFromNormalizedRunPayload() = %q, want %q", got, want)
 	}
 }
 
-func TestExtractPullRequestHeadRefFromNormalizedRunPayload_FallbackToRawPayload(t *testing.T) {
+func TestExtractPullRequestHeadBuildRefFromNormalizedRunPayload_PrefersSHA(t *testing.T) {
+	t.Parallel()
+
+	payload := json.RawMessage(`{"pull_request":{"head":{"ref":"feature/from-normalized","sha":"0123456789abcdef0123456789abcdef01234567"}}}`)
+	if got, want := extractPullRequestHeadBuildRefFromNormalizedRunPayload(payload), "0123456789abcdef0123456789abcdef01234567"; got != want {
+		t.Fatalf("extractPullRequestHeadBuildRefFromNormalizedRunPayload() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractPullRequestHeadBuildRefFromNormalizedRunPayload_FallbackToRawPayload(t *testing.T) {
 	t.Parallel()
 
 	payload := json.RawMessage(`{"raw_payload":{"pull_request":{"head":{"ref":"feature/from-raw"}}}}`)
-	if got, want := extractPullRequestHeadRefFromNormalizedRunPayload(payload), "feature/from-raw"; got != want {
-		t.Fatalf("extractPullRequestHeadRefFromNormalizedRunPayload() = %q, want %q", got, want)
+	if got, want := extractPullRequestHeadBuildRefFromNormalizedRunPayload(payload), "feature/from-raw"; got != want {
+		t.Fatalf("extractPullRequestHeadBuildRefFromNormalizedRunPayload() = %q, want %q", got, want)
 	}
 }
 
@@ -69,6 +78,29 @@ func TestResolveRuntimeBuildRefForIssueTrigger_CodeOnlyKeepsDefault(t *testing.T
 	}
 	got, want := svc.resolveRuntimeBuildRefForIssueTrigger(context.Background(), "project-1", envelope, "main", agentdomain.RuntimeModeCodeOnly), "main"
 	if got != want {
+		t.Fatalf("resolveRuntimeBuildRefForIssueTrigger() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRuntimeBuildRefForIssueTrigger_ResolvesDefaultRefToSHA(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		githubToken: "token",
+		githubMgmt: &inMemoryPushMainVersionBumpClient{
+			refToSHA: map[string]string{
+				"codex-k8s/codex-k8s@main": "89abcdef0123456789abcdef0123456789abcdef",
+			},
+		},
+	}
+
+	envelope := githubWebhookEnvelope{
+		Repository: githubRepositoryRecord{FullName: "codex-k8s/codex-k8s"},
+		Issue:      githubIssueRecord{Number: 240},
+	}
+
+	got := svc.resolveRuntimeBuildRefForIssueTrigger(context.Background(), "project-1", envelope, "main", agentdomain.RuntimeModeFullEnv)
+	if want := "89abcdef0123456789abcdef0123456789abcdef"; got != want {
 		t.Fatalf("resolveRuntimeBuildRefForIssueTrigger() = %q, want %q", got, want)
 	}
 }

--- a/services/internal/control-plane/internal/domain/webhook/service.go
+++ b/services/internal/control-plane/internal/domain/webhook/service.go
@@ -65,6 +65,7 @@ type pushMainVersionBumpClient interface {
 	GetFile(ctx context.Context, token string, owner string, repo string, filePath string, ref string) ([]byte, bool, error)
 	ListChangedFilesBetweenCommits(ctx context.Context, token string, owner string, repo string, beforeSHA string, afterSHA string) ([]string, error)
 	CommitFilesOnBranch(ctx context.Context, token string, owner string, repo string, branch string, baseSHA string, message string, files map[string][]byte) (string, error)
+	ResolveRefToCommitSHA(ctx context.Context, token string, owner string, repo string, ref string) (string, error)
 }
 
 // Service ingests provider webhooks into idempotent run and flow-event records.
@@ -304,8 +305,10 @@ func (s *Service) IngestGitHubWebhook(ctx context.Context, cmd IngestCommand) (I
 		}
 		triggerSource := strings.TrimSpace(trigger.Source)
 		if strings.EqualFold(triggerSource, webhookdomain.TriggerSourcePullRequestReview) || strings.EqualFold(triggerSource, triggerSourcePullRequestLabel) {
-			prHeadRef := strings.TrimSpace(envelope.PullRequest.Head.Ref)
-			if prHeadRef != "" {
+			prHeadSHA := strings.TrimSpace(envelope.PullRequest.Head.SHA)
+			if prHeadSHA != "" {
+				runtimeBuildRef = prHeadSHA
+			} else if prHeadRef := strings.TrimSpace(envelope.PullRequest.Head.Ref); prHeadRef != "" {
 				runtimeBuildRef = prHeadRef
 			}
 		} else if strings.EqualFold(triggerSource, webhookdomain.TriggerSourceIssueLabel) {

--- a/services/internal/control-plane/internal/domain/webhook/service_test.go
+++ b/services/internal/control-plane/internal/domain/webhook/service_test.go
@@ -2700,6 +2700,7 @@ func (r *inMemoryProjectMemberRepo) GetLearningModeOverride(_ context.Context, _
 
 type inMemoryPushMainVersionBumpClient struct {
 	filesByRef map[string][]byte
+	refToSHA   map[string]string
 
 	changedPaths []string
 	changedErr   error
@@ -2759,4 +2760,15 @@ func (c *inMemoryPushMainVersionBumpClient) CommitFilesOnBranch(_ context.Contex
 		c.lastCommitFiles[path] = append([]byte(nil), raw...)
 	}
 	return "bumped-sha", nil
+}
+
+func (c *inMemoryPushMainVersionBumpClient) ResolveRefToCommitSHA(_ context.Context, _ string, owner string, repo string, ref string) (string, error) {
+	if c == nil || c.refToSHA == nil {
+		return strings.TrimSpace(ref), nil
+	}
+	key := strings.TrimSpace(owner) + "/" + strings.TrimSpace(repo) + "@" + strings.TrimSpace(ref)
+	if value, ok := c.refToSHA[key]; ok {
+		return strings.TrimSpace(value), nil
+	}
+	return strings.TrimSpace(ref), nil
 }


### PR DESCRIPTION
## Контекст
Issue: https://github.com/codex-k8s/codex-k8s/issues/240

Цель: убрать лишние пересборки после merge в `main`, ускорить старт AI-задач и не гонять mirror/codegen/kaniko, когда все нужные теги уже есть в внутреннем registry.

## Что сделано

### 1) Общие теги образов для prod и ai
В `services.yaml` убран env-префикс из `tagTemplate` для build-образов:
- `api-gateway`
- `control-plane`
- `worker`
- `agent-runner`
- `web-console`

Было: `{{ .Env }}-{{ version }}`
Стало: `{{ version }}`

Это убирает ситуацию, когда после prod-сборки сразу идет такая же ai-сборка только из-за другого тега.

### 2) Fast-path: если все build-образы уже есть, полностью пропускаем heavy stage
В `runtimedeploy/service_build.go` добавлен precheck `resolveReusableBuildImages`:
- проверяем наличие всех target-тегов build-образов в internal registry;
- если все теги найдены, сразу:
  - выставляем image vars в runtime vars;
  - выходим из `buildImages` без запуска:
    - mirror,
    - codegen-check,
    - kaniko-build.

Важно: это как раз покрывает ваш кейс «если билды не нужны — mirror тоже не нужен».

### 3) Детерминированнее `build_ref` для issue/PR full-env
Улучшен выбор `runtime_build_ref` в webhook:
- для PR-trigger (label/review): приоритет `pull_request.head.sha`, fallback на `head.ref`;
- для issue-trigger:
  - сначала пытаемся взять из run history `pull_request.head.sha` (fallback на ref);
  - если истории нет — резолвим default ref в commit SHA через GitHub API.

Для этого:
- расширен DTO `githubPullRequestHead` (`sha`);
- в run payload сохраняется `pull_request.head.sha`;
- в `githubmgmt` добавлен `ResolveRefToCommitSHA`.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/webhook`
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy`
- `go test ./services/internal/control-plane/internal/clients/githubmgmt`
- `go test ./services/internal/control-plane/internal/...`

Все зелёные.

## Ожидаемый эффект
- После merge в `main` и последующего быстрого запуска AI-задачи не будет второй «такой же» сборки из-за env-разных тегов.
- Для docs-only и иных изменений без новых image-тегов runtime deploy пройдет существенно быстрее: build/mirror/codegen не запускаются.
- `build_ref` для full-env запусков стал стабильнее и ближе к конкретному commit snapshot.
