### PR TITLE
fix: remove runs polling and harden realtime websocket

### DIFF
--- a/services/external/api-gateway/internal/transport/http/models/realtime.go
+++ b/services/external/api-gateway/internal/transport/http/models/realtime.go
@@ -31,11 +31,13 @@ const (
 
 // RunsRealtimeMessage is a typed websocket message for the paginated runs list.
 type RunsRealtimeMessage struct {
-	Type       ListRealtimeMessageType `json:"type"`
-	Items      []Run                   `json:"items,omitempty"`
-	Pagination *Pagination             `json:"pagination,omitempty"`
-	Message    *string                 `json:"message,omitempty"`
-	SentAt     string                  `json:"sent_at"`
+	Type                  ListRealtimeMessageType `json:"type"`
+	Items                 []Run                   `json:"items,omitempty"`
+	Pagination            *Pagination             `json:"pagination,omitempty"`
+	WaitQueueCount        *int                    `json:"wait_queue_count,omitempty"`
+	PendingApprovalsCount *int                    `json:"pending_approvals_count,omitempty"`
+	Message               *string                 `json:"message,omitempty"`
+	SentAt                string                  `json:"sent_at"`
 }
 
 // RuntimeDeployTasksRealtimeMessage is a typed websocket message for the paginated runtime deploy tasks list.

--- a/services/external/api-gateway/internal/transport/http/staff_list_realtime_handler.go
+++ b/services/external/api-gateway/internal/transport/http/staff_list_realtime_handler.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -15,6 +16,7 @@ import (
 const (
 	staffListRealtimeDefaultPage     = 1
 	staffListRealtimeDefaultPageSize = 20
+	staffRunsRealtimeCardsLimit      = 20
 )
 
 type listRealtimeKind string
@@ -44,7 +46,12 @@ type paginatedRealtimeResponse[ProtoItem any] interface {
 	GetTotalCount() int32
 }
 
-type runsListRealtimeSnapshot = paginatedRealtimeSnapshot[models.Run]
+type runsListRealtimeSnapshot struct {
+	Items                 []models.Run
+	Pagination            models.Pagination
+	WaitQueueCount        *int
+	PendingApprovalsCount *int
+}
 type runtimeDeployTasksRealtimeSnapshot = paginatedRealtimeSnapshot[models.RuntimeDeployTaskListItem]
 
 // RunsRealtime opens an authenticated websocket stream for the paginated runs table.
@@ -65,8 +72,8 @@ func (h *staffHandler) streamListRealtime(c *echo.Context, kind listRealtimeKind
 			c,
 			resolveRunListPage(staffListRealtimeDefaultPage, staffListRealtimeDefaultPageSize),
 			(*staffHandler).fetchRunsRealtimeSnapshot,
-			func(snapshot runsListRealtimeSnapshot) any { return newListRealtimeSnapshotMessage(snapshot) },
-			func(err error) any { return newListRealtimeErrorMessage[models.Run](err) },
+			func(snapshot runsListRealtimeSnapshot) any { return newRunsRealtimeSnapshotMessage(snapshot) },
+			func(err error) any { return newRunsRealtimeErrorMessage(err) },
 		)
 	case listRealtimeRuntimeDeployTasks:
 		return streamResolvedRealtime(
@@ -184,7 +191,45 @@ func streamRealtimeSnapshots[Snapshot any](
 }
 
 func (h *staffHandler) fetchRunsRealtimeSnapshot(ctx context.Context, principal *controlplanev1.Principal, arg runListPageArg) (runsListRealtimeSnapshot, error) {
-	return fetchPaginatedRealtimeSnapshot(ctx, principal, arg, h.listRunsCall, casters.Runs)
+	resp, err := h.listRunsCall(ctx, principal, arg)
+	if err != nil {
+		return runsListRealtimeSnapshot{}, err
+	}
+
+	snapshot := runsListRealtimeSnapshot{
+		Items:      casters.Runs(resp.GetItems()),
+		Pagination: newPagination(resp.GetPage(), resp.GetPageSize(), resp.GetTotalCount()),
+	}
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+	var waitQueueCount *int
+	var pendingApprovalsCount *int
+
+	go func() {
+		defer wait.Done()
+		waitsResp, listErr := h.listRunWaitsCall(ctx, principal, runListFilterArg{limit: staffRunsRealtimeCardsLimit})
+		if listErr != nil {
+			return
+		}
+		count := len(waitsResp.GetItems())
+		waitQueueCount = &count
+	}()
+
+	go func() {
+		defer wait.Done()
+		approvalsResp, listErr := h.listPendingApprovalsCall(ctx, principal, staffRunsRealtimeCardsLimit)
+		if listErr != nil {
+			return
+		}
+		count := len(approvalsResp.GetItems())
+		pendingApprovalsCount = &count
+	}()
+
+	wait.Wait()
+	snapshot.WaitQueueCount = waitQueueCount
+	snapshot.PendingApprovalsCount = pendingApprovalsCount
+	return snapshot, nil
 }
 
 func (h *staffHandler) fetchRuntimeDeployTasksRealtimeSnapshot(ctx context.Context, principal *controlplanev1.Principal, arg runtimeDeployListArg) (runtimeDeployTasksRealtimeSnapshot, error) {
@@ -208,6 +253,25 @@ func newListRealtimeErrorMessage[T any](err error) listRealtimeMessage[T] {
 	}
 }
 
+func newRunsRealtimeSnapshotMessage(snapshot runsListRealtimeSnapshot) models.RunsRealtimeMessage {
+	return models.RunsRealtimeMessage{
+		Type:                  models.ListRealtimeMessageTypeSnapshot,
+		Items:                 snapshot.Items,
+		Pagination:            &snapshot.Pagination,
+		WaitQueueCount:        snapshot.WaitQueueCount,
+		PendingApprovalsCount: snapshot.PendingApprovalsCount,
+		SentAt:                realtimeSentAt(),
+	}
+}
+
+func newRunsRealtimeErrorMessage(err error) models.RunsRealtimeMessage {
+	return models.RunsRealtimeMessage{
+		Type:    models.ListRealtimeMessageTypeError,
+		Message: realtimeErrorMessagePtr(err),
+		SentAt:  realtimeSentAt(),
+	}
+}
+
 func realtimeErrorMessagePtr(err error) *string {
 	text := realtimeErrorText(err)
 	return &text
@@ -219,12 +283,16 @@ func realtimeSentAt() string {
 
 func newPaginatedRealtimeSnapshot[T any](items []T, page int32, pageSize int32, totalCount int32) paginatedRealtimeSnapshot[T] {
 	return paginatedRealtimeSnapshot[T]{
-		Items: items,
-		Pagination: models.Pagination{
-			Page:       int(page),
-			PageSize:   int(pageSize),
-			TotalCount: int(totalCount),
-		},
+		Items:      items,
+		Pagination: newPagination(page, pageSize, totalCount),
+	}
+}
+
+func newPagination(page int32, pageSize int32, totalCount int32) models.Pagination {
+	return models.Pagination{
+		Page:       int(page),
+		PageSize:   int(pageSize),
+		TotalCount: int(totalCount),
 	}
 }
 

--- a/services/staff/web-console/src/features/runs/list-realtime.ts
+++ b/services/staff/web-console/src/features/runs/list-realtime.ts
@@ -50,6 +50,12 @@ function parseRunsRealtimeMessage(raw: string): RunsRealtimeMessage | null {
       type,
       items: Array.isArray(payload.items) ? payload.items : undefined,
       pagination: parsePagination(payload.pagination),
+      wait_queue_count: Number.isFinite(Number(payload.wait_queue_count))
+        ? Math.max(0, Math.trunc(Number(payload.wait_queue_count)))
+        : undefined,
+      pending_approvals_count: Number.isFinite(Number(payload.pending_approvals_count))
+        ? Math.max(0, Math.trunc(Number(payload.pending_approvals_count)))
+        : undefined,
       message: typeof payload.message === "string" ? payload.message : undefined,
       sent_at: String(payload.sent_at || new Date().toISOString()),
     };

--- a/services/staff/web-console/src/features/runs/types.ts
+++ b/services/staff/web-console/src/features/runs/types.ts
@@ -39,6 +39,8 @@ export type RunsRealtimeMessage = {
   type: RunsRealtimeMessageType;
   items?: Run[];
   pagination?: RealtimePagination;
+  wait_queue_count?: number;
+  pending_approvals_count?: number;
   message?: string;
   sent_at: string;
 };

--- a/services/staff/web-console/src/pages/RunsPage.vue
+++ b/services/staff/web-console/src/pages/RunsPage.vue
@@ -5,12 +5,6 @@
     <VAlert v-if="runsError" type="error" variant="tonal" class="mt-4">
       {{ t(runsError.messageKey) }}
     </VAlert>
-    <VAlert v-if="runs.error" type="error" variant="tonal" class="mt-4">
-      {{ t(runs.error.messageKey) }}
-    </VAlert>
-    <VAlert v-if="runs.approvalsError" type="error" variant="tonal" class="mt-4">
-      {{ t(runs.approvalsError.messageKey) }}
-    </VAlert>
 
     <VRow class="mt-4" density="compact">
       <VCol cols="12" md="4">
@@ -26,7 +20,7 @@
           <VCardText class="d-flex align-center justify-space-between ga-2 flex-wrap">
             <div>
               <div class="text-caption text-medium-emphasis">{{ t("pages.runs.waitQueue") }}</div>
-              <div class="text-h6 font-weight-bold">{{ runs.waitQueue.length }}</div>
+              <div class="text-h6 font-weight-bold">{{ waitQueueCount }}</div>
             </div>
             <VBtn size="small" variant="text" icon="mdi-open-in-new" :title="t('pages.runs.details')" :to="{ name: 'wait-queue' }" />
           </VCardText>
@@ -37,7 +31,7 @@
           <VCardText class="d-flex align-center justify-space-between ga-2 flex-wrap">
             <div>
               <div class="text-caption text-medium-emphasis">{{ t("pages.runs.pendingApprovals") }}</div>
-              <div class="text-h6 font-weight-bold">{{ runs.pendingApprovals.length }}</div>
+              <div class="text-h6 font-weight-bold">{{ pendingApprovalsCount }}</div>
             </div>
             <VBtn size="small" variant="text" icon="mdi-open-in-new" :title="t('pages.runs.details')" :to="{ name: 'approvals' }" />
           </VCardText>
@@ -135,7 +129,6 @@
 </template>
 
 <script setup lang="ts">
-// TODO(#19): Добавить table settings + row actions menu через общий DataTable wrapper и master-detail layout для Runs/Approvals.
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 import { useI18n } from "vue-i18n";
@@ -146,15 +139,15 @@ import { formatDateTime } from "../shared/lib/datetime";
 import { colorForRunStatus } from "../shared/lib/chips";
 import { bindRealtimePageLifecycle } from "../shared/ws/lifecycle";
 import { subscribeRunsRealtime } from "../features/runs/list-realtime";
-import { useRunsStore } from "../features/runs/store";
 import type { Run, RunsRealtimeMessage } from "../features/runs/types";
 
 const { t, locale } = useI18n({ useScope: "global" });
-const runs = useRunsStore();
 const loading = ref(true);
 const runsError = ref<ApiError | null>(null);
 const runItems = ref<Run[]>([]);
 const totalCount = ref(0);
+const waitQueueCount = ref(0);
+const pendingApprovalsCount = ref(0);
 const tablePage = ref(1);
 const itemsPerPage = ref(20);
 const stopRunsRealtimeRef = ref<(() => void) | null>(null);
@@ -172,13 +165,6 @@ const headers = [
   { title: "", key: "actions", sortable: false, width: 72, align: "end" },
 ] as const;
 
-async function refreshSidebarCards(): Promise<void> {
-  await Promise.all([
-    runs.loadRunWaits(20),
-    runs.loadPendingApprovals(20),
-  ]);
-}
-
 function applyRunsRealtimeMessage(message: RunsRealtimeMessage): void {
   if (message.type === "error") {
     runsError.value = new ApiError({ kind: "unknown", messageKey: "errors.unknown" });
@@ -187,6 +173,12 @@ function applyRunsRealtimeMessage(message: RunsRealtimeMessage): void {
   }
   if (!message.pagination) {
     return;
+  }
+  if (typeof message.wait_queue_count === "number") {
+    waitQueueCount.value = message.wait_queue_count;
+  }
+  if (typeof message.pending_approvals_count === "number") {
+    pendingApprovalsCount.value = message.pending_approvals_count;
   }
   const maxPage = Math.max(1, Math.ceil(message.pagination.total_count / message.pagination.page_size));
   if (tablePage.value > maxPage) {
@@ -231,12 +223,10 @@ function handlePageSuspend(): void {
 }
 
 function handlePageResume(): void {
-  void refreshSidebarCards();
   startRunsRealtime();
 }
 
 onMounted(() => {
-  void refreshSidebarCards();
   startRunsRealtime();
   stopLifecycleBindingRef.value = bindRealtimePageLifecycle({
     onResume: handlePageResume,

--- a/services/staff/web-console/src/pages/operations/RuntimeDeployTaskDetailsPage.vue
+++ b/services/staff/web-console/src/pages/operations/RuntimeDeployTaskDetailsPage.vue
@@ -208,7 +208,6 @@ const requestedAction = ref<"cancel" | "stop" | null>(null);
 const actionReason = ref("");
 const realtimeState = ref<RuntimeDeployRealtimeState>("connecting");
 const stopRealtimeRef = ref<(() => void) | null>(null);
-const fallbackPollTimer = ref<number | null>(null);
 const reloadPending = ref(false);
 const stopLifecycleBindingRef = ref<(() => void) | null>(null);
 
@@ -380,20 +379,6 @@ function goBack(): void {
   void router.push({ name: "runtime-deploy-tasks" });
 }
 
-function clearFallbackPolling(): void {
-  if (fallbackPollTimer.value !== null) {
-    window.clearInterval(fallbackPollTimer.value);
-    fallbackPollTimer.value = null;
-  }
-}
-
-function ensureFallbackPolling(): void {
-  if (fallbackPollTimer.value !== null) return;
-  fallbackPollTimer.value = window.setInterval(() => {
-    void loadTask();
-  }, 10000);
-}
-
 function stopRealtime(): void {
   stopRealtimeRef.value?.();
   stopRealtimeRef.value = null;
@@ -414,18 +399,12 @@ function startRealtime(): void {
     },
     onStateChange: (state) => {
       realtimeState.value = state;
-      if (state === "connected") {
-        clearFallbackPolling();
-        return;
-      }
-      ensureFallbackPolling();
     },
   });
 }
 
 function handlePageSuspend(): void {
   stopRealtime();
-  clearFallbackPolling();
 }
 
 function handlePageResume(): void {
@@ -445,14 +424,12 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   stopLifecycleBinding();
   stopRealtime();
-  clearFallbackPolling();
 });
 
 watch(
   () => props.runId,
   async (nextRunID, prevRunID) => {
     if (nextRunID === prevRunID) return;
-    clearFallbackPolling();
     await loadTask();
     startRealtime();
   },

--- a/services/staff/web-console/src/shared/ws/realtime-client.ts
+++ b/services/staff/web-console/src/shared/ws/realtime-client.ts
@@ -55,6 +55,13 @@ export function createRealtimeClient<TMessage>(config: RealtimeClientConfig<TMes
     }
   }
 
+  function detachSocketHandlers(target: WebSocket): void {
+    target.onopen = null;
+    target.onmessage = null;
+    target.onerror = null;
+    target.onclose = null;
+  }
+
   function armFirstMessageTimer(): void {
     const timeoutMs = config.firstMessageTimeoutMs;
     if (!active || hasReceivedMessage || firstMessageTimeoutNotified || !timeoutMs || timeoutMs <= 0) {
@@ -75,16 +82,28 @@ export function createRealtimeClient<TMessage>(config: RealtimeClientConfig<TMes
 
   function closeSocket(): void {
     if (!socket) return;
-    socket.onopen = null;
-    socket.onmessage = null;
-    socket.onerror = null;
-    socket.onclose = null;
+    const currentSocket = socket;
+    socket = null;
+    if (currentSocket.readyState === WebSocket.CONNECTING) {
+      currentSocket.onopen = () => {
+        detachSocketHandlers(currentSocket);
+        try {
+          currentSocket.close();
+        } catch {
+          // Ignore close errors.
+        }
+      };
+      currentSocket.onmessage = null;
+      currentSocket.onerror = null;
+      currentSocket.onclose = null;
+      return;
+    }
+    detachSocketHandlers(currentSocket);
     try {
-      socket.close();
+      currentSocket.close();
     } catch {
       // Ignore close errors.
     }
-    socket = null;
   }
 
   function scheduleReconnect(): void {
@@ -110,14 +129,21 @@ export function createRealtimeClient<TMessage>(config: RealtimeClientConfig<TMes
     closeSocket();
     notifyState(reconnectAttempt === 0 ? "connecting" : "reconnecting");
 
-    socket = new WebSocket(config.url);
+    const currentSocket = new WebSocket(config.url);
+    socket = currentSocket;
 
-    socket.onopen = () => {
+    currentSocket.onopen = () => {
+      if (socket !== currentSocket) {
+        return;
+      }
       reconnectAttempt = 0;
       notifyState("connected");
     };
 
-    socket.onmessage = (event: MessageEvent<string>) => {
+    currentSocket.onmessage = (event: MessageEvent<string>) => {
+      if (socket !== currentSocket) {
+        return;
+      }
       const parsed = config.parseMessage(String(event.data ?? ""));
       if (!parsed) return;
       hasReceivedMessage = true;
@@ -125,17 +151,24 @@ export function createRealtimeClient<TMessage>(config: RealtimeClientConfig<TMes
       config.onMessage(parsed);
     };
 
-    socket.onerror = () => {
-      if (!socket) return;
+    currentSocket.onerror = () => {
+      if (socket !== currentSocket) return;
+      if (currentSocket.readyState === WebSocket.CONNECTING) {
+        return;
+      }
       try {
-        socket.close();
+        currentSocket.close();
       } catch {
         // Ignore close errors.
       }
     };
 
-    socket.onclose = () => {
+    currentSocket.onclose = () => {
+      if (socket === currentSocket) {
+        socket = null;
+      }
       if (!active) return;
+      if (socket !== null) return;
       scheduleReconnect();
     };
   }


### PR DESCRIPTION
## Что сделано
- убран REST polling карточек wait queue и approvals на странице Runs
- данные для карточек Runs теперь приходят в websocket snapshot списка запусков
- исправлен lifecycle websocket-клиента при быстрой смене пагинации и переподписке
- убран fallback polling из деталей runtime deploy task

## Проверки
- `npm --prefix services/staff/web-console run build`
- `go test ./services/external/api-gateway/internal/transport/http/...`
- `git diff --check`

Closes #347