### PR TITLE
fix: retry runtime deploy when slot namespace is terminating

### DIFF
--- a/services/internal/control-plane/internal/clients/kubernetes/client.go
+++ b/services/internal/control-plane/internal/clients/kubernetes/client.go
@@ -284,8 +284,11 @@ func (c *Client) EnsureNamespace(ctx context.Context, namespace string) error {
 		return fmt.Errorf("namespace is required")
 	}
 
-	_, err := c.clientset.CoreV1().Namespaces().Get(ctx, targetNamespace, metav1.GetOptions{})
+	existing, err := c.clientset.CoreV1().Namespaces().Get(ctx, targetNamespace, metav1.GetOptions{})
 	if err == nil {
+		if existing.DeletionTimestamp != nil {
+			return fmt.Errorf("namespace %s is terminating", targetNamespace)
+		}
 		return nil
 	}
 	if !k8serrors.IsNotFound(err) {

--- a/services/internal/control-plane/internal/clients/kubernetes/client_test.go
+++ b/services/internal/control-plane/internal/clients/kubernetes/client_test.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestEnsureNamespace_FailsWhenNamespaceIsTerminating(t *testing.T) {
+	t.Parallel()
+
+	deletionTime := metav1.NewTime(time.Date(2026, 3, 12, 19, 39, 0, 0, time.UTC))
+	client := NewForClient(&rest.Config{Host: "https://example.invalid"}, fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "codex-k8s-dev-2",
+			DeletionTimestamp: &deletionTime,
+		},
+	}))
+
+	err := client.EnsureNamespace(context.Background(), "codex-k8s-dev-2")
+	if err == nil {
+		t.Fatal("expected terminating namespace error, got nil")
+	}
+	if got, want := err.Error(), "namespace codex-k8s-dev-2 is terminating"; got != want {
+		t.Fatalf("EnsureNamespace() error = %q, want %q", got, want)
+	}
+}

--- a/services/jobs/worker/internal/domain/worker/runtime_deploy_retry.go
+++ b/services/jobs/worker/internal/domain/worker/runtime_deploy_retry.go
@@ -83,6 +83,12 @@ func isRetryableRuntimeDeployError(err error) bool {
 		if strings.Contains(msg, "connection reset") || strings.Contains(msg, "broken pipe") {
 			return true
 		}
+		if strings.Contains(msg, "namespace is terminating") {
+			return true
+		}
+		if strings.Contains(msg, "because it is being terminated") {
+			return true
+		}
 		return false
 	default:
 		return false

--- a/services/jobs/worker/internal/domain/worker/runtime_deploy_retry_test.go
+++ b/services/jobs/worker/internal/domain/worker/runtime_deploy_retry_test.go
@@ -24,3 +24,15 @@ func TestIsRetryableRuntimeDeployError_TaskCanceledIsNotRetryable(t *testing.T) 
 		t.Fatal("expected canceled runtime deploy task error to be non-retryable")
 	}
 }
+
+func TestIsRetryableRuntimeDeployError_NamespaceTerminatingIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	err := status.Error(
+		codes.Internal,
+		"runtime deploy task failed: ensure runtime namespace repo snapshot: jobs.batch \"codex-k8s-repo-sync\" is forbidden: unable to create new content in namespace codex-k8s-dev-2 because it is being terminated",
+	)
+	if !isRetryableRuntimeDeployError(err) {
+		t.Fatal("expected terminating namespace runtime deploy error to be retryable")
+	}
+}


### PR DESCRIPTION
## Контекст
- Во время orchestration по Issue #360 intake-stage был успешно завершён и смержен в PR #379.
- Следующий stage `run:vision` на Issue #378 упал до старта агента.
- Диагностика по run `dd98602f-55f5-4ccc-b06f-e4e5f062b0c9` показала race на full-env slot namespace: `runtime_deploy_task` попытался создать `repo-sync` job в `codex-k8s-dev-2`, пока этот namespace уже переходил в `Terminating` после предыдущего run.

## Что изменено
- `services/internal/control-plane/internal/clients/kubernetes/client.go`
  - `EnsureNamespace` теперь явно возвращает ошибку, если namespace существует, но уже находится в `Terminating`.
- `services/jobs/worker/internal/domain/worker/runtime_deploy_retry.go`
  - ошибки runtime prepare с признаками `namespace is terminating` / `because it is being terminated` теперь считаются retryable, а не terminal.
- Добавлены unit-тесты на обе стороны фикса:
  - `services/internal/control-plane/internal/clients/kubernetes/client_test.go`
  - `services/jobs/worker/internal/domain/worker/runtime_deploy_retry_test.go`

## Проверки
- `go test ./services/internal/control-plane/internal/clients/kubernetes ./services/jobs/worker/internal/domain/worker`
- `git diff --check`

## Риски и ограничения
- Фикс закрывает race именно на reused slot namespace в состоянии `Terminating`.
- После merge нужен production deploy и повторный запуск `run:vision` на Issue #378.
- Текущий orchestration flow по #360/#361/#366 остановлен до выката этого фикса, как и требовал сценарий при системной поломке.

## Закрытие
- Этот PR не закрывает отдельную GitHub issue, а устраняет блокирующий infrastructure bug, найденный в процессе stage orchestration.