### PR TITLE
Issue #404: синхронизировать prompt contract заголовков со Sprint/Day контекстом (#404)

### DIFF
--- a/services/jobs/agent-runner/internal/runner/helpers_prompt_blocks_test.go
+++ b/services/jobs/agent-runner/internal/runner/helpers_prompt_blocks_test.go
@@ -17,11 +17,70 @@ func TestRenderPromptArtifactContractBlocks_UsesFullIssueURLAndRoleSpecificSecti
 	if !strings.Contains(issueBlock, "Dev follow-up") {
 		t.Fatalf("issue contract must contain dev issue pattern, got: %q", issueBlock)
 	}
+	if !strings.Contains(issueBlock, "Dev follow-up[ Sprint S<спринт> Day<день>]") {
+		t.Fatalf("issue contract must describe optional sprint/day placement, got: %q", issueBlock)
+	}
 	if !strings.Contains(prBlock, "## Логи и runtime-диагностика") {
 		t.Fatalf("pr contract must contain dev-specific diagnostics section, got: %q", prBlock)
 	}
 	if !strings.Contains(prBlock, "Closes https://github.com/codex-k8s/codex-k8s/issues/253") {
 		t.Fatalf("pr contract must contain full issue URL closes directive, got: %q", prBlock)
+	}
+}
+
+func TestRenderPromptArtifactContractBlocks_WorkPatternsKeepOptionalSprintDayForRoleTitles(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		agentKey       string
+		locale         string
+		triggerKind    string
+		expectedIssue  string
+		expectedPR     string
+	}{
+		{
+			name:          "qa en",
+			agentKey:      "qa",
+			locale:        promptLocaleEN,
+			triggerKind:   "qa",
+			expectedIssue: "QA gap[ Sprint S<sprint> Day<day>]",
+			expectedPR:    "Issue #246: qa[ Sprint S<sprint> Day<day>] — <short verification result> (#246)",
+		},
+		{
+			name:          "sre ru",
+			agentKey:      "sre",
+			locale:        promptLocaleRU,
+			triggerKind:   "ops",
+			expectedIssue: "SRE remediation[ Sprint S<спринт> Day<день>]",
+			expectedPR:    "Issue #246: sre[ Sprint S<спринт> Day<день>] — <краткий итог remediation> (#246)",
+		},
+		{
+			name:          "default ru",
+			agentKey:      "unknown",
+			locale:        promptLocaleRU,
+			triggerKind:   "plan",
+			expectedIssue: "default[ Sprint S<спринт> Day<день>]",
+			expectedPR:    "Issue #246: plan-package — <краткая цель пакета>",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			issueBlock, prBlock, err := renderPromptArtifactContractBlocks("codex-k8s/codex-k8s", 246, tc.agentKey, tc.triggerKind, promptTemplateKindWork, tc.locale)
+			if err != nil {
+				t.Fatalf("renderPromptArtifactContractBlocks() error = %v", err)
+			}
+			if !strings.Contains(issueBlock, tc.expectedIssue) {
+				t.Fatalf("issue contract must contain optional sprint/day pattern %q, got: %q", tc.expectedIssue, issueBlock)
+			}
+			if !strings.Contains(prBlock, tc.expectedPR) {
+				t.Fatalf("pr contract must contain expected pattern %q, got: %q", tc.expectedPR, prBlock)
+			}
+		})
 	}
 }
 

--- a/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/issue_contract_en.tmpl
+++ b/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/issue_contract_en.tmpl
@@ -2,15 +2,15 @@ Follow-up Issue formatting contract:
 - Create a new Issue only when a separate follow-up, gap, incident, remediation, or handover task is required.
 - Title:
 {{- if eq .AgentKey "dev" }}
-  - pattern: `Dev follow-up: <short technical gap or next step>`
+  - pattern: `Dev follow-up[ Sprint S<sprint> Day<day>]: <short technical gap or next step>`
 {{- else if eq .AgentKey "qa" }}
-  - pattern: `QA gap: <short defect, scenario, or test gap>`
+  - pattern: `QA gap[ Sprint S<sprint> Day<day>]: <short defect, scenario, or test gap>`
 {{- else if eq .AgentKey "sre" }}
-  - pattern: `SRE remediation: <short infrastructure problem or action>`
+  - pattern: `SRE remediation[ Sprint S<sprint> Day<day>]: <short infrastructure problem or action>`
 {{- else if eq .AgentKey "reviewer" }}
