### PR TITLE
fix: force rebuild worker image after production drift

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -95,7 +95,7 @@ spec:
         - libs/go
         - proto
     worker:
-      value: "0.1.57"
+      value: "0.1.58"
       bumpOn:
         - services/jobs/worker
         - libs/go


### PR DESCRIPTION
## Контекст
- После последних merge в `main` начали нестабильно падать run, в том числе `run:plan:revise` `e5e4eee6-a1b2-40a5-806c-80f702126c30` для PR `#432`.
- Диагностика показала, что `runtime_deploy` у revise-рана завершался успешно, а сбой происходил уже после старта агента.

## Что оказалось причиной
- В production остался stale `worker` image, не соответствующий текущему `main`.
- Прямое подтверждение из production логов: worker при старте вызывает gRPC метод `ExpireNextInteraction`, которого в текущем `main` уже нет и который текущий `control-plane` не реализует.
- История репозитория показывает, что `ExpireNextInteraction` жил в старом коммите `9f5687e` и позже был удалён. Значит production worker работает не на том коде, который сейчас лежит в `main`.
- Это классический deploy drift: из-за пропущенной пересборки worker runtime path в проде расходится с текущими `control-plane` и репозиторием, что и даёт нестабильность ранoв.

## Что изменено
- В `services.yaml` поднята версия `worker` `0.1.57 -> 0.1.58`, чтобы self-deploy принудительно пересобрал и перевыкатил production worker из текущего `main`.
- Код сервиса не менялся: актуальная логика уже есть в `main`, проблема именно в недоставленном worker image.

## Проверки
- `git diff --check`
- подтверждена production-фактура:
  - stale worker логирует `rpc error: code = Unimplemented desc = unknown method ExpireNextInteraction for service codexk8s.controlplane.v1.ControlPlaneService`;
  - `runtime_deploy_tasks` для failed revise-run были `succeeded`, а ломался уже post-deploy run path.
- поиск по истории: `git log -S'ExpireNextInteraction' -- services/jobs/worker services/internal/control-plane proto`

## Ожидаемый эффект после merge
- production соберёт `worker:0.1.58`;
- worker выровняется с текущим `main` и `control-plane`;
- после этого можно повторно запускать revise/stage-runs и смотреть, осталась ли какая-либо отдельная ошибка поверх устранённого deploy drift.