### PR TITLE
Issue #314: показать discussion-run в списке запусков (#314)

### DIFF
--- a/services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestRunListQueriesIncludeReviewerTriggerLabel(t *testing.T) {
+func TestRunListQueriesIncludeDiscussionAndReviewerTriggerLabels(t *testing.T) {
 	t.Parallel()
 
 	queries := map[string]string{
@@ -16,6 +16,9 @@ func TestRunListQueriesIncludeReviewerTriggerLabel(t *testing.T) {
 	for name, query := range queries {
 		if !strings.Contains(query, "ILIKE 'run:%'") {
 			t.Fatalf("%s query must keep run trigger filter", name)
+		}
+		if !strings.Contains(query, "= 'mode:discussion'") {
+			t.Fatalf("%s query must include discussion trigger filter", name)
 		}
 		if !strings.Contains(query, "ILIKE 'need:reviewer'") {
 			t.Fatalf("%s query must include reviewer trigger filter", name)

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql
@@ -105,6 +105,7 @@ LEFT JOIN LATERAL (
 ) ws ON true
 WHERE (
         COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'run:%'
+        OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
         OR COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'need:reviewer'
     )
 ORDER BY created_at DESC

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql
@@ -107,6 +107,7 @@ WHERE pm.user_id = $1::uuid
   AND ar.project_id IS NOT NULL
   AND (
         COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'run:%'
+        OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
         OR COALESCE(ar.run_payload->'trigger'->>'label', '') ILIKE 'need:reviewer'
       )
 ORDER BY ar.created_at DESC


### PR DESCRIPTION
## Контекст
- Issue: #314 `Bug: при запуске mode:discussion ран не отображается в списке ранов`.
- Ветка реализации: `codex/issue-314`.
- Scope: backend-фикс выборки staff runs list для discussion-run без изменения API-контракта.

## Основание для изменений
- `mode:discussion` по продуктовой политике создаёт полноценный run и должен быть виден в staff web-console.
- Раздел `Запуски` использует backend-выборки `staffrun list_all/list_for_user`; в них были разрешены только `run:*` и `need:reviewer`, поэтому discussion-run отсутствовал в таблице.

## Основной смысл правок
- Включить `mode:discussion` в SQL-фильтры списка запусков для admin- и user-scoped выборок.
- Зафиксировать это отдельным unit-тестом на текст запросов, чтобы регрессия не вернулась.

## Что сделано
- Обновлён SQL-фильтр списка запусков для админа: `services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql`.
- Обновлён SQL-фильтр списка запусков для участника проекта: `services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql`.
- Расширен тест `services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go`: теперь он проверяет наличие фильтров и для `mode:discussion`, и для `need:reviewer`.

## Логи и runtime-диагностика
- Kubernetes runtime-диагностика не выполнялась: для фикса хватило анализа SQL-запросов и кода staff list path.
- Логи pod/job не запрашивались.

## БД и миграции
- Миграции не требовались.
- Схема БД не менялась; изменена только логика выборки существующих записей `agent_runs`.

## Проверки
- `go test ./services/internal/control-plane/internal/repository/postgres/staffrun/...` — успешно.
- `make lint-go` — успешно.
- `make dupl-go` — неуспешно из-за уже существующих дублей вне scope правки (`services/jobs/worker/internal/domain/worker/agent_job_context.go`, `libs/go/k8s/joblauncher/launcher.go`, `services/internal/control-plane/internal/clients/kubernetes/client.go`, `services/internal/control-plane/internal/domain/{mcp,runstatus}/model.go`).

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты проверены, нарушений по scope правки нет.
- `docs/design-guidelines/go/check_list.md` — релевантные пункты проверены, transport/SQL/repository границы соблюдены.
- `docs/design-guidelines/vue/check_list.md` — не требовался, frontend не менялся.

## Риски и ограничения
- Фикс затрагивает только список запусков; детали конкретного run и runtime-state path не менялись.
- Для member-scoped списка сохраняется текущее ограничение `ar.project_id IS NOT NULL`; если появятся discussion-run без project binding, это отдельный кейс вне scope текущего issue.

## Рекомендации / следующий шаг
- После merge имеет смысл вручную проверить в staff UI сценарий `mode:discussion`: появление run в `/runs` и переход в `/runs/:id`.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/314
