### PR TITLE
Issue #409: человекочитаемые recovery-события в таймлайне run (#409)

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -77,7 +77,7 @@ spec:
       - path: docs/templates/docset_pr.md
   versions:
     api-gateway:
-      value: "0.1.53"
+      value: "0.1.54"
       bumpOn:
         - services/external/api-gateway
         # Production staff UI is embedded into api-gateway image.
@@ -107,7 +107,7 @@ spec:
         - libs/go
         - proto
     web-console:
-      value: "0.1.30"
+      value: "0.1.31"
       bumpOn:
         - services/staff/web-console
         - libs/ts

--- a/services/staff/web-console/src/i18n/messages/en.ts
+++ b/services/staff/web-console/src/i18n/messages/en.ts
@@ -338,6 +338,16 @@ export const en = {
       waitState: "wait_state",
       status: "status",
       buildFailed: "Finished before agent handoff",
+      events: {
+        workerHeartbeatMissed: "Worker heartbeat missed",
+        workerHeartbeatMissedWithActor: "Worker heartbeat missed · {actorId}",
+        staleLeaseDetected: "Stale lease detected",
+        staleLeaseDetectedWithActor: "Stale lease detected · {actorId}",
+        staleLeaseReleased: "Stale lease released",
+        staleLeaseReleasedWithActor: "Stale lease released · {actorId}",
+        leaseReclaimedAfterStale: "Lease reclaimed after stale lease",
+        leaseReclaimedAfterStaleWithActor: "Lease reclaimed after stale lease · {actorId}",
+      },
     },
   },
   logs: {

--- a/services/staff/web-console/src/i18n/messages/ru.ts
+++ b/services/staff/web-console/src/i18n/messages/ru.ts
@@ -338,6 +338,16 @@ export const ru = {
       waitState: "wait_state",
       status: "status",
       buildFailed: "Завершилось до передачи управления агенту",
+      events: {
+        workerHeartbeatMissed: "Worker перестал отправлять heartbeat",
+        workerHeartbeatMissedWithActor: "Worker перестал отправлять heartbeat · {actorId}",
+        staleLeaseDetected: "Обнаружен stale lease",
+        staleLeaseDetectedWithActor: "Обнаружен stale lease · {actorId}",
+        staleLeaseReleased: "Освобожден stale lease",
+        staleLeaseReleasedWithActor: "Освобожден stale lease · {actorId}",
+        leaseReclaimedAfterStale: "Lease восстановлен после stale lease",
+        leaseReclaimedAfterStaleWithActor: "Lease восстановлен после stale lease · {actorId}",
+      },
     },
   },
   logs: {

--- a/services/staff/web-console/src/shared/lib/run-timeline.test.ts
+++ b/services/staff/web-console/src/shared/lib/run-timeline.test.ts
@@ -3,6 +3,22 @@ import assert from "node:assert/strict";
 
 import { buildRunTimelinePhases, buildRunTimelineStatuses } from "./run-timeline.ts";
 
+const timelineTranslations = {
+  "runs.timeline.events.workerHeartbeatMissed": "Worker heartbeat missed",
+  "runs.timeline.events.workerHeartbeatMissedWithActor": "Worker heartbeat missed · {actorId}",
+  "runs.timeline.events.staleLeaseDetected": "Stale lease detected",
+  "runs.timeline.events.staleLeaseDetectedWithActor": "Stale lease detected · {actorId}",
+  "runs.timeline.events.staleLeaseReleased": "Stale lease released",
+  "runs.timeline.events.staleLeaseReleasedWithActor": "Stale lease released · {actorId}",
+  "runs.timeline.events.leaseReclaimedAfterStale": "Lease reclaimed after stale lease",
+  "runs.timeline.events.leaseReclaimedAfterStaleWithActor": "Lease reclaimed after stale lease · {actorId}",
+} as const;
+
+function translateTimelineStatus(key: string, params?: Record<string, string>): string {
+  const template = timelineTranslations[key as keyof typeof timelineTranslations] || key;
+  return template.replaceAll("{actorId}", params?.actorId ?? "");
+}
+
 test("buildRunTimelinePhases adds build-deploy, auth and ready steps for full-env runs", () => {
   const run = {
     created_at: "2026-03-12T10:00:00Z",
@@ -87,7 +103,12 @@ test("buildRunTimelineStatuses collapses adjacent duplicates and formats compact
     },
   ];
 
-  const entries = buildRunTimelineStatuses(events as never, "ru", new Date("2026-03-12T12:00:00Z"));
+  const entries = buildRunTimelineStatuses(
+    events as never,
+    "ru",
+    translateTimelineStatus,
+    new Date("2026-03-12T12:00:00Z"),
+  );
   assert.equal(entries.length, 2);
   assert.equal(entries[0]?.at, "2026-03-12T10:06:00Z");
   assert.equal(entries[0]?.repeatCount, 2);
@@ -119,14 +140,37 @@ test("buildRunTimelineStatuses includes stale lease recovery events in timeline"
     },
   ];
 
-  const entries = buildRunTimelineStatuses(events as never, "en", new Date("2026-03-12T12:00:00Z"));
+  const entries = buildRunTimelineStatuses(
+    events as never,
+    "en",
+    translateTimelineStatus,
+    new Date("2026-03-12T12:00:00Z"),
+  );
   assert.deepEqual(
     entries.map((item) => item.text),
     [
-      "run.reclaimed_after_stale_lease · worker-2",
-      "run.lease.released · worker-old",
-      "run.lease.detected_stale · worker-old",
-      "worker.instance.heartbeat.missed · worker-old",
+      "Lease reclaimed after stale lease · worker-2",
+      "Stale lease released · worker-old",
+      "Stale lease detected · worker-old",
+      "Worker heartbeat missed · worker-old",
     ],
   );
+});
+
+test("buildRunTimelineStatuses uses event translation without actor placeholder leakage", () => {
+  const events = [
+    {
+      event_type: "run.lease.detected_stale",
+      created_at: "2026-03-12T10:07:00Z",
+      payload_json: "{}",
+    },
+  ];
+
+  const entries = buildRunTimelineStatuses(
+    events as never,
+    "en",
+    translateTimelineStatus,
+    new Date("2026-03-12T12:00:00Z"),
+  );
+  assert.deepEqual(entries.map((item) => item.text), ["Stale lease detected"]);
 });

