### PR TITLE
fix: correct discussion run status comment rendering

### DIFF
--- a/services/internal/control-plane/internal/domain/runstatus/constants.go
+++ b/services/internal/control-plane/internal/domain/runstatus/constants.go
@@ -30,6 +30,11 @@ const (
 )
 
 const (
+	workloadKindJob = "job"
+	workloadKindPod = "pod"
+)
+
+const (
 	runStatusSucceeded = "succeeded"
 	runStatusFailed    = "failed"
 )

--- a/services/internal/control-plane/internal/domain/runstatus/helpers.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers.go
@@ -53,13 +53,34 @@ func normalizeCommentTargetKind(value string) commentTargetKind {
 }
 
 func normalizeRuntimeMode(value string, triggerKind string) string {
-	if strings.EqualFold(strings.TrimSpace(value), runtimeModeFullEnv) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case runtimeModeFullEnv:
 		return runtimeModeFullEnv
+	case runtimeModeCode:
+		return runtimeModeCode
 	}
 	if webhookdomain.IsKnownTriggerKind(webhookdomain.NormalizeTriggerKind(triggerKind)) {
 		return runtimeModeFullEnv
 	}
 	return runtimeModeCode
+}
+
+func isDiscussionTriggerLabel(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), webhookdomain.DefaultModeDiscussionLabel)
+}
+
+func resolveWorkloadKind(triggerKind string, triggerLabel string) string {
+	if isDiscussionTriggerLabel(triggerLabel) || webhookdomain.NormalizeTriggerKind(triggerKind) == webhookdomain.TriggerKindAIRepair {
+		return workloadKindPod
+	}
+	return workloadKindJob
+}
+
+func resolveTriggerKindDisplay(triggerKind string, triggerLabel string) string {
+	if isDiscussionTriggerLabel(triggerLabel) {
+		return "discussion"
+	}
+	return normalizeTriggerKind(triggerKind)
 }
 
 func normalizeRequestedByType(value RequestedByType) RequestedByType {
@@ -125,6 +146,9 @@ func mergeState(base commentState, update commentState) commentState {
 	}
 	if strings.TrimSpace(update.TriggerKind) != "" {
 		base.TriggerKind = normalizeTriggerKind(update.TriggerKind)
+	}
+	if strings.TrimSpace(update.TriggerLabel) != "" {
+		base.TriggerLabel = strings.TrimSpace(update.TriggerLabel)
 	}
 	if strings.TrimSpace(update.PromptLocale) != "" {
 		base.PromptLocale = normalizeLocale(update.PromptLocale, localeEN)

--- a/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
@@ -114,6 +114,14 @@ func TestResolveUpsertTriggerKind(t *testing.T) {
 	}
 }
 
+func TestNormalizeRuntimeMode_PreservesExplicitCodeOnly(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeRuntimeMode(runtimeModeCode, triggerKindDev); got != runtimeModeCode {
+		t.Fatalf("normalizeRuntimeMode(code-only, dev) = %q, want %q", got, runtimeModeCode)
+	}
+}
+
 func TestFindRunStatusComment_PicksLatestCommentByID(t *testing.T) {
 	t.Parallel()
 

--- a/services/internal/control-plane/internal/domain/runstatus/model.go
+++ b/services/internal/control-plane/internal/domain/runstatus/model.go
@@ -239,6 +239,7 @@ type commentState struct {
 	IssueURL                 string `json:"issue_url,omitempty"`
 	PullRequestURL           string `json:"pull_request_url,omitempty"`
 	TriggerKind              string `json:"trigger_kind,omitempty"`
+	TriggerLabel             string `json:"trigger_label,omitempty"`
 	PromptLocale             string `json:"prompt_locale,omitempty"`
 	Model                    string `json:"model,omitempty"`
 	ReasoningEffort          string `json:"reasoning_effort,omitempty"`

--- a/services/internal/control-plane/internal/domain/runstatus/render.go
+++ b/services/internal/control-plane/internal/domain/runstatus/render.go
@@ -34,7 +34,8 @@ type commentTemplateNextStepAction struct {
 
 type commentTemplateContext struct {
 	RunID                    string
-	TriggerKind              string
+	TriggerKindDisplay       string
+	WorkloadKind             string
 	RuntimeMode              string
 	JobName                  string
 	JobNamespace             string
@@ -127,7 +128,8 @@ func buildCommentTemplateContext(state commentState, managementURL string, marke
 
 	return commentTemplateContext{
 		RunID:                        strings.TrimSpace(state.RunID),
-		TriggerKind:                  normalizeTriggerKind(trimmedTriggerKind),
+		TriggerKindDisplay:           resolveTriggerKindDisplay(trimmedTriggerKind, state.TriggerLabel),
+		WorkloadKind:                 resolveWorkloadKind(trimmedTriggerKind, state.TriggerLabel),
 		RuntimeMode:                  trimmedRuntimeMode,
 		JobName:                      trimmedJobName,
 		JobNamespace:                 trimmedJobNamespace,
@@ -144,7 +146,7 @@ func buildCommentTemplateContext(state commentState, managementURL string, marke
 		NextStepActions:              templateActions,
 		ManagementURL:                managementURL,
 		StateMarker:                  marker,
-		ShowTriggerKind:              trimmedTriggerKind != "",
+		ShowTriggerKind:              resolveTriggerKindDisplay(trimmedTriggerKind, state.TriggerLabel) != "",
 		ShowRuntimeMode:              trimmedRuntimeMode != "",
 		ShowJobRef:                   trimmedJobName != "" && trimmedJobNamespace != "",
 		ShowNamespace:                trimmedNamespace != "",

--- a/services/internal/control-plane/internal/domain/runstatus/render_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/render_test.go
@@ -280,3 +280,35 @@ func TestRenderCommentBody_RendersRecentAgentStatusesEN(t *testing.T) {
 		t.Fatalf("expected status text in body: %q", body)
 	}
 }
+
+func TestRenderCommentBody_RendersDiscussionRunAsPod(t *testing.T) {
+	t.Parallel()
+
+	body := mustRenderCommentBody(t, commentState{
+		RunID:        "run-discussion",
+		Phase:        PhaseStarted,
+		TriggerKind:  triggerKindDev,
+		TriggerLabel: "mode:discussion",
+		RuntimeMode:  runtimeModeCode,
+		JobName:      "codex-k8s-run-run-discussion",
+		JobNamespace: "codex-issue-demo",
+		Namespace:    "codex-issue-demo",
+		PromptLocale: localeRU,
+	}, "https://platform.codex-k8s.dev/runs/run-discussion", nil, nil)
+
+	if !strings.Contains(body, "Режим запуска: `discussion`") {
+		t.Fatalf("expected discussion trigger display in body: %q", body)
+	}
+	if !strings.Contains(body, "Runtime mode: `code-only`") {
+		t.Fatalf("expected code-only runtime mode in body: %q", body)
+	}
+	if !strings.Contains(body, "Pod: `codex-issue-demo/codex-k8s-run-run-discussion`") {
+		t.Fatalf("expected pod workload reference in body: %q", body)
+	}
+	if strings.Contains(body, "Job: `codex-issue-demo/codex-k8s-run-run-discussion`") {
+		t.Fatalf("expected job workload reference to be hidden for discussion run: %q", body)
+	}
+	if strings.Contains(body, "Ожидание подготовки окружения") {
+		t.Fatalf("expected runtime preparation timeline to be hidden for discussion run: %q", body)
+	}
+}

--- a/services/internal/control-plane/internal/domain/runstatus/service.go
+++ b/services/internal/control-plane/internal/domain/runstatus/service.go
@@ -91,6 +91,10 @@ func (s *Service) UpsertRunStatusComment(ctx context.Context, params UpsertComme
 	}
 	effectiveTriggerKind := resolveUpsertTriggerKind(params.TriggerKind, runCtx.triggerKind)
 	trackedCommentID := s.findTrackedRunStatusCommentID(ctx, runCtx.run.CorrelationID, runID)
+	triggerLabel := ""
+	if runCtx.payload.Trigger != nil {
+		triggerLabel = strings.TrimSpace(runCtx.payload.Trigger.Label)
+	}
 
 	currentState := commentState{
 		RunID:                    runID,
@@ -101,6 +105,7 @@ func (s *Service) UpsertRunStatusComment(ctx context.Context, params UpsertComme
 		RuntimeMode:              normalizeRuntimeMode(params.RuntimeMode, effectiveTriggerKind),
 		Namespace:                strings.TrimSpace(params.Namespace),
 		TriggerKind:              effectiveTriggerKind,
+		TriggerLabel:             triggerLabel,
 		PromptLocale:             normalizeLocale(params.PromptLocale, s.cfg.DefaultLocale),
 		Model:                    strings.TrimSpace(params.Model),
 		ReasoningEffort:          strings.TrimSpace(params.ReasoningEffort),

--- a/services/internal/control-plane/internal/domain/runstatus/templates/comment_en.md.tmpl
+++ b/services/internal/control-plane/internal/domain/runstatus/templates/comment_en.md.tmpl
@@ -19,13 +19,17 @@
 
 - Run ID: `{{ .RunID }}`
 {{- if .ShowTriggerKind }}
-- Trigger mode: `{{ .TriggerKind }}`
+- Trigger mode: `{{ .TriggerKindDisplay }}`
 {{- end }}
 {{- if .ShowRuntimeMode }}
 - Runtime mode: `{{ .RuntimeMode }}`
 {{- end }}
 {{- if .ShowJobRef }}
+{{- if eq .WorkloadKind "pod" }}
+- Pod: `{{ .JobNamespace }}/{{ .JobName }}`
+{{- else }}
 - Job: `{{ .JobNamespace }}/{{ .JobName }}`
+{{- end }}
 {{- end }}
 {{- if .ShowNamespace }}
 - Namespace: `{{ .Namespace }}`

--- a/services/internal/control-plane/internal/domain/runstatus/templates/comment_ru.md.tmpl
+++ b/services/internal/control-plane/internal/domain/runstatus/templates/comment_ru.md.tmpl
@@ -19,13 +19,17 @@
 
 - Run ID: `{{ .RunID }}`
 {{- if .ShowTriggerKind }}
-- Режим запуска: `{{ .TriggerKind }}`
+- Режим запуска: `{{ .TriggerKindDisplay }}`
 {{- end }}
 {{- if .ShowRuntimeMode }}
 - Runtime mode: `{{ .RuntimeMode }}`
 {{- end }}
 {{- if .ShowJobRef }}
+{{- if eq .WorkloadKind "pod" }}
+- Pod: `{{ .JobNamespace }}/{{ .JobName }}`
+{{- else }}
 - Job: `{{ .JobNamespace }}/{{ .JobName }}`
+{{- end }}
 {{- end }}
 {{- if .ShowNamespace }}
 - Namespace: `{{ .Namespace }}`


### PR DESCRIPTION
## Что сделано
- исправил нормализацию `runtime_mode` в `runstatus`: явный `code-only` больше не превращается в `full-env`
- добавил в state-marker `trigger_label`, чтобы шаблоны могли корректно распознавать `mode:discussion`
- перевел GitHub service-comment для discussion-run на корректное отображение:
  - `discussion` вместо ложного `dev`
  - `code-only` вместо ложного `full-env`
  - `Pod` вместо `Job`
- добавил регрессионные тесты на discussion-mode rendering

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runstatus/...`
- `go test ./services/internal/control-plane/internal/transport/grpc ./services/internal/control-plane/internal/domain/webhook ./services/internal/control-plane/internal/domain/runstatus/...`
- `git diff --check`

## Self-check
- чек-лист выполнен, релевантно 16 пунктов общего чек-листа, все выполнены
- чек-лист Go выполнен, релевантно 14 пунктов, все выполнены

## Известные хвосты вне diff
- `make lint-go` падает на pre-existing проблемах:
  - `services/external/api-gateway/internal/transport/http/staff_realtime_handler.go:117`
  - `libs/go/servicescfg/load_validation.go:315`
- `make dupl-go` падает на pre-existing дублях:
  - `services/jobs/worker/internal/domain/worker/agent_job_context.go:313`
  - `libs/go/k8s/joblauncher/launcher.go:663`
  - `services/internal/control-plane/internal/clients/kubernetes/client.go:162`
  - `services/internal/control-plane/internal/clients/kubernetes/client.go:586`
