### PR TITLE
Context7 API key in codex config

### DIFF
--- a/services/jobs/agent-runner/internal/runner/helpers_prompt_templates.go
+++ b/services/jobs/agent-runner/internal/runner/helpers_prompt_templates.go
@@ -86,12 +86,14 @@ func (s *Service) renderTaskTemplate(templateKind string, repoDir string) (strin
 }
 
 func (s *Service) writeCodexConfig(codexDir string, model string, reasoningEffort string) error {
-	hasContext7 := strings.TrimSpace(os.Getenv(envContext7APIKey)) != ""
+	context7APIKey := strings.TrimSpace(os.Getenv(envContext7APIKey))
+	hasContext7 := context7APIKey != ""
 	content, err := renderTemplate(templateNameCodexConfig, codexConfigTemplateData{
 		Model:           strings.TrimSpace(model),
 		ReasoningEffort: strings.TrimSpace(reasoningEffort),
 		MCPBaseURL:      s.cfg.MCPBaseURL,
 		HasContext7:     hasContext7,
+		Context7APIKey:  context7APIKey,
 	})
 	if err != nil {
 		return err

--- a/services/jobs/agent-runner/internal/runner/structs.go
+++ b/services/jobs/agent-runner/internal/runner/structs.go
@@ -211,6 +211,7 @@ type codexConfigTemplateData struct {
 	ReasoningEffort string
 	MCPBaseURL      string
 	HasContext7     bool
+	Context7APIKey  string
 }
 
 type kubectlKubeconfigTemplateData struct {

--- a/services/jobs/agent-runner/internal/runner/templates/codex_config.toml.tmpl
+++ b/services/jobs/agent-runner/internal/runner/templates/codex_config.toml.tmpl
@@ -18,4 +18,7 @@ tool_timeout_sec = 180
 [mcp_servers.context7]
 command = "npx"
 args = ["-y", "@upstash/context7-mcp"]
+
+[mcp_servers.context7.env]
+CONTEXT7_API_KEY = "{{ .Context7APIKey }}"
 {{- end }}


### PR DESCRIPTION
## Что сделано
- добавил рендер блока `[mcp_servers.context7.env]` в `config.toml` codex-cli, если задан `CODEXK8S_CONTEXT7_API_KEY`
- прокинул значение ключа в данные шаблона `codex_config.toml`
- сохранил `CODEXK8S_CONTEXT7_API_KEY` в Kubernetes secret `codex-k8s-runtime` на production

## Проверки
- `go test ./services/jobs/agent-runner/internal/runner/...`
- `git diff --check`

## Примечание
- блок `context7.env` рендерится только когда `CODEXK8S_CONTEXT7_API_KEY` не пустой