### PR TITLE
Исправить ложный failed-статус для успешных run при новом формате Codex output

### DIFF
--- a/services/jobs/agent-runner/internal/runner/helpers_exec_session.go
+++ b/services/jobs/agent-runner/internal/runner/helpers_exec_session.go
@@ -155,8 +155,8 @@ func parseCodexReportOutput(output []byte) (codexReport, json.RawMessage, error)
 		if !json.Valid(raw) {
 			return codexReport{}, false
 		}
-		var report codexReport
-		if err := json.Unmarshal(raw, &report); err != nil {
+		report, err := decodeCodexReport(raw)
+		if err != nil {
 			return codexReport{}, false
 		}
 		return report, true
@@ -178,6 +178,85 @@ func parseCodexReportOutput(output []byte) (codexReport, json.RawMessage, error)
 	}
 
 	return codexReport{}, nil, fmt.Errorf("failed to parse codex structured output")
+}
+
+type rawCodexReport struct {
+	Status          string          `json:"status"`
+	Summary         json.RawMessage `json:"summary"`
+	Branch          string          `json:"branch"`
+	PRNumber        int             `json:"pr_number"`
+	PRURL           string          `json:"pr_url"`
+	SessionID       string          `json:"session_id"`
+	Model           string          `json:"model"`
+	ReasoningEffort string          `json:"reasoning_effort"`
+	Diagnosis       string          `json:"diagnosis"`
+	ActionItems     []string        `json:"action_items"`
+	EvidenceRefs    []string        `json:"evidence_refs"`
+	ToolGaps        []string        `json:"tool_gaps"`
+	PullRequest     *rawCodexPR     `json:"pr"`
+}
+
+type rawCodexPR struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+func decodeCodexReport(raw []byte) (codexReport, error) {
+	var payload rawCodexReport
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return codexReport{}, err
+	}
+
+	summary, err := decodeCodexSummary(payload.Summary)
+	if err != nil {
+		return codexReport{}, err
+	}
+
+	report := codexReport{
+		Summary:         summary,
+		Branch:          strings.TrimSpace(payload.Branch),
+		PRNumber:        payload.PRNumber,
+		PRURL:           strings.TrimSpace(payload.PRURL),
+		SessionID:       strings.TrimSpace(payload.SessionID),
+		Model:           strings.TrimSpace(payload.Model),
+		ReasoningEffort: strings.TrimSpace(payload.ReasoningEffort),
+		Diagnosis:       strings.TrimSpace(payload.Diagnosis),
+		ActionItems:     normalizeStringList(payload.ActionItems),
+		EvidenceRefs:    normalizeStringList(payload.EvidenceRefs),
+		ToolGaps:        normalizeStringList(payload.ToolGaps),
+	}
+	if payload.PullRequest != nil {
+		if report.PRNumber <= 0 {
+			report.PRNumber = payload.PullRequest.Number
+		}
+		if report.PRURL == "" {
+			report.PRURL = strings.TrimSpace(payload.PullRequest.URL)
+		}
+	}
+	return report, nil
+}
+
+func decodeCodexSummary(raw json.RawMessage) (string, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return "", nil
+	}
+
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return strings.TrimSpace(single), nil
+	}
+
+	var items []string
+	if err := json.Unmarshal(raw, &items); err == nil {
+		normalized := normalizeStringList(items)
+		if len(normalized) == 0 {
+			return "", nil
+		}
+		return strings.Join(normalized, "\n"), nil
+	}
+
+	return "", fmt.Errorf("decode codex summary: unsupported payload %s", trimmed)
 }
 
 func trimCapturedOutput(raw string, maxBytes int) string {

--- a/services/jobs/agent-runner/internal/runner/helpers_exec_session_parse_test.go
+++ b/services/jobs/agent-runner/internal/runner/helpers_exec_session_parse_test.go
@@ -1,0 +1,82 @@
+package runner
+
+import "testing"
+
+func TestParseCodexReportOutput_FlatSchema(t *testing.T) {
+	raw := []byte(`{"summary":"ok","branch":"main","pr_number":324,"pr_url":"https://example.test/pr/324","session_id":"sess-1","model":"gpt-5.4","reasoning_effort":"high"}`)
+
+	report, payload, err := parseCodexReportOutput(raw)
+	if err != nil {
+		t.Fatalf("parseCodexReportOutput() error = %v", err)
+	}
+	if string(payload) != string(raw) {
+		t.Fatalf("payload = %s, want %s", string(payload), string(raw))
+	}
+	if report.Summary != "ok" {
+		t.Fatalf("summary = %q, want ok", report.Summary)
+	}
+	if report.PRNumber != 324 {
+		t.Fatalf("pr_number = %d, want 324", report.PRNumber)
+	}
+	if report.PRURL != "https://example.test/pr/324" {
+		t.Fatalf("pr_url = %q", report.PRURL)
+	}
+}
+
+func TestParseCodexReportOutput_CompletedEnvelope(t *testing.T) {
+	raw := []byte(`{
+		"status":"completed",
+		"branch":"codex/issue-320",
+		"commit":"77a833f",
+		"pr":{"number":324,"url":"https://github.com/codex-k8s/codex-k8s/pull/324"},
+		"issue":{"number":320,"follow_up_issue":{"number":325,"url":"https://github.com/codex-k8s/codex-k8s/issues/325"}},
+		"summary":[
+			"Удалил устаревшую проверку.",
+			"Синхронизировал delivery-доки."
+		],
+		"checks":[
+			{"name":"git diff","result":"passed","details":"git diff --check"}
+		],
+		"acceptance":{
+			"review":"Проверьте PR",
+			"approve":"Approve PR",
+			"merge":"Merge PR"
+		}
+	}`)
+
+	report, _, err := parseCodexReportOutput(raw)
+	if err != nil {
+		t.Fatalf("parseCodexReportOutput() error = %v", err)
+	}
+	if report.Branch != "codex/issue-320" {
+		t.Fatalf("branch = %q, want codex/issue-320", report.Branch)
+	}
+	if report.PRNumber != 324 {
+		t.Fatalf("pr_number = %d, want 324", report.PRNumber)
+	}
+	if report.PRURL != "https://github.com/codex-k8s/codex-k8s/pull/324" {
+		t.Fatalf("pr_url = %q", report.PRURL)
+	}
+	wantSummary := "Удалил устаревшую проверку.\nСинхронизировал delivery-доки."
+	if report.Summary != wantSummary {
+		t.Fatalf("summary = %q, want %q", report.Summary, wantSummary)
+	}
+}
+
+func TestParseCodexReportOutput_LastJSONLineFallback(t *testing.T) {
+	raw := []byte("noise before\n{\"status\":\"completed\",\"branch\":\"codex/issue-320\",\"pr\":{\"number\":324,\"url\":\"https://example.test/pr/324\"},\"summary\":[\"done\"]}")
+
+	report, payload, err := parseCodexReportOutput(raw)
+	if err != nil {
+		t.Fatalf("parseCodexReportOutput() error = %v", err)
+	}
+	if string(payload) != "{\"status\":\"completed\",\"branch\":\"codex/issue-320\",\"pr\":{\"number\":324,\"url\":\"https://example.test/pr/324\"},\"summary\":[\"done\"]}" {
+		t.Fatalf("unexpected payload: %s", string(payload))
+	}
+	if report.Summary != "done" {
+		t.Fatalf("summary = %q, want done", report.Summary)
+	}
+	if report.PRNumber != 324 {
+		t.Fatalf("pr_number = %d, want 324", report.PRNumber)
+	}
+}


### PR DESCRIPTION
## Что сделано
- исправлен парсинг structured output в `agent-runner`: теперь принимаются оба формата
  - старый плоский JSON (`summary`, `pr_number`, `pr_url`)
  - новый completed-envelope (`status=completed`, `pr{number,url}`, `summary[]`)
- добавлены регрессионные тесты на оба варианта payload, включая payload по мотивам production run `f12ce9a0-2782-4929-900d-9fd5cec003c4`

## Причина бага
Для run `f12ce9a0-2782-4929-900d-9fd5cec003c4` `codex exec` завершился успешно и вернул completed JSON, но runner пытался распарсить его как старый плоский `codexReport`.
Из-за этого `parseCodexReportOutput` падал, `defer` сохранял failed-snapshot, pod завершался с ошибкой, а worker маркировал весь run как `failed`.

## Как проверено
- `go test ./services/jobs/agent-runner/internal/runner/...`
- `git diff --check`

## Чек-лист
- [x] `docs/design-guidelines/common/check_list.md` — релевантные пункты выполнены
- [x] `docs/design-guidelines/go/check_list.md` — релевантные пункты выполнены
