### PR TITLE
fix: prod frontend must rebuild when web-console changes

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -74,9 +74,13 @@ spec:
       - path: docs/templates/docset_pr.md
   versions:
     api-gateway:
-      value: "0.1.23"
+      value: "0.1.24"
       bumpOn:
         - services/external/api-gateway
+        # Production staff UI is embedded into api-gateway image.
+        - services/staff/web-console
+        - libs/ts
+        - libs/vue
         - libs/go
         - proto
     control-plane:


### PR DESCRIPTION
## Что исправлено
- Добавлен `services/staff/web-console` в `spec.versions.api-gateway.bumpOn` в `services.yaml`.
- Добавлены `libs/ts` и `libs/vue` в тот же `bumpOn` набор для консистентности UI-зависимостей.
- Поднят `spec.versions.api-gateway.value` до `0.1.24`, чтобы текущий прод пересобрал `api-gateway` и подхватил новый UI из merge PR #272.

## Почему это нужно
В production UI встраивается в образ `api-gateway` (Dockerfile копирует `services/staff/web-console` в stage `web`), а отдельный `web-console` deployment в production не используется. Поэтому bump только `web-console` не обновляет продовый интерфейс.

## Проверка
- После merge ожидается сборка `api-gateway:0.1.24` и rollout deployment `codex-k8s`.
- В UI должны исчезнуть удаленные пункты меню из PR #272.