### PR TITLE
fix: avoid Vite EMFILE in hot-reload slots

### DIFF
--- a/deploy/base/web-console/web-console.yaml.tpl
+++ b/deploy/base/web-console/web-console.yaml.tpl
@@ -68,6 +68,13 @@ spec:
             # Dedicated path so we can route websocket directly to Vite service (bypassing auth proxy).
             - name: VITE_HMR_PATH
               value: "/__vite_ws"
+{{ if eq (envOr "CODEXK8S_HOT_RELOAD" "") "true" }}
+            # Shared repo PVC makes fs.watch exhaust file descriptors; polling keeps Vite stable in slots.
+            - name: VITE_WATCH_USE_POLLING
+              value: "true"
+            - name: VITE_WATCH_INTERVAL
+              value: "1000"
+{{ end }}
           readinessProbe:
             httpGet:
               path: /

--- a/services.yaml
+++ b/services.yaml
@@ -107,7 +107,7 @@ spec:
         - libs/go
         - proto
     web-console:
-      value: "0.1.34"
+      value: "0.1.35"
       bumpOn:
         - services/staff/web-console
         - libs/ts

--- a/services/staff/web-console/vite.config.ts
+++ b/services/staff/web-console/vite.config.ts
@@ -3,6 +3,7 @@ import vue from "@vitejs/plugin-vue";
 import vuetify from "vite-plugin-vuetify";
 
 const disableHmr = ["1", "true", "yes"].includes(String(process.env.VITE_DISABLE_HMR || "").toLowerCase());
+const enablePollingWatch = ["1", "true", "yes"].includes(String(process.env.VITE_WATCH_USE_POLLING || "").toLowerCase());
 
 function parseOptionalInt(value: string | undefined): number | undefined {
   if (!value) {
@@ -21,6 +22,17 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    watch: (() => {
+      const interval = parseOptionalInt(process.env.VITE_WATCH_INTERVAL);
+      if (!enablePollingWatch && interval === undefined) {
+        return undefined;
+      }
+
+      return {
+        usePolling: enablePollingWatch,
+        interval,
+      };
+    })(),
     allowedHosts: process.env.VITE_ALLOWED_HOSTS ? [process.env.VITE_ALLOWED_HOSTS] : true,
     hmr: (() => {
       if (disableHmr) {


### PR DESCRIPTION
## Проблема
- orchestration по `#361` остановился на `run:intake`
- slot `codex-k8s-dev-5` не становился ready
- `web-console` в hot-reload режиме падал с `EMFILE: too many open files`

## Что изменено
- `vite.config.ts`: добавлен явный watcher polling mode через env
- `deploy/base/web-console/web-console.yaml.tpl`: для hot-reload слотов включён polling watcher
- `services.yaml`: поднята версия `web-console`, чтобы runtime build пересобрал образ

## Проверки
- `npm --prefix services/staff/web-console run build`
- `env VITE_WATCH_USE_POLLING=true VITE_WATCH_INTERVAL=1000 npm --prefix services/staff/web-console run dev -- --host 127.0.0.1 --port 5173`
- `git diff --check`

## Контекст
- баг найден во время orchestration задачи `#361`
- после merge и deploy можно продолжать stage-flow с `run:intake` для `#361`