### PR TITLE
fix: prevent stuck full-env runs while slot worker compiles

### DIFF
--- a/deploy/base/codex-k8s/app.yaml.tpl
+++ b/deploy/base/codex-k8s/app.yaml.tpl
@@ -967,6 +967,12 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /health/livez
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /health/livez


### PR DESCRIPTION
## Что сделано
- добавлен `startupProbe` для `codex-k8s-worker` в `deploy/base/codex-k8s/app.yaml.tpl`
- `startupProbe` теперь даёт slot-worker достаточно времени на первый hot-reload build через `CompileDaemon`
- это убирает цикл `liveness -> SIGTERM -> CrashLoopBackOff` до готовности worker в full-env namespace

## Корень проблемы
Для run `c231b300-fe12-4d94-a624-dcda1e107f6a` и `f8c1d538-7ed8-4ef0-ad80-0edb2fd15b60` зависание было не в агенте и не в ручном delete namespace.

Проблема была в самом slot namespace:
- `codex-k8s-worker` стартовал в hot-reload режиме через `CompileDaemon`
- первый build занимал заметное время
- у worker не было `startupProbe`, только обычные `readiness/liveness`
- kubelet начинал liveness раньше завершения startup и сам убивал контейнер
- из-за этого deployment worker так и не становился `Ready`, а `runtime_deploy` бесконечно ждал готовности окружения

Следствие:
- ран на платформе зависал со спиннером
- ручное удаление namespace не помогало, потому что при следующем prepare поднимался тот же битый hot-reload worker

## Проверки
- `git diff --check`
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy`

## Как проверить после merge
1. Merge PR
2. Дождаться self-deploy production
3. Перезапустить проблемные run
4. Убедиться, что в slot namespace `codex-k8s-worker` проходит startup и становится `Ready` без `CrashLoopBackOff`
