### PR TITLE
Issue #298: discussion-run service-comment синхронизирован с code-only runtime (#298)

### DIFF
--- a/services/internal/control-plane/internal/domain/runstatus/constants.go
+++ b/services/internal/control-plane/internal/domain/runstatus/constants.go
@@ -15,8 +15,9 @@ const (
 )
 
 const (
-	triggerKindDev       = "dev"
-	triggerKindDevRevise = "dev_revise"
+	triggerKindDev        = "dev"
+	triggerKindDevRevise  = "dev_revise"
+	triggerKindDiscussion = "discussion"
 )
 
 const (

--- a/services/internal/control-plane/internal/domain/runstatus/helpers.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers.go
@@ -59,6 +59,9 @@ func normalizeRuntimeMode(value string, triggerKind string) string {
 	case runtimeModeCode:
 		return runtimeModeCode
 	}
+	if strings.EqualFold(strings.TrimSpace(triggerKind), triggerKindDiscussion) {
+		return runtimeModeCode
+	}
 	if webhookdomain.IsKnownTriggerKind(webhookdomain.NormalizeTriggerKind(triggerKind)) {
 		return runtimeModeFullEnv
 	}
@@ -69,16 +72,30 @@ func isDiscussionTriggerLabel(value string) bool {
 	return strings.EqualFold(strings.TrimSpace(value), webhookdomain.DefaultModeDiscussionLabel)
 }
 
-func resolveWorkloadKind(triggerKind string, triggerLabel string) string {
-	if isDiscussionTriggerLabel(triggerLabel) || webhookdomain.NormalizeTriggerKind(triggerKind) == webhookdomain.TriggerKindAIRepair {
+func isDiscussionTriggerKind(triggerKind string, triggerLabel string, discussionMode bool) bool {
+	if discussionMode || isDiscussionTriggerLabel(triggerLabel) {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(triggerKind), triggerKindDiscussion)
+}
+
+func resolveCommentTriggerKind(triggerKind string, triggerLabel string, discussionMode bool) string {
+	if isDiscussionTriggerKind(triggerKind, triggerLabel, discussionMode) {
+		return triggerKindDiscussion
+	}
+	return normalizeTriggerKind(triggerKind)
+}
+
+func resolveWorkloadKind(triggerKind string, triggerLabel string, discussionMode bool) string {
+	if isDiscussionTriggerKind(triggerKind, triggerLabel, discussionMode) || webhookdomain.NormalizeTriggerKind(triggerKind) == webhookdomain.TriggerKindAIRepair {
 		return workloadKindPod
 	}
 	return workloadKindJob
 }
 
-func resolveTriggerKindDisplay(triggerKind string, triggerLabel string) string {
-	if isDiscussionTriggerLabel(triggerLabel) {
-		return "discussion"
+func resolveTriggerKindDisplay(triggerKind string, triggerLabel string, discussionMode bool) string {
+	if isDiscussionTriggerKind(triggerKind, triggerLabel, discussionMode) {
+		return triggerKindDiscussion
 	}
 	return normalizeTriggerKind(triggerKind)
 }
@@ -145,11 +162,15 @@ func mergeState(base commentState, update commentState) commentState {
 		base.PullRequestURL = strings.TrimSpace(update.PullRequestURL)
 	}
 	if strings.TrimSpace(update.TriggerKind) != "" {
-		base.TriggerKind = normalizeTriggerKind(update.TriggerKind)
+		base.TriggerKind = strings.TrimSpace(update.TriggerKind)
 	}
 	if strings.TrimSpace(update.TriggerLabel) != "" {
 		base.TriggerLabel = strings.TrimSpace(update.TriggerLabel)
 	}
+	if update.DiscussionMode {
+		base.DiscussionMode = true
+	}
+	base.TriggerKind = resolveCommentTriggerKind(base.TriggerKind, base.TriggerLabel, base.DiscussionMode)
 	if strings.TrimSpace(update.PromptLocale) != "" {
 		base.PromptLocale = normalizeLocale(update.PromptLocale, localeEN)
 	}

--- a/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/helpers_test.go
@@ -122,6 +122,14 @@ func TestNormalizeRuntimeMode_PreservesExplicitCodeOnly(t *testing.T) {
 	}
 }
 
+func TestNormalizeRuntimeMode_DefaultsDiscussionToCodeOnly(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeRuntimeMode("", triggerKindDiscussion); got != runtimeModeCode {
+		t.Fatalf("normalizeRuntimeMode(empty, discussion) = %q, want %q", got, runtimeModeCode)
+	}
+}
+
 func TestFindRunStatusComment_PrefersHigherPhaseAndFallsBackToLatestCommentByID(t *testing.T) {
 	t.Parallel()
 

--- a/services/internal/control-plane/internal/domain/runstatus/model.go
+++ b/services/internal/control-plane/internal/domain/runstatus/model.go
@@ -243,6 +243,7 @@ type commentState struct {
 	PullRequestURL           string `json:"pull_request_url,omitempty"`
 	TriggerKind              string `json:"trigger_kind,omitempty"`
 	TriggerLabel             string `json:"trigger_label,omitempty"`
+	DiscussionMode           bool   `json:"discussion_mode,omitempty"`
 	PromptLocale             string `json:"prompt_locale,omitempty"`
 	Model                    string `json:"model,omitempty"`
 	ReasoningEffort          string `json:"reasoning_effort,omitempty"`

--- a/services/internal/control-plane/internal/domain/runstatus/next_step_actions.go
+++ b/services/internal/control-plane/internal/domain/runstatus/next_step_actions.go
@@ -72,6 +72,9 @@ func stageDescriptorFromTriggerKind(labels nextstepdomain.Labels, triggerKind st
 }
 
 func buildNextStepActions(publicBaseURL string, labels nextstepdomain.Labels, runCtx runContext, state commentState) []nextStepCommentAction {
+	if isDiscussionTriggerKind(state.TriggerKind, state.TriggerLabel, state.DiscussionMode) {
+		return nil
+	}
 	descriptor, ok := stageDescriptorFromTriggerKind(labels, state.TriggerKind)
 	if !ok {
 		return nil

--- a/services/internal/control-plane/internal/domain/runstatus/next_step_actions_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/next_step_actions_test.go
@@ -61,3 +61,18 @@ func TestStageDescriptorFromTriggerKind_UsesConfiguredReviseLabels(t *testing.T)
 		})
 	}
 }
+
+func TestBuildNextStepActions_SkipsDiscussionMode(t *testing.T) {
+	t.Parallel()
+
+	actions := buildNextStepActions("https://platform.codex-k8s.dev", nextstepdomain.DefaultLabels(), runContext{}, commentState{
+		RepositoryFullName: "codex-k8s/codex-k8s",
+		IssueNumber:        298,
+		TriggerKind:        triggerKindDiscussion,
+		TriggerLabel:       "mode:discussion",
+		DiscussionMode:     true,
+	})
+	if len(actions) != 0 {
+		t.Fatalf("expected no next-step actions for discussion run, got %#v", actions)
+	}
+}

--- a/services/internal/control-plane/internal/domain/runstatus/render.go
+++ b/services/internal/control-plane/internal/domain/runstatus/render.go
@@ -128,8 +128,8 @@ func buildCommentTemplateContext(state commentState, managementURL string, marke
 
 	return commentTemplateContext{
 		RunID:                        strings.TrimSpace(state.RunID),
-		TriggerKindDisplay:           resolveTriggerKindDisplay(trimmedTriggerKind, state.TriggerLabel),
-		WorkloadKind:                 resolveWorkloadKind(trimmedTriggerKind, state.TriggerLabel),
+		TriggerKindDisplay:           resolveTriggerKindDisplay(trimmedTriggerKind, state.TriggerLabel, state.DiscussionMode),
+		WorkloadKind:                 resolveWorkloadKind(trimmedTriggerKind, state.TriggerLabel, state.DiscussionMode),
 		RuntimeMode:                  trimmedRuntimeMode,
 		JobName:                      trimmedJobName,
 		JobNamespace:                 trimmedJobNamespace,
@@ -146,7 +146,7 @@ func buildCommentTemplateContext(state commentState, managementURL string, marke
 		NextStepActions:              templateActions,
 		ManagementURL:                managementURL,
 		StateMarker:                  marker,
-		ShowTriggerKind:              resolveTriggerKindDisplay(trimmedTriggerKind, state.TriggerLabel) != "",
+		ShowTriggerKind:              resolveTriggerKindDisplay(trimmedTriggerKind, state.TriggerLabel, state.DiscussionMode) != "",
 		ShowRuntimeMode:              trimmedRuntimeMode != "",
 		ShowJobRef:                   trimmedJobName != "" && trimmedJobNamespace != "",
 		ShowNamespace:                trimmedNamespace != "",

--- a/services/internal/control-plane/internal/domain/runstatus/service.go
+++ b/services/internal/control-plane/internal/domain/runstatus/service.go
@@ -95,6 +95,8 @@ func (s *Service) UpsertRunStatusComment(ctx context.Context, params UpsertComme
 	if runCtx.payload.Trigger != nil {
 		triggerLabel = strings.TrimSpace(runCtx.payload.Trigger.Label)
 	}
+	discussionMode := runCtx.payload.DiscussionMode || isDiscussionTriggerLabel(triggerLabel)
+	effectiveCommentTriggerKind := resolveCommentTriggerKind(effectiveTriggerKind, triggerLabel, discussionMode)
 
 	currentState := commentState{
 		RunID:                    runID,
@@ -102,10 +104,11 @@ func (s *Service) UpsertRunStatusComment(ctx context.Context, params UpsertComme
 		RepositoryFullName:       strings.TrimSpace(runCtx.payload.Repository.FullName),
 		JobName:                  strings.TrimSpace(params.JobName),
 		JobNamespace:             strings.TrimSpace(params.JobNamespace),
-		RuntimeMode:              normalizeRuntimeMode(params.RuntimeMode, effectiveTriggerKind),
+		RuntimeMode:              normalizeRuntimeMode(params.RuntimeMode, effectiveCommentTriggerKind),
 		Namespace:                strings.TrimSpace(params.Namespace),
-		TriggerKind:              effectiveTriggerKind,
+		TriggerKind:              effectiveCommentTriggerKind,
 		TriggerLabel:             triggerLabel,
+		DiscussionMode:           discussionMode,
 		PromptLocale:             normalizeLocale(params.PromptLocale, s.cfg.DefaultLocale),
 		Model:                    strings.TrimSpace(params.Model),
 		ReasoningEffort:          strings.TrimSpace(params.ReasoningEffort),

--- a/services/internal/control-plane/internal/domain/runstatus/service_upsert_test.go
+++ b/services/internal/control-plane/internal/domain/runstatus/service_upsert_test.go
@@ -3,11 +3,13 @@ package runstatus
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/codex-k8s/codex-k8s/libs/go/crypto/tokencrypt"
 	floweventdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/flowevent"
 	mcpdomain "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/mcp"
+	nextstepdomain "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/nextstep"
 	agentrunrepo "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/repository/agentrun"
 	platformtokenrepo "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/repository/platformtoken"
 	staffrunrepo "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/repository/staffrun"
@@ -148,6 +150,107 @@ func TestUpsertRunStatusComment_MergesTrackedCommentStateBeforeFallbackEdit(t *t
 	}
 }
 
+func TestUpsertRunStatusComment_DiscussionRunUsesDiscussionMarkerAndSkipsDevNextSteps(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tokenCrypt, err := tokencrypt.NewService("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+	if err != nil {
+		t.Fatalf("tokencrypt.NewService: %v", err)
+	}
+	botTokenEncrypted, err := tokenCrypt.EncryptString("bot-token")
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+
+	runPayload, err := json.Marshal(querytypes.RunPayload{
+		DiscussionMode: true,
+		Repository:     querytypes.RunPayloadRepository{FullName: "codex-k8s/codex-k8s"},
+		Issue:          &querytypes.RunPayloadIssue{Number: 298, HTMLURL: "https://github.com/codex-k8s/codex-k8s/issues/298"},
+		Trigger: &querytypes.RunPayloadTrigger{
+			Source: triggerSourceIssueLabel,
+			Label:  "mode:discussion",
+			Kind:   triggerKindDev,
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(runPayload): %v", err)
+	}
+
+	github := &runstatusTestGitHub{
+		listIssueCommentsFunc: func(context.Context, mcpdomain.GitHubListIssueCommentsParams) ([]mcpdomain.GitHubIssueComment, error) {
+			return nil, nil
+		},
+		createIssueCommentFunc: func(_ context.Context, params mcpdomain.GitHubCreateIssueCommentParams) (mcpdomain.GitHubIssueComment, error) {
+			return mcpdomain.GitHubIssueComment{
+				ID:   501,
+				Body: params.Body,
+				URL:  "https://github.com/codex-k8s/codex-k8s/issues/298#issuecomment-501",
+			}, nil
+		},
+	}
+
+	service, err := NewService(Config{
+		PublicBaseURL:  "https://platform.codex-k8s.dev",
+		DefaultLocale:  localeRU,
+		NextStepLabels: nextstepdomain.DefaultLabels(),
+	}, Dependencies{
+		Runs: &runstatusTestRunsRepository{
+			run: agentrunrepo.Run{
+				ID:            "run-discussion",
+				CorrelationID: "corr-discussion",
+				RunPayload:    runPayload,
+			},
+		},
+		Platform: &runstatusTestPlatformTokenRepository{
+			item: platformtokenrepo.PlatformGitHubTokens{BotTokenEncrypted: botTokenEncrypted},
+		},
+		TokenCrypt: tokenCrypt,
+		GitHub:     github,
+		Kubernetes: runstatusTestKubernetesClient{},
+		StaffRuns:  &runstatusTestStaffRunsRepository{},
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	result, err := service.UpsertRunStatusComment(ctx, UpsertCommentParams{
+		RunID:        "run-discussion",
+		Phase:        PhaseAuthRequired,
+		PromptLocale: localeRU,
+		RunStatus:    "running",
+	})
+	if err != nil {
+		t.Fatalf("UpsertRunStatusComment: %v", err)
+	}
+	if result.CommentID != 501 {
+		t.Fatalf("unexpected comment id: got %d want 501", result.CommentID)
+	}
+	if github.lastCreatedBody == "" {
+		t.Fatal("expected CreateIssueComment body to be captured")
+	}
+	if strings.Contains(github.lastCreatedBody, "run:dev:revise") {
+		t.Fatalf("discussion comment must not suggest dev revise next steps: %q", github.lastCreatedBody)
+	}
+	if strings.Contains(github.lastCreatedBody, "Runtime mode: `full-env`") {
+		t.Fatalf("discussion comment must not fall back to full-env: %q", github.lastCreatedBody)
+	}
+
+	state, ok := extractStateMarker(github.lastCreatedBody)
+	if !ok {
+		t.Fatalf("created comment body does not contain state marker: %q", github.lastCreatedBody)
+	}
+	if state.TriggerKind != triggerKindDiscussion {
+		t.Fatalf("expected trigger kind %q, got %q", triggerKindDiscussion, state.TriggerKind)
+	}
+	if !state.DiscussionMode {
+		t.Fatal("expected discussion_mode=true in state marker")
+	}
+	if state.RuntimeMode != runtimeModeCode {
+		t.Fatalf("expected runtime mode %q, got %q", runtimeModeCode, state.RuntimeMode)
+	}
+}
+
 type runstatusTestRunsRepository struct {
 	run agentrunrepo.Run
 }
@@ -267,6 +370,7 @@ type runstatusTestGitHub struct {
 	getIssueCommentCalls  int
 	editIssueCommentCalls int
 	lastEditedBody        string
+	lastCreatedBody       string
 }
 
 func (g *runstatusTestGitHub) ListIssueComments(ctx context.Context, params mcpdomain.GitHubListIssueCommentsParams) ([]mcpdomain.GitHubIssueComment, error) {
@@ -285,6 +389,7 @@ func (g *runstatusTestGitHub) GetIssueComment(ctx context.Context, params mcpdom
 }
 
 func (g *runstatusTestGitHub) CreateIssueComment(ctx context.Context, params mcpdomain.GitHubCreateIssueCommentParams) (mcpdomain.GitHubIssueComment, error) {
+	g.lastCreatedBody = params.Body
 	if g.createIssueCommentFunc == nil {
 		return mcpdomain.GitHubIssueComment{}, nil
 	}

--- a/services/internal/control-plane/internal/domain/types/query/run_payload.go
+++ b/services/internal/control-plane/internal/domain/types/query/run_payload.go
@@ -2,13 +2,14 @@ package query
 
 // RunPayload represents normalized run payload persisted in agent_runs.
 type RunPayload struct {
-	Project     RunPayloadProject      `json:"project"`
-	Repository  RunPayloadRepository   `json:"repository"`
-	Agent       *RunPayloadAgent       `json:"agent,omitempty"`
-	Issue       *RunPayloadIssue       `json:"issue,omitempty"`
-	PullRequest *RunPayloadPullRequest `json:"pull_request,omitempty"`
-	Trigger     *RunPayloadTrigger     `json:"trigger,omitempty"`
-	Runtime     *RunPayloadRuntime     `json:"runtime,omitempty"`
+	DiscussionMode bool                   `json:"discussion_mode,omitempty"`
+	Project        RunPayloadProject      `json:"project"`
+	Repository     RunPayloadRepository   `json:"repository"`
+	Agent          *RunPayloadAgent       `json:"agent,omitempty"`
+	Issue          *RunPayloadIssue       `json:"issue,omitempty"`
+	PullRequest    *RunPayloadPullRequest `json:"pull_request,omitempty"`
+	Trigger        *RunPayloadTrigger     `json:"trigger,omitempty"`
+	Runtime        *RunPayloadRuntime     `json:"runtime,omitempty"`
 }
 
 // RunPayloadProject is project section of run payload.

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/repository_queries_test.go
@@ -25,3 +25,26 @@ func TestRunListQueriesIncludeDiscussionAndReviewerTriggerLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestRunQueriesNormalizeDiscussionTriggerKind(t *testing.T) {
+	t.Parallel()
+
+	queries := map[string]string{
+		"list_all":            queryListAll,
+		"list_for_user":       queryListForUser,
+		"list_jobs_all":       queryListJobsAll,
+		"list_jobs_for_user":  queryListJobsForUser,
+		"list_waits_all":      queryListWaitsAll,
+		"list_waits_for_user": queryListWaitsForUser,
+		"get_by_id":           queryGetByID,
+	}
+
+	for name, query := range queries {
+		if !strings.Contains(query, "discussion_mode") {
+			t.Fatalf("%s query must inspect discussion_mode payload flag", name)
+		}
+		if !strings.Contains(query, "THEN 'discussion'") {
+			t.Fatalf("%s query must normalize trigger_kind to discussion", name)
+		}
+	}
+}

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/get_by_id.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/get_by_id.sql
@@ -16,7 +16,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_all.sql
@@ -16,7 +16,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_for_user.sql
@@ -15,7 +15,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_jobs_all.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_jobs_all.sql
@@ -11,7 +11,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,
@@ -100,7 +105,15 @@ LEFT JOIN LATERAL (
 ) ws ON true
 WHERE COALESCE(rt.job_name, '') <> ''
   AND ar.status = COALESCE(NULLIF($3::text, ''), 'running')
-  AND ($2::text = '' OR COALESCE(ar.run_payload->'trigger'->>'kind', '') = $2::text)
+  AND (
+        $2::text = ''
+        OR CASE
+            WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+                OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+                THEN 'discussion'
+            ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+        END = $2::text
+      )
   AND ($4::text = '' OR COALESCE(ws.agent_key, '') = $4::text)
 ORDER BY ar.created_at DESC
 LIMIT $1;

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_jobs_for_user.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_jobs_for_user.sql
@@ -11,7 +11,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,
@@ -103,7 +108,15 @@ WHERE pm.user_id = $1::uuid
   AND ar.project_id IS NOT NULL
   AND COALESCE(rt.job_name, '') <> ''
   AND ar.status = COALESCE(NULLIF($4::text, ''), 'running')
-  AND ($3::text = '' OR COALESCE(ar.run_payload->'trigger'->>'kind', '') = $3::text)
+  AND (
+        $3::text = ''
+        OR CASE
+            WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+                OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+                THEN 'discussion'
+            ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+        END = $3::text
+      )
   AND ($5::text = '' OR COALESCE(ws.agent_key, '') = $5::text)
 ORDER BY ar.created_at DESC
 LIMIT $2;

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_waits_all.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_waits_all.sql
@@ -11,7 +11,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,
@@ -100,7 +105,15 @@ LEFT JOIN LATERAL (
 ) ws ON true
 WHERE COALESCE(ws.wait_state, '') <> ''
   AND ar.status = COALESCE(NULLIF($3::text, ''), 'running')
-  AND ($2::text = '' OR COALESCE(ar.run_payload->'trigger'->>'kind', '') = $2::text)
+  AND (
+        $2::text = ''
+        OR CASE
+            WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+                OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+                THEN 'discussion'
+            ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+        END = $2::text
+      )
   AND ($4::text = '' OR COALESCE(ws.agent_key, '') = $4::text)
   AND ($5::text = '' OR COALESCE(ws.wait_state, '') = $5::text)
 ORDER BY ar.created_at DESC

--- a/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_waits_for_user.sql
+++ b/services/internal/control-plane/internal/repository/postgres/staffrun/sql/list_waits_for_user.sql
@@ -11,7 +11,12 @@ SELECT
         ELSE NULL
     END AS issue_number,
     COALESCE(ar.run_payload->'issue'->>'html_url', '') AS issue_url,
-    COALESCE(ar.run_payload->'trigger'->>'kind', '') AS trigger_kind,
+    CASE
+        WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+            OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+            THEN 'discussion'
+        ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+    END AS trigger_kind,
     COALESCE(ar.run_payload->'trigger'->>'label', '') AS trigger_label,
     COALESCE(ws.agent_key, '') AS agent_key,
     COALESCE(rt.job_name, '') AS job_name,
@@ -103,7 +108,15 @@ WHERE pm.user_id = $1::uuid
   AND ar.project_id IS NOT NULL
   AND COALESCE(ws.wait_state, '') <> ''
   AND ar.status = COALESCE(NULLIF($4::text, ''), 'running')
-  AND ($3::text = '' OR COALESCE(ar.run_payload->'trigger'->>'kind', '') = $3::text)
+  AND (
+        $3::text = ''
+        OR CASE
+            WHEN COALESCE(ar.run_payload->>'discussion_mode', '') = 'true'
+                OR COALESCE(ar.run_payload->'trigger'->>'label', '') = 'mode:discussion'
+                THEN 'discussion'
+            ELSE COALESCE(ar.run_payload->'trigger'->>'kind', '')
+        END = $3::text
+      )
   AND ($5::text = '' OR COALESCE(ws.agent_key, '') = $5::text)
   AND ($6::text = '' OR COALESCE(ws.wait_state, '') = $6::text)
 ORDER BY ar.created_at DESC


### PR DESCRIPTION
## Контекст
- Issue: #298.
- Ветка: `codex/issue-298`.
- Репозиторий: `codex-k8s/codex-k8s`.
- Цель: убрать расхождение между реальным `mode:discussion` run (`discussion` + `code-only`) и тем, что показывают GitHub service-comment и staff UI.

## Основание для изменений
- В `runstatus` discussion-run наследовал raw `trigger_kind=dev`, из-за чего status payload и next-step matrix продолжали вести себя как обычный `run:dev` flow.
- При upsert без явного `runtime_mode` discussion-run мог fallback'нуться в `full-env`, хотя реальный runtime уже был `code-only`.
- Staff run queries отдавали raw `trigger_kind` из payload, поэтому UI продолжал показывать `dev` вместо `discussion`.

## Основной смысл правок
- Ввести effective trigger для discussion-run на уровне run-status payload.
- Убрать misleading next-step matrix обычного dev-flow для discussion-run.
- Нормализовать `trigger_kind` в staff queries, чтобы UI и GitHub показывали один и тот же discussion-контекст.

## Что сделано
- В `services/internal/control-plane/internal/domain/runstatus/*` добавил effective `discussion` trigger для comment state, явный `discussion_mode` marker и code-only fallback вместо `full-env` для discussion-run.
- В `services/internal/control-plane/internal/domain/runstatus/next_step_actions.go` отключил dev/revise next-step matrix для discussion-run.
- В `services/internal/control-plane/internal/repository/postgres/staffrun/sql/*.sql` нормализовал `trigger_kind` к `discussion` по `discussion_mode`/`mode:discussion` и синхронно обновил SQL-фильтры для jobs/waits.
- В `services/internal/control-plane/internal/domain/types/query/run_payload.go` добавил typed `discussion_mode` в query payload.
- Добавил regression tests на discussion marker/runtime/next-steps и на SQL normalization для staffrun.

## Логи и runtime-диагностика
- `gh api repos/codex-k8s/codex-k8s/issues/298/comments --paginate --jq '.[] | {user: .user.login, body: .body, id: .id, created_at: .created_at}'` — использовал для проверки текущего формата GitHub service-comment.
- `kubectl` и runtime-логи namespace не запрашивал: для фикса было достаточно unit/integration тестов доменного слоя и SQL-репозитория.

## БД и миграции
- Миграции не требовались.
- Схема БД не менялась.
- Изменения ограничены чтением существующего `run_payload` (`discussion_mode` / `trigger.label`) в SQL queries и доменном рендере status comment.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runstatus ./services/internal/control-plane/internal/repository/postgres/staffrun` — passed.
- `go test ./services/internal/control-plane/internal/domain/webhook` — passed.
- `go mod tidy` — completed, diff in `go.mod`/`go.sum` не появился.
- `make lint-go` — passed.
- `make dupl-go` — passed.

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты проверены, нарушений не осталось.
- `docs/design-guidelines/go/check_list.md` — релевантные пункты проверены, нарушений не осталось.
- `docs/design-guidelines/vue/check_list.md` — не требуется, Vue-код не менялся.

## Риски и ограничения
- Нормализация UI опирается на persisted `discussion_mode` и fallback по label `mode:discussion`; legacy run без этих признаков останется с raw `trigger_kind`.
- Поведение проверено unit/integration тестами в control-plane; отдельный live smoke discussion-run в Kubernetes не выполнял.

## Рекомендации / следующий шаг
- После merge прогнать smoke-сценарий из issue: поставить `mode:discussion`, добавить human comment и проверить, что GitHub comment и staff UI показывают `discussion`/`code-only` без dev next-steps.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/298