--- a/services/staff/web-console/src/shared/lib/run-timeline.ts
+++ b/services/staff/web-console/src/shared/lib/run-timeline.ts
@@ -32,9 +32,32 @@ export type TimelineStatusEntry = {
 };
 
 type EventPayload = Record<string, unknown>;
+type TimelineStatusTranslator = (key: string, params?: Record<string, string>) => string;
+type RecoveryStatusMessage = {
+  key: string;
+  params?: Record<string, string>;
+};
 
 const runtimeModeFullEnv = "full-env";
 const runtimeModeCodeOnly = "code-only";
+const recoveryEventTranslations = {
+  "worker.instance.heartbeat.missed": {
+    withoutActor: "runs.timeline.events.workerHeartbeatMissed",
+    withActor: "runs.timeline.events.workerHeartbeatMissedWithActor",
+  },
+  "run.lease.detected_stale": {
+    withoutActor: "runs.timeline.events.staleLeaseDetected",
+    withActor: "runs.timeline.events.staleLeaseDetectedWithActor",
+  },
+  "run.lease.released": {
+    withoutActor: "runs.timeline.events.staleLeaseReleased",
+    withActor: "runs.timeline.events.staleLeaseReleasedWithActor",
+  },
+  "run.reclaimed_after_stale_lease": {
+    withoutActor: "runs.timeline.events.leaseReclaimedAfterStale",
+    withActor: "runs.timeline.events.leaseReclaimedAfterStaleWithActor",
+  },
+} as const;
 
 function parsePayload(raw: string): EventPayload | null {
   const value = String(raw || "").trim();
@@ -72,21 +95,17 @@ function findAuthResolvedAt(events: FlowEvent[]): string | null {
   return null;
 }
 
-function recoveryStatusText(eventType: string, payload: EventPayload | null): string | null {
+function recoveryStatusMessage(eventType: string, payload: EventPayload | null): RecoveryStatusMessage | null {
+  const translation = recoveryEventTranslations[eventType as keyof typeof recoveryEventTranslations];
+  if (!translation) return null;
+
   const workerId = typeof payload?.worker_id === "string" ? payload.worker_id.trim() : "";
   const ownerId = typeof payload?.previous_lease_owner === "string" ? payload.previous_lease_owner.trim() : "";
   const actorId = workerId || ownerId;
 
-  switch (eventType) {
-    case "worker.instance.heartbeat.missed":
-    case "run.lease.detected_stale":
-    case "run.lease.released":
-      return actorId ? `${eventType} · ${actorId}` : eventType;
-    case "run.reclaimed_after_stale_lease":
-      return actorId ? `${eventType} · ${actorId}` : eventType;
-    default:
-      return null;
-  }
+  return actorId
+    ? { key: translation.withActor, params: { actorId } }
+    : { key: translation.withoutActor };
 }
 
 function resolveRuntimeMode(events: FlowEvent[], run: Run | null): string {
@@ -200,7 +219,12 @@ export function buildRunTimelinePhases(run: Run | null, events: FlowEvent[], loc
   return steps;
 }
 
-export function buildRunTimelineStatuses(events: FlowEvent[], locale: string, referenceDate: Date = new Date()): TimelineStatusEntry[] {
+export function buildRunTimelineStatuses(
+  events: FlowEvent[],
+  locale: string,
+  translateStatus: TimelineStatusTranslator,
+  referenceDate: Date = new Date(),
+): TimelineStatusEntry[] {
   const entries: TimelineStatusEntry[] = [];
   for (const eventItem of events) {
     const payload = parsePayload(eventItem.payload_json || "");
@@ -209,7 +233,8 @@ export function buildRunTimelineStatuses(events: FlowEvent[], locale: string, re
     if (eventItem.event_type === "run.agent.status_reported") {
       statusText = typeof payload?.status_text === "string" ? payload.status_text.trim() : "";
     } else {
-      statusText = recoveryStatusText(eventItem.event_type, payload) || "";
+      const message = recoveryStatusMessage(eventItem.event_type, payload);
+      statusText = message ? translateStatus(message.key, message.params) : "";
     }
     if (!statusText) continue;
 

--- a/services/staff/web-console/src/shared/ui/RunTimeline.vue
+++ b/services/staff/web-console/src/shared/ui/RunTimeline.vue
@@ -96,7 +96,9 @@ function subtitleForStep(subtitleKind?: TimelinePhaseStep["subtitleKind"], subti
 }
 
 const phaseSteps = computed(() => buildRunTimelinePhases(props.run, props.events, props.locale));
-const statusEntries = computed(() => buildRunTimelineStatuses(props.events, props.locale));
+const statusEntries = computed(() =>
+  buildRunTimelineStatuses(props.events, props.locale, (key, params) => String(t(key, params ?? {}))),
+);
 
 function titleForItem(item: TimelineDisplayItem): string {
   if (item.kind === "agentStatus") {


### PR DESCRIPTION
## Контекст
- Issue: #409 `Починить таймлайн`.
- В staff web-console часть системных событий run timeline (`worker.instance.heartbeat.missed`, `run.lease.detected_stale`, `run.lease.released`, `run.reclaimed_after_stale_lease`) отображалась как raw `event_type`.
- Работа выполнена в ветке `codex/issue-409` против `main`, runtime context: `full-env`, target env: `ai`.

## Основание для изменений
- В issue приложен пример из run timeline, где системные recovery-события показывались не человекочитаемо и обходили i18n.
- Для staff UI это регресс UX: оператор видит внутренний event id вместо нормальной подписи события.

## Основной смысл правок
- Перевел recovery-события таймлайна на i18n-ключи с параметром `actorId`.
- Сохранил существующее поведение для agent status updates и для повторов одинаковых событий.
- Поднял версии `api-gateway` и `web-console` в `services.yaml`, чтобы candidate/prod build не пропустил пересборку UI.

## Что сделано
- В `services/staff/web-console/src/shared/lib/run-timeline.ts` добавлен типизированный маппинг recovery event -> i18n key и параметров перевода.
- В `services/staff/web-console/src/shared/ui/RunTimeline.vue` перевод системных статусов теперь делается через `t(...)`, а не через сырой `event_type`.
- В `services/staff/web-console/src/i18n/messages/ru.ts` и `services/staff/web-console/src/i18n/messages/en.ts` добавлены локализованные подписи recovery-событий.
- В `services/staff/web-console/src/shared/lib/run-timeline.test.ts` обновлены проверки на локализованный текст и добавлен сценарий без `actorId`, чтобы не протекал placeholder.
- В `services.yaml` обновлены версии `api-gateway` (`0.1.53 -> 0.1.54`) и `web-console` (`0.1.30 -> 0.1.31`).

## Логи и runtime-диагностика
- `kubectl` и runtime-логи не использовал.
- Диагностика выполнена по evidence из issue и по чтению кода staff UI.

## БД и миграции
- Изменений БД нет.
- Миграции не требовались.

## Проверки
- `npm run test:unit` в `services/staff/web-console` — успешно.
- `npm run build` в `services/staff/web-console` — успешно.
- `git diff --check` — успешно.
- `gh pr list --head codex/issue-409 --json number,title,url,headRefName,baseRefName,state` до публикации — PR для ветки отсутствовал.

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` — релевантные пункты выполнены.
- `docs/design-guidelines/vue/check_list.md` — релевантные пункты выполнены.
- `docs/design-guidelines/go/check_list.md` — не требовался, Go-код не менялся.

## Риски и ограничения
- Локализованы только системные recovery-события, которые раньше показывали raw `event_type`; пользовательские `run.agent.status_reported` остаются как есть.
- `vite build` по-прежнему предупреждает о крупных чанках, но сборка успешна; это существующее состояние и не связано с данной правкой.

## Рекомендации / следующий шаг
- Reviewer/Owner: открыть run details с lease-recovery событиями и убедиться, что таймлайн теперь показывает человекочитаемые подписи на RU/EN локалях.
- QA: использовать candidate lineage этой issue для smoke-проверки страницы run details после сборки образов.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/409
