### PR TITLE
fix: correct trimPrefix template helper order

### DIFF
--- a/libs/go/manifesttpl/render.go
+++ b/libs/go/manifesttpl/render.go
@@ -53,9 +53,11 @@ func funcMap(vars map[string]string) template.FuncMap {
 			}
 			return right
 		},
-		"join":       strings.Join,
-		"trimPrefix": strings.TrimPrefix,
-		"toLower":    strings.ToLower,
+		"join": strings.Join,
+		"trimPrefix": func(prefix string, value string) string {
+			return strings.TrimPrefix(value, prefix)
+		},
+		"toLower": strings.ToLower,
 	}
 }
 

--- a/libs/go/manifesttpl/render_test.go
+++ b/libs/go/manifesttpl/render_test.go
@@ -1,0 +1,29 @@
+package manifesttpl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRender_TrimPrefixTemplateHelperUsesPrefixFirstOrder(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(strings.TrimSpace(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  tag: '{{ trimPrefix "v" "v1.32.2" }}'
+`) + "\n")
+
+	out, err := Render("trim-prefix", raw, nil)
+	if err != nil {
+		t.Fatalf("render template: %v", err)
+	}
+
+	rendered := string(out)
+	if !strings.Contains(rendered, "tag: '1.32.2'") {
+		t.Fatalf("unexpected rendered template:\n%s", rendered)
+	}
+}

--- a/libs/go/servicescfg/load_helpers.go
+++ b/libs/go/servicescfg/load_helpers.go
@@ -90,9 +90,11 @@ func renderTemplate(name string, raw []byte, ctx ResolvedContext) ([]byte, error
 			}
 			return right
 		},
-		"join":       strings.Join,
-		"trimPrefix": strings.TrimPrefix,
-		"toLower":    strings.ToLower,
+		"join": strings.Join,
+		"trimPrefix": func(prefix string, value string) string {
+			return strings.TrimPrefix(value, prefix)
+		},
+		"toLower": strings.ToLower,
 	}
 
 	tmpl, err := template.New(name).Funcs(funcs).Parse(string(raw))

--- a/libs/go/servicescfg/load_test.go
+++ b/libs/go/servicescfg/load_test.go
@@ -763,6 +763,43 @@ spec:
 	}
 }
 
+func TestLoad_TrimPrefixTemplateHelperUsesPrefixFirstOrder(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "services.yaml")
+	writeFile(t, path, `
+apiVersion: codex-k8s.dev/v1alpha1
+kind: ServiceStack
+metadata:
+  name: demo
+spec:
+  versions:
+    kubectl:
+      value: "v1.32.2"
+  environments:
+    production:
+      namespaceTemplate: "{{ .Project }}-prod"
+  images:
+    kubectl:
+      type: external
+      from: 'alpine/k8s:{{ trimPrefix "v" (index .Versions "kubectl") }}'
+      local: 'registry.local/demo/alpine-k8s:{{ trimPrefix "v" (index .Versions "kubectl") }}'
+`)
+
+	result, err := Load(path, LoadOptions{Env: "production"})
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	kubectlImage := result.Stack.Spec.Images["kubectl"]
+	if got, want := kubectlImage.From, "alpine/k8s:1.32.2"; got != want {
+		t.Fatalf("unexpected kubectl source image: got %q want %q", got, want)
+	}
+	if got, want := kubectlImage.Local, "registry.local/demo/alpine-k8s:1.32.2"; got != want {
+		t.Fatalf("unexpected kubectl mirror image: got %q want %q", got, want)
+	}
+}
+
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {


### PR DESCRIPTION
## Что сделано

- исправлен helper `trimPrefix` в шаблонных функциях:
  - `libs/go/servicescfg/load_helpers.go`
  - `libs/go/manifesttpl/render.go`
- теперь helper работает в template-friendly порядке аргументов: `trimPrefix(prefix, value)`;
- добавлены регрессионные тесты для `servicescfg` и `manifesttpl`.

## Что было причиной падения run по issue #260

Оба запуска `#260` падали не в агенте и не в PR-flow, а раньше — на `runtime_deploy` стадии mirror external dependencies.

Факты:
- failed runs:
  - `d4ae4a20-9fcb-409a-9c30-e56708aeee5b`
  - `3c8d485c-001c-4050-a8bf-7670db98cdbd`
- `runtime_deploy_tasks.last_error` в production:
  - `build images: mirror external dependencies: wait mirror job codex-k8s-mirror-kubectl-... failed`
- лог mirror job в `codex-k8s-dev-1`:
  - `SOURCE_IMAGE=alpine/k8s:v`
  - `TARGET_IMAGE=127.0.0.1:5000/codex-k8s/mirror/alpine-k8s:v`
  - `MANIFEST_UNKNOWN: manifest unknown; unknown tag=v`

Корень проблемы:
- в `services.yaml` используется шаблон `{{ trimPrefix "v" (index .Versions "kubectl") }}`;
- helper был зарегистрирован как прямой `strings.TrimPrefix`, то есть фактически ожидал порядок `(value, prefix)`;
- в результате из `v1.32.2` рендерился не `1.32.2`, а `v`.

## Проверки

- `go test ./libs/go/servicescfg ./libs/go/manifesttpl`
- `git diff --check`
- `make dupl-go`

## Lint

`make lint-go` падает на pre-existing замечаниях вне этого diff:
- `services/external/api-gateway/internal/transport/http/staff_realtime_handler.go:117`
- `libs/go/servicescfg/load_validation.go:315`
