### PR TITLE
Issue #343: исключить разрушение hot-reload артефактов в full-env слотах (#343)

### DIFF
--- a/services/jobs/agent-runner/README.md
+++ b/services/jobs/agent-runner/README.md
@@ -11,6 +11,13 @@ Prompt seed policy:
   - `role-<agent_key>-<kind>_<locale>.md` / `role-<agent_key>-<kind>.md`;
 - fallback chain: `stage+role -> role -> stage -> dev -> default -> embedded runner template`.
 
+## Full-env repo cache
+
+В `full-env` runner работает поверх общего repo-cache PVC namespace и перед запуском только
+сбрасывает tracked-файлы и не-ignored untracked файлы. Ignored runtime-артефакты hot-reload
+сервисов (например `services/staff/web-console/node_modules/`) сохраняются, чтобы dev-slot не
+ломал live Vite/CompileDaemon окружение во время branch reset.
+
 ```text
 services/jobs/agent-runner/                          runtime исполнитель агентных запусков
 ├── README.md                                        карта структуры сервиса и run-пайплайна

--- a/services/jobs/agent-runner/internal/runner/helpers_run_context.go
+++ b/services/jobs/agent-runner/internal/runner/helpers_run_context.go
@@ -18,6 +18,15 @@ func normalizeRuntimeMode(value string) string {
 	return runtimeModeCodeOnly
 }
 
+func gitCleanArgs(runtimeMode string) []string {
+	if normalizeRuntimeMode(runtimeMode) == runtimeModeFullEnv {
+		// Full-env runner shares repo-cache PVC with hot-reload services, so ignored runtime
+		// artifacts (for example web-console `node_modules/`) must survive branch resets.
+		return []string{"clean", "-fd"}
+	}
+	return []string{"clean", "-fdx"}
+}
+
 func normalizeTemplateKind(value string, triggerKind string) string {
 	if strings.EqualFold(strings.TrimSpace(value), promptTemplateKindDiscussion) {
 		return promptTemplateKindDiscussion

--- a/services/jobs/agent-runner/internal/runner/helpers_run_context_test.go
+++ b/services/jobs/agent-runner/internal/runner/helpers_run_context_test.go
@@ -1,0 +1,26 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGitCleanArgs(t *testing.T) {
+	t.Run("full-env preserves ignored runtime artifacts", func(t *testing.T) {
+		if got, want := gitCleanArgs(runtimeModeFullEnv), []string{"clean", "-fd"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("gitCleanArgs(full-env) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("code-only keeps hard cleanup", func(t *testing.T) {
+		if got, want := gitCleanArgs(runtimeModeCodeOnly), []string{"clean", "-fdx"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("gitCleanArgs(code-only) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unknown mode defaults to code-only cleanup", func(t *testing.T) {
+		if got, want := gitCleanArgs("unexpected"), []string{"clean", "-fdx"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("gitCleanArgs(unexpected) = %v, want %v", got, want)
+		}
+	})
+}

--- a/services/jobs/agent-runner/internal/runner/service.go
+++ b/services/jobs/agent-runner/internal/runner/service.go
@@ -531,7 +531,7 @@ func (s *Service) prepareRepository(ctx context.Context, result runResult, state
 	if err := runCommandQuiet(ctx, state.repoDir, "git", "reset", "--hard"); err != nil {
 		return fmt.Errorf("git reset failed")
 	}
-	if err := runCommandQuiet(ctx, state.repoDir, "git", "clean", "-fdx"); err != nil {
+	if err := runCommandQuiet(ctx, state.repoDir, "git", gitCleanArgs(s.cfg.RuntimeMode)...); err != nil {
 		return fmt.Errorf("git clean failed")
 	}
 


### PR DESCRIPTION
## Контекст
- Issue: https://github.com/codex-k8s/codex-k8s/issues/343
- Воспроизводимый симптом из issue: full-env dev-slot открывает пустую staff UI страницу, а браузер получает ошибки загрузки Vite-модулей (`404/504`).
- Прямой доступ к namespace `codex-k8s-dev-1` из текущего run не разрешён RBAC, поэтому root cause воспроизведён и подтверждён в собственном full-env namespace `codex-k8s-dev-3` с тем же стеком (`api-gateway` + `web-console` + shared repo-cache PVC).

## Основание для изменений
- `agent-runner` в `full-env` перед стартом сессии выполнял `git reset --hard && git clean -fdx` по общему `/workspace`.
- Для dev-slot это общий repo-cache PVC, из которого live `web-console` читает исходники и `node_modules` для Vite hot-reload.
- `git clean -fdx` удалял ignored runtime-артефакты (`services/staff/web-console/node_modules/`, `node_modules/.vite/**`), после чего `api-gateway` продолжал отдавать `src/main.ts`, но optimized deps падали с `504`, а в логах Vite появлялись ошибки про отсутствующие CSS и `.vite/deps/*`.

## Основной смысл правок
- В `full-env` runner сохраняет ignored runtime-артефакты на общем PVC и очищает только tracked-файлы и не-ignored untracked-файлы.
- В `code-only` режимах жёсткая очистка `git clean -fdx` сохранена без изменения.

## Что сделано
- В `services/jobs/agent-runner/internal/runner/helpers_run_context.go` добавлен `gitCleanArgs(runtimeMode)`, который для `full-env` выбирает `git clean -fd`, а для остальных режимов оставляет `git clean -fdx`.
- В `services/jobs/agent-runner/internal/runner/service.go` `prepareRepository` переведён на runtime-aware стратегию очистки.
- В `services/jobs/agent-runner/internal/runner/helpers_run_context_test.go` добавлены unit-тесты на full-env/code-only/unknown runtime mode.
- В `services/jobs/agent-runner/README.md` зафиксировано поведение общего repo-cache PVC в `full-env` и причина сохранения ignored runtime-артефактов.

## Логи и runtime-диагностика
- `kubectl -n codex-k8s-dev-3 get deploy,pod,svc,ingress -o wide`: подтверждён живой full-env стек (`codex-k8s`, `codex-k8s-web-console`, `codex-k8s-control-plane`, `codex-k8s-worker`).
- `curl -H "Host: codex-k8s-dev-3.ai.platform.codex-k8s.dev" http://codex-k8s/src/main.ts`: gateway отдавал Vite-transformed imports на `/node_modules/.vite/deps/vue.js?v=3931ac16`, `/pinia.js`, `/vue3-cookies.js`.
- `curl -H "Host: codex-k8s-dev-3.ai.platform.codex-k8s.dev" http://codex-k8s/node_modules/.vite/deps/vue.js?v=3931ac16`: получен `504 Gateway Timeout`.
- `kubectl -n codex-k8s-dev-3 logs deploy/codex-k8s-web-console --tail=200`: Vite логировал `Failed to load url /node_modules/vuetify/lib/styles/main.css`, `Failed to load url /node_modules/@mdi/font/css/materialdesignicons.css` и отсутствие `/workspace/services/staff/web-console/node_modules/.vite/deps/vue.js`.
- `kubectl -n codex-k8s-dev-3 exec <web-console-pod> -- ls`: подтверждено отсутствие `/workspace/services/staff/web-console/node_modules` после старта runner-а.

## БД и миграции
- Изменений БД нет.
- Миграции не добавлялись.

## Проверки
- `go test ./services/jobs/agent-runner/internal/runner/...` — passed.
- `go mod tidy` — passed, изменений `go.mod`/`go.sum` не осталось.
- `make lint-go` — passed.
- `make dupl-go` — passed.
- `git diff --check` — passed.

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` — выполнен, релевантные пункты для Go/job-сервиса и PR-flow соблюдены.
- `docs/design-guidelines/go/check_list.md` — выполнен, релевантные пункты для `agent-runner` соблюдены.
- `docs/design-guidelines/vue/check_list.md` — не требуется, production Vue-код не менялся.

## Риски и ограничения
- В `full-env` теперь сохраняются ignored runtime-артефакты общего PVC; если в ветке меняется lockfile/frontend dependency graph, для полного выравнивания всё ещё может потребоваться redeploy слота или явный `npm ci` в pod `web-console`.
- Из-за RBAC текущего run не было прямого `kubectl`-доступа к namespace `codex-k8s-dev-1`; root cause подтверждён на собственном namespace с тем же runtime-контуром и идентичным симптомом `504` на Vite deps.

## Рекомендации / следующий шаг
- После merge запустить новый `run:dev`/`run:dev:revise` и повторно проверить slot URL через browser smoke, чтобы убедиться, что `git clean` больше не выносит `node_modules` live `web-console`.
- Если понадобится дополнительная страховка, следующим шагом можно добавить automated smoke check на Vite deps path в full-env regression bundle.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/343