-  - pattern: `Review follow-up: <short risk or blocker>`
+  - pattern: `Review follow-up[ Sprint S<sprint> Day<day>]: <short risk or blocker>`
 {{- else }}
-  - pattern: `{{ .AgentKey }}: <short goal, decision, or gap>`
+  - pattern: `{{ .AgentKey }}[ Sprint S<sprint> Day<day>]: <short goal, decision, or gap>`
 {{- end }}
   - one line, no trailing period;
   - state the subject/result first, then the qualifier;

--- a/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/issue_contract_ru.tmpl
+++ b/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/issue_contract_ru.tmpl
@@ -2,15 +2,15 @@
 - Создавайте новый Issue только если нужен отдельный follow-up, gap, incident, remediation или handover-задача.
 - Заголовок:
 {{- if eq .AgentKey "dev" }}
-  - pattern: `Dev follow-up: <краткий технический пробел или следующий шаг>`
+  - pattern: `Dev follow-up[ Sprint S<спринт> Day<день>]: <краткий технический пробел или следующий шаг>`
 {{- else if eq .AgentKey "qa" }}
-  - pattern: `QA gap: <краткий дефект, сценарий или пробел проверки>`
+  - pattern: `QA gap[ Sprint S<спринт> Day<день>]: <краткий дефект, сценарий или пробел проверки>`
 {{- else if eq .AgentKey "sre" }}
-  - pattern: `SRE remediation: <краткая инфраструктурная проблема или действие>`
+  - pattern: `SRE remediation[ Sprint S<спринт> Day<день>]: <краткая инфраструктурная проблема или действие>`
 {{- else if eq .AgentKey "reviewer" }}
-  - pattern: `Review follow-up: <краткий риск или блокер>`
+  - pattern: `Review follow-up[ Sprint S<спринт> Day<день>]: <краткий риск или блокер>`
 {{- else }}
-  - pattern: `{{ .AgentKey }}: <краткая цель, решение или пробел>`
+  - pattern: `{{ .AgentKey }}[ Sprint S<спринт> Day<день>]: <краткая цель, решение или пробел>`
 {{- end }}
   - одна строка, без точки в конце;
   - сначала предмет/результат, потом уточнение;

--- a/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/pr_contract_work_en.tmpl
+++ b/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/pr_contract_work_en.tmpl
@@ -13,9 +13,9 @@ PR formatting contract:
 {{- if eq .AgentKey "dev" }}
   - pattern: `Issue #{{ .IssueNumber }}: <short technical result> (#{{ .IssueNumber }})`
 {{- else if eq .AgentKey "qa" }}
-  - pattern: `Issue #{{ .IssueNumber }}: qa — <short verification result> (#{{ .IssueNumber }})`
+  - pattern: `Issue #{{ .IssueNumber }}: qa[ Sprint S<sprint> Day<day>] — <short verification result> (#{{ .IssueNumber }})`
 {{- else if eq .AgentKey "sre" }}
-  - pattern: `Issue #{{ .IssueNumber }}: sre — <short remediation result> (#{{ .IssueNumber }})`
+  - pattern: `Issue #{{ .IssueNumber }}: sre[ Sprint S<sprint> Day<day>] — <short remediation result> (#{{ .IssueNumber }})`
 {{- else }}
   - pattern: `Issue #{{ .IssueNumber }}: {{ .StageName }}-package — <short package goal>`
 {{- end }}

--- a/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/pr_contract_work_ru.tmpl
+++ b/services/jobs/agent-runner/internal/runner/templates/prompt_blocks/pr_contract_work_ru.tmpl
@@ -13,9 +13,9 @@
 {{- if eq .AgentKey "dev" }}
   - pattern: `Issue #{{ .IssueNumber }}: <краткий технический результат> (#{{ .IssueNumber }})`
 {{- else if eq .AgentKey "qa" }}
-  - pattern: `Issue #{{ .IssueNumber }}: qa — <краткий итог проверки> (#{{ .IssueNumber }})`
+  - pattern: `Issue #{{ .IssueNumber }}: qa[ Sprint S<спринт> Day<день>] — <краткий итог проверки> (#{{ .IssueNumber }})`
 {{- else if eq .AgentKey "sre" }}
-  - pattern: `Issue #{{ .IssueNumber }}: sre — <краткий итог remediation> (#{{ .IssueNumber }})`
+  - pattern: `Issue #{{ .IssueNumber }}: sre[ Sprint S<спринт> Day<день>] — <краткий итог remediation> (#{{ .IssueNumber }})`
 {{- else }}
   - pattern: `Issue #{{ .IssueNumber }}: {{ .StageName }}-package — <краткая цель пакета>`
 {{- end }}


