### PR TITLE
Issue #301: cleanup stale discussion namespaces after label removal (#301)

### DIFF
--- a/services/internal/control-plane/internal/domain/webhook/service_helpers.go
+++ b/services/internal/control-plane/internal/domain/webhook/service_helpers.go
@@ -155,7 +155,7 @@ func (s *Service) maybeCleanupRunNamespaces(ctx context.Context, cmd IngestComma
 	case eventType == string(webhookdomain.GitHubEventIssues) &&
 		(action == string(webhookdomain.GitHubActionClosed) || action == string(webhookdomain.GitHubActionDeleted)) &&
 		envelope.Issue.Number > 0:
-		if err := s.cleanupActiveDiscussionRunsByIssue(ctx, requestedByID, repositoryFullName, envelope.Issue.Number); err != nil {
+		if err := s.cleanupDiscussionRunsByIssue(ctx, requestedByID, repositoryFullName, envelope.Issue.Number); err != nil {
 			return err
 		}
 		_, cleanupErr = s.runStatus.CleanupNamespacesByIssue(ctx, runstatusdomain.CleanupByIssueParams{
@@ -167,7 +167,7 @@ func (s *Service) maybeCleanupRunNamespaces(ctx context.Context, cmd IngestComma
 		envelope.Issue.Number > 0 &&
 		((action == string(webhookdomain.GitHubActionUnlabeled) && s.triggerLabels.isModeDiscussionLabel(envelope.Label.Name)) ||
 			(action == string(webhookdomain.GitHubActionLabeled) && s.triggerLabels.isRunTriggerLabel(envelope.Label.Name))):
-		cleanupErr = s.cleanupActiveDiscussionRunsByIssue(ctx, requestedByID, repositoryFullName, envelope.Issue.Number)
+		cleanupErr = s.cleanupDiscussionRunsByIssue(ctx, requestedByID, repositoryFullName, envelope.Issue.Number)
 	case eventType == string(webhookdomain.GitHubEventPullRequest) && action == "closed" && envelope.PullRequest.Number > 0:
 		_, cleanupErr = s.runStatus.CleanupNamespacesByPullRequest(ctx, runstatusdomain.CleanupByPullRequestParams{
 			RepositoryFullName: repositoryFullName,
@@ -182,7 +182,7 @@ func (s *Service) maybeCleanupRunNamespaces(ctx context.Context, cmd IngestComma
 	return nil
 }
 
-func (s *Service) cleanupActiveDiscussionRunsByIssue(ctx context.Context, requestedByID string, repositoryFullName string, issueNumber int64) error {
+func (s *Service) cleanupDiscussionRunsByIssue(ctx context.Context, requestedByID string, repositoryFullName string, issueNumber int64) error {
 	if s.agentRuns == nil || strings.TrimSpace(repositoryFullName) == "" || issueNumber <= 0 {
 		return nil
 	}
@@ -204,18 +204,12 @@ func (s *Service) cleanupActiveDiscussionRunsByIssue(ctx context.Context, reques
 		if normalizeLabelToken(extractTriggerLabel(run.RunPayload)) != discussionLabel {
 			continue
 		}
+
 		switch rundomain.Status(strings.TrimSpace(run.Status)) {
 		case rundomain.StatusPending, rundomain.StatusRunning:
-		default:
-			continue
-		}
-
-		canceled, err := s.agentRuns.CancelActiveByID(ctx, run.ID)
-		if err != nil {
-			return fmt.Errorf("cancel active discussion run %s: %w", run.ID, err)
-		}
-		if !canceled {
-			continue
+			if _, err := s.agentRuns.CancelActiveByID(ctx, run.ID); err != nil {
+				return fmt.Errorf("cancel active discussion run %s: %w", run.ID, err)
+			}
 		}
 
 		if _, err := s.runStatus.DeleteRunNamespace(ctx, runstatusdomain.DeleteNamespaceParams{

--- a/services/internal/control-plane/internal/domain/webhook/service_test.go
+++ b/services/internal/control-plane/internal/domain/webhook/service_test.go
@@ -579,6 +579,109 @@ func TestIngestGitHubWebhook_ModeDiscussionRemovedCleansDiscussionContext(t *tes
 	}
 }
 
+func TestIngestGitHubWebhook_ModeDiscussionRemovalDeletesStaleErroredNamespace(t *testing.T) {
+	ctx := context.Background()
+	runs := &inMemoryRunRepo{
+		items: map[string]string{},
+		byRunID: map[string]agentrunrepo.Run{
+			"run-discussion-active": {
+				ID:            "run-discussion-active",
+				CorrelationID: "corr-discussion-active",
+				ProjectID:     "project-1",
+				Status:        "running",
+				RunPayload:    json.RawMessage(`{"trigger":{"label":"mode:discussion","kind":"dev"}}`),
+			},
+			"run-discussion-stale": {
+				ID:            "run-discussion-stale",
+				CorrelationID: "corr-discussion-stale",
+				ProjectID:     "project-1",
+				Status:        "error",
+				RunPayload:    json.RawMessage(`{"trigger":{"label":"mode:discussion","kind":"dev"}}`),
+			},
+		},
+		searchItems: []agentrunrepo.RunLookupItem{
+			{
+				RunID:              "run-discussion-active",
+				ProjectID:          "project-1",
+				RepositoryFullName: "codex-k8s/codex-k8s",
+				IssueNumber:        289,
+				TriggerKind:        string(webhookdomain.TriggerKindDev),
+				TriggerLabel:       webhookdomain.DefaultModeDiscussionLabel,
+				Status:             "running",
+			},
+			{
+				RunID:              "run-discussion-stale",
+				ProjectID:          "project-1",
+				RepositoryFullName: "codex-k8s/codex-k8s",
+				IssueNumber:        289,
+				TriggerKind:        string(webhookdomain.TriggerKindDev),
+				TriggerLabel:       webhookdomain.DefaultModeDiscussionLabel,
+				Status:             "error",
+			},
+		},
+	}
+	events := &inMemoryEventRepo{}
+	repos := &inMemoryRepoCfgRepo{
+		byExternalID: map[int64]repocfgrepo.FindResult{
+			42: {
+				ProjectID:        "project-1",
+				RepositoryID:     "repo-1",
+				ServicesYAMLPath: "services.yaml",
+				DefaultRef:       "main",
+			},
+		},
+	}
+	users := &inMemoryUserRepo{
+		byLogin: map[string]userrepo.User{
+			"member": {ID: "user-1", GitHubLogin: "member"},
+		},
+	}
+	members := &inMemoryProjectMemberRepo{
+		roles: map[string]string{"project-1|user-1": "read_write"},
+	}
+	runStatus := &inMemoryRunStatusService{}
+	svc := NewService(Config{
+		AgentRuns:  runs,
+		FlowEvents: events,
+		Repos:      repos,
+		Users:      users,
+		Members:    members,
+		RunStatus:  runStatus,
+	})
+
+	payload := json.RawMessage(`{
+		"action":"unlabeled",
+		"label":{"name":"mode:discussion"},
+		"issue":{"id":1001,"number":289,"title":"Discuss feature","html_url":"https://github.com/codex-k8s/codex-k8s/issues/289","state":"open","labels":[]},
+		"repository":{"id":42,"full_name":"codex-k8s/codex-k8s","name":"codex-k8s"},
+		"sender":{"id":10,"login":"member","type":"User"}
+	}`)
+	cmd := IngestCommand{
+		CorrelationID: "delivery-discussion-unlabeled-stale-1",
+		DeliveryID:    "delivery-discussion-unlabeled-stale-1",
+		EventType:     string(webhookdomain.GitHubEventIssues),
+		ReceivedAt:    time.Now().UTC(),
+		Payload:       payload,
+	}
+
+	got, err := svc.IngestGitHubWebhook(ctx, cmd)
+	if err != nil {
+		t.Fatalf("ingest failed: %v", err)
+	}
+	if got.RunID != "" {
+		t.Fatalf("expected no new run on mode:discussion removal, got %q", got.RunID)
+	}
+	if len(runs.canceledRunIDs) != 1 || runs.canceledRunIDs[0] != "run-discussion-active" {
+		t.Fatalf("expected only active discussion run to be canceled, got %#v", runs.canceledRunIDs)
+	}
+	if len(runStatus.deleteNamespaceCalls) != 2 {
+		t.Fatalf("expected namespace delete for active and stale discussion runs, got %#v", runStatus.deleteNamespaceCalls)
+	}
+	if runStatus.deleteNamespaceCalls[0].RunID != "run-discussion-active" || runStatus.deleteNamespaceCalls[1].RunID != "run-discussion-stale" {
+		t.Fatalf("unexpected discussion namespace delete order: %#v", runStatus.deleteNamespaceCalls)
+	}
+}
+
 func TestIngestGitHubWebhook_PushMain_CreatesDeployOnlyProductionRun(t *testing.T) {
 	ctx := context.Background()
 	runs := &inMemoryRunRepo{items: map[string]string{}}


### PR DESCRIPTION
## Контекст
- Issue: `#301` — stale discussion namespace остаётся после снятия `mode:discussion`, если один из discussion-run ранее завершился с ошибкой.
- Подтверждённый кейс из issue: после снятия label у issue `#289` старый namespace `codex-issue-3278207d1cd3-i289-r952c7c8e77b0` не был удалён, хотя более новый discussion namespace cleanup прошёл.
- Затронута область: `services/internal/control-plane/internal/domain/webhook`.

## Основание для изменений
- Policy в [docs/product/labels_and_trigger_policy.md] уже требует удалять managed discussion namespace после снятия `mode:discussion` и при постановке любого `run:*`.
- В текущей реализации cleanup при `issues.unlabeled(mode:discussion)` и `issues.labeled(run:*)` удалял namespace только у `pending/running` discussion-run и пропускал `error/failed` discussion-run.
- Issue #301 фиксирует конкретный production-like симптом этого расхождения.

## Основной смысл правок
- Привести webhook cleanup к фактической policy discussion mode: удалять namespace у всех discussion-run конкретного issue, а отмену выполнять только для реально активных запусков.

## Что сделано
- В [services/internal/control-plane/internal/domain/webhook/service_helpers.go] helper переименован в `cleanupDiscussionRunsByIssue`.
- Логика cleanup изменена: для discussion-run со статусом `pending/running` выполняется `CancelActiveByID`, после чего `DeleteRunNamespace` вызывается для каждого discussion-run issue, включая `error/failed`.
- Все существующие call-site в `maybeCleanupRunNamespaces` переведены на обновлённый helper для сценариев:
  - `issues.unlabeled` c label `mode:discussion`;
  - `issues.labeled` с любым `run:*`;
  - `issues.closed` / `issues.deleted`.
- Добавлен регрессионный тест [services/internal/control-plane/internal/domain/webhook/service_test.go], который воспроизводит комбинацию из активного и stale errored discussion-run и проверяет:
  - отменяется только активный run;
  - namespace cleanup вызывается для обоих run.

## Логи и runtime-диагностика
- `kubectl` и runtime-логи в Kubernetes не использовались.
- Диагностика выполнялась по коду, issue-описанию и юнит-тестам.
- Для уточнения поведения Kubernetes client использовал Context7 по `k8s.io/client-go` для актуального паттерна обработки `IsNotFound` и операций `Get/Delete/List`.

## БД и миграции
- Изменений схемы БД нет.
- Миграции не добавлялись.
- SQL и репозиторные контракты не менялись.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/webhook` — passed.
- `go mod tidy` — completed, изменений в `go.mod`/`go.sum` не осталось.
- `make lint-go` — passed.
- `make dupl-go` — passed.

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты проверены, нарушений не выявлено.
- `docs/design-guidelines/go/check_list.md` — релевантные пункты проверены, нарушений не выявлено.
- `docs/design-guidelines/vue/check_list.md` — не требуется, frontend не затрагивался.

## Риски и ограничения
- Cleanup по issue по-прежнему опирается на `ListRunIDsByRepositoryIssue(..., limit=200)`; это поведение в рамках данного фикса не менялось.
- Исправление покрывает discussion-run, у которых `run_payload.trigger.label = mode:discussion`; повреждённые/неконсистентные payload вне этого контракта не входят в scope issue #301.

## Рекомендации / следующий шаг
- QA стоит повторно прогнать сценарий issue `#289`: несколько discussion-run для одного issue, затем снятие `mode:discussion` и проверка отсутствия stale namespace в кластере.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/301