### PR DESCRIPTION
## Контекст
- Issue #404 фиксирует drift между `docs/delivery/development_process_requirements.md` и repo prompt contract templates в `services/jobs/agent-runner/internal/runner/templates/prompt_blocks/*`.
- Source-of-truth для этого контракта: `docs/delivery/development_process_requirements.md`, `docs/architecture/prompt_templates_policy.md`, `services/jobs/agent-runner/internal/runner/promptseeds/README.md`.
- Ветка реализации: `codex/issue-404`, базовая ветка: `main`.

## Основание для изменений
- В process standard и prompt policy уже зафиксировано правило: если заголовок явно содержит role token, optional-фрагмент `Sprint S<спринт> Day<день>` ставится сразу после него.
- Repo templates `issue_contract_{ru,en}.tmpl` и `pr_contract_work_{ru,en}.tmpl` оставались на старом паттерне без этого optional-фрагмента, поэтому runtime prompt мог снова обучать агент неверному title contract.
- Для проверки синхронизации использованы локальные тесты и актуальная справка Context7 по `text/template` (`/websites/pkg_go_dev_go1_25_3`) по `if`/trim markers `{{- ... -}}`.

## Основной смысл правок
- Синхронизирован текст prompt contract с действующим process standard для role-bearing заголовков.
- Добавлено regression-покрытие, которое проверяет optional Sprint/Day сегмент в `ru` и `en` и не затрагивает fallback для не role-bearing PR patterns.

## Что сделано
- Обновлены role-bearing follow-up patterns в `services/jobs/agent-runner/internal/runner/templates/prompt_blocks/issue_contract_ru.tmpl` и `services/jobs/agent-runner/internal/runner/templates/prompt_blocks/issue_contract_en.tmpl`.
- Обновлены role-bearing PR patterns для `qa` и `sre` в `services/jobs/agent-runner/internal/runner/templates/prompt_blocks/pr_contract_work_ru.tmpl` и `services/jobs/agent-runner/internal/runner/templates/prompt_blocks/pr_contract_work_en.tmpl`.
- Расширен `services/jobs/agent-runner/internal/runner/helpers_prompt_blocks_test.go`: добавлены проверки optional Sprint/Day сегмента для `dev`, `qa`, `sre` и fallback-case без role-bearing PR title.

## Логи и runtime-диагностика
- `kubectl`/runtime-диагностика не выполнялись: изменение ограничено prompt templates и локальными тестами.
- Production/full-env логи не запрашивались.

## БД и миграции
- Изменений БД нет.
- Миграции не добавлялись и не запускались.

## Проверки
- `go test ./services/jobs/agent-runner/internal/runner/...` — успешно.
- `make lint-go` — неуспешно из-за уже существующего baseline-нарушения вне области изменений: `services/internal/control-plane/internal/clients/kubernetes/client_test.go:18` (`SA1019`, deprecated `fake.NewSimpleClientset`).
- `make dupl-go` — неуспешно из-за уже существующих дублей вне области изменений: `services/internal/control-plane/internal/domain/mcp/model.go`, `services/internal/control-plane/internal/domain/runstatus/model.go`, `services/internal/control-plane/internal/clients/kubernetes/client.go`.
- `gh issue view 404 --json number,title,body,labels,state,url` — выполнено для сверки контекста issue.

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты проверены, нарушений в области текущих файлов не выявлено.
- `docs/design-guidelines/go/check_list.md` — релевантные пункты проверены; production Go-код не менялся, добавлены только regression tests для prompt blocks.
- `go mod tidy` не требовался: зависимости и `go.mod` не менялись.

## Риски и ограничения
- Изменение синхронизирует только work-contract templates, указанные в Issue #404; revise/discussion/main-direct контракты не менялись, потому что issue их не затрагивает.
- `make lint-go` и `make dupl-go` остаются красными из-за pre-existing baseline вне области PR; этот PR их не исправляет.

## Рекомендации / следующий шаг
- После merge стоит отдельно закрыть baseline замечания по `lint-go`/`dupl-go`, чтобы обязательные чек-проверки для Go-изменений стали зелёными на уровне репозитория.
- Для review достаточно проверить соответствие четырёх prompt templates разделу `Стандарт заголовков и содержимого Issue/PR` в `docs/delivery/development_process_requirements.md` и пройти новые тесты в `helpers_prompt_blocks_test.go`.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/404
