### PR TITLE
fix: hand off running leases during worker rollout

### DIFF
--- a/services/jobs/worker/internal/app/app.go
+++ b/services/jobs/worker/internal/app/app.go
@@ -365,6 +365,9 @@ func Run() error {
 			}
 			cancelShutdown()
 			stopCtx, cancelStop := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := service.ReleaseOwnedRunLeasesOnShutdown(stopCtx); err != nil {
+				logger.Warn("release owned run leases on shutdown failed", "worker_id", cfg.WorkerID, "err", err)
+			}
 			if err := markWorkerStopped(stopCtx, workerInstances, cfg.WorkerID, time.Now().UTC()); err != nil {
 				logger.Warn("mark worker stopped failed", "worker_id", cfg.WorkerID, "err", err)
 			}

--- a/services/jobs/worker/internal/domain/repository/runqueue/repository.go
+++ b/services/jobs/worker/internal/domain/repository/runqueue/repository.go
@@ -11,6 +11,7 @@ type (
 	ClaimRunningParams        = querytypes.RunQueueClaimRunningParams
 	CreatePendingResumeParams = querytypes.RunQueueCreatePendingResumeParams
 	ReleaseStaleLeasesParams  = querytypes.RunQueueReleaseStaleLeasesParams
+	ReleaseOwnedLeasesParams  = querytypes.RunQueueReleaseOwnedLeasesParams
 	ClaimedRun                = querytypes.RunQueueClaimedRun
 	RunningRun                = querytypes.RunQueueRunningRun
 	NonTerminalRun            = querytypes.RunQueueNonTerminalRun
@@ -29,6 +30,8 @@ type Repository interface {
 	ClaimRunning(ctx context.Context, params ClaimRunningParams) ([]RunningRun, error)
 	// ReleaseStaleLeases clears running-run leases whose owner worker instance is stale.
 	ReleaseStaleLeases(ctx context.Context, params ReleaseStaleLeasesParams) ([]ReleasedStaleLease, error)
+	// ReleaseOwnedLeases clears running-run leases currently owned by one worker during graceful shutdown.
+	ReleaseOwnedLeases(ctx context.Context, params ReleaseOwnedLeasesParams) ([]ReleasedStaleLease, error)
 	// ListRunning returns active runs for reconciliation.
 	ListRunning(ctx context.Context, limit int) ([]RunningRun, error)
 	// ListNonTerminalByRunIDs returns non-terminal agent_runs referenced by managed namespaces.

--- a/services/jobs/worker/internal/domain/types/query/runqueue.go
+++ b/services/jobs/worker/internal/domain/types/query/runqueue.go
@@ -43,6 +43,12 @@ type RunQueueReleaseStaleLeasesParams struct {
 	ActiveWorkerIDs []string
 }
 
+// RunQueueReleaseOwnedLeasesParams describes one graceful running-lease release during worker shutdown.
+type RunQueueReleaseOwnedLeasesParams struct {
+	// WorkerID identifies worker instance that currently owns running-run leases.
+	WorkerID string
+}
+
 // RunQueueClaimedRun represents a pending run promoted into running state.
 type RunQueueClaimedRun struct {
 	// RunID is a unique run identifier.

--- a/services/jobs/worker/internal/domain/worker/service_shutdown.go
+++ b/services/jobs/worker/internal/domain/worker/service_shutdown.go
@@ -1,0 +1,27 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	floweventdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/flowevent"
+	runqueuerepo "github.com/codex-k8s/codex-k8s/services/jobs/worker/internal/domain/repository/runqueue"
+)
+
+// ReleaseOwnedRunLeasesOnShutdown releases running-run leases held by current worker before pod termination.
+func (s *Service) ReleaseOwnedRunLeasesOnShutdown(ctx context.Context) error {
+	released, err := s.runs.ReleaseOwnedLeases(ctx, runqueuerepo.ReleaseOwnedLeasesParams{
+		WorkerID: s.cfg.WorkerID,
+	})
+	if err != nil {
+		return fmt.Errorf("release owned running leases on shutdown: %w", err)
+	}
+
+	for _, item := range released {
+		if err := s.insertRunLeaseStaleEvent(ctx, item, floweventdomain.EventTypeRunLeaseReleased); err != nil {
+			return fmt.Errorf("insert graceful run lease release event: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/services/jobs/worker/internal/domain/worker/service_test.go
+++ b/services/jobs/worker/internal/domain/worker/service_test.go
@@ -1723,6 +1723,48 @@ func TestTickReclaimsRunAfterStaleLeaseAndLaunchesMissingWorkload(t *testing.T) 
 	}
 }
 
+func TestReleaseOwnedRunLeasesOnShutdown_ReleasesOwnedLeasesAndEmitsEvent(t *testing.T) {
+	t.Parallel()
+
+	runs := &fakeRunQueue{
+		releasedOwnedLeases: []runqueuerepo.ReleasedStaleLease{{
+			RunID:              "run-shutdown",
+			CorrelationID:      "corr-shutdown",
+			ProjectID:          "proj-shutdown",
+			PreviousLeaseOwner: "worker-1",
+			PreviousLeaseUntil: timePtr(time.Date(2026, 3, 14, 16, 0, 0, 0, time.UTC)),
+			WorkerStatus:       "stopped",
+		}},
+	}
+	events := &fakeFlowEvents{}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	svc := NewService(Config{
+		WorkerID: "worker-1",
+	}, Dependencies{
+		Runs:   runs,
+		Events: events,
+		Logger: logger,
+	})
+	svc.now = func() time.Time { return time.Date(2026, 3, 14, 16, 5, 0, 0, time.UTC) }
+
+	if err := svc.ReleaseOwnedRunLeasesOnShutdown(context.Background()); err != nil {
+		t.Fatalf("ReleaseOwnedRunLeasesOnShutdown() error = %v", err)
+	}
+	if len(runs.releaseOwnedParams) != 1 {
+		t.Fatalf("expected one graceful release call, got %d", len(runs.releaseOwnedParams))
+	}
+	if got, want := runs.releaseOwnedParams[0].WorkerID, "worker-1"; got != want {
+		t.Fatalf("release worker_id = %q, want %q", got, want)
+	}
+	if len(events.inserted) != 1 {
+		t.Fatalf("expected one release event, got %d", len(events.inserted))
+	}
+	if got, want := events.inserted[0].EventType, floweventdomain.EventTypeRunLeaseReleased; got != want {
+		t.Fatalf("event_type = %q, want %q", got, want)
+	}
+}
+
 func TestTickRunningFullEnvJobNotFound_ReviseReuseFastPathRelaunchesWithoutRuntimePrepare(t *testing.T) {
 	t.Parallel()
 
@@ -1808,8 +1850,10 @@ type fakeRunQueue struct {
 	claimRunningCalls   int
 	claimRunning        []runqueuerepo.ClaimRunningParams
 	releasedStaleLeases []runqueuerepo.ReleasedStaleLease
+	releasedOwnedLeases []runqueuerepo.ReleasedStaleLease
 	releaseStaleCalls   int
 	releaseStaleParams  []runqueuerepo.ReleaseStaleLeasesParams
+	releaseOwnedParams  []runqueuerepo.ReleaseOwnedLeasesParams
 	resumePending       []runqueuerepo.CreatePendingResumeParams
 	finished            []runqueuerepo.FinishParams
 	extended            []runqueuerepo.ExtendLeaseParams
@@ -1865,6 +1909,14 @@ func (f *fakeRunQueue) ReleaseStaleLeases(_ context.Context, params runqueuerepo
 	f.releaseStaleCalls++
 	f.releaseStaleParams = append(f.releaseStaleParams, params)
 	return f.releasedStaleLeases, nil
+}
+
+func (f *fakeRunQueue) ReleaseOwnedLeases(_ context.Context, params runqueuerepo.ReleaseOwnedLeasesParams) ([]runqueuerepo.ReleasedStaleLease, error) {
+	if f.releaseStaleErr != nil {
+		return nil, f.releaseStaleErr
+	}
+	f.releaseOwnedParams = append(f.releaseOwnedParams, params)
+	return f.releasedOwnedLeases, nil
 }
 
 func (f *fakeRunQueue) CreatePendingResumeIfAbsent(_ context.Context, params runqueuerepo.CreatePendingResumeParams) (bool, error) {

--- a/services/jobs/worker/internal/repository/postgres/runqueue/repository.go
+++ b/services/jobs/worker/internal/repository/postgres/runqueue/repository.go
@@ -45,6 +45,8 @@ var (
 	queryClaimRunning string
 	//go:embed sql/release_stale_running_leases.sql
 	queryReleaseStaleRunningLeases string
+	//go:embed sql/release_owned_running_leases.sql
+	queryReleaseOwnedRunningLeases string
 	//go:embed sql/list_running.sql
 	queryListRunning string
 	//go:embed sql/list_non_terminal_by_run_ids.sql
@@ -290,6 +292,44 @@ func (r *Repository) ReleaseStaleLeases(ctx context.Context, params domainrepo.R
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate released stale running leases: %w", err)
+	}
+	return items, nil
+}
+
+// ReleaseOwnedLeases clears running-run leases currently owned by one worker during graceful shutdown.
+func (r *Repository) ReleaseOwnedLeases(ctx context.Context, params domainrepo.ReleaseOwnedLeasesParams) ([]domainrepo.ReleasedStaleLease, error) {
+	workerID := strings.TrimSpace(params.WorkerID)
+	if workerID == "" {
+		return nil, fmt.Errorf("release owned running leases: worker_id is required")
+	}
+
+	rows, err := r.db.Query(ctx, queryReleaseOwnedRunningLeases, workerID)
+	if err != nil {
+		return nil, fmt.Errorf("release owned running leases: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]domainrepo.ReleasedStaleLease, 0, 8)
+	for rows.Next() {
+		var (
+			item                  domainrepo.ReleasedStaleLease
+			previousLeaseUntilRaw pgtype.Timestamptz
+		)
+		if err := rows.Scan(
+			&item.RunID,
+			&item.CorrelationID,
+			&item.ProjectID,
+			&item.PreviousLeaseOwner,
+			&previousLeaseUntilRaw,
+			&item.WorkerStatus,
+		); err != nil {
+			return nil, fmt.Errorf("scan released owned running lease row: %w", err)
+		}
+		item.PreviousLeaseUntil = timestamptzPtr(previousLeaseUntilRaw)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate released owned running leases: %w", err)
 	}
 	return items, nil
 }

--- a/services/jobs/worker/internal/repository/postgres/runqueue/sql/release_owned_running_leases.sql
+++ b/services/jobs/worker/internal/repository/postgres/runqueue/sql/release_owned_running_leases.sql
@@ -1,0 +1,36 @@
+-- name: runqueue__release_owned_running_leases :many
+WITH candidates AS (
+    SELECT r.id,
+           r.correlation_id,
+           r.project_id,
+           COALESCE(r.lease_owner, '') AS previous_lease_owner,
+           r.lease_until AS previous_lease_until
+    FROM agent_runs AS r
+    WHERE r.status = 'running'
+      AND r.lease_owner = $1
+    ORDER BY r.started_at NULLS FIRST, r.created_at ASC
+    FOR UPDATE
+),
+released AS (
+    UPDATE agent_runs AS r
+    SET lease_owner = NULL,
+        lease_until = NULL,
+        stale_reclaim_pending = TRUE,
+        updated_at = NOW()
+    FROM candidates AS c
+    WHERE r.id = c.id
+    RETURNING r.id::text AS run_id,
+              c.correlation_id,
+              c.project_id,
+              c.previous_lease_owner,
+              c.previous_lease_until,
+              'stopped'::text AS worker_status
+)
+SELECT run_id,
+       correlation_id,
+       project_id,
+       previous_lease_owner,
+       previous_lease_until,
+       worker_status
+FROM released
+ORDER BY run_id;


### PR DESCRIPTION
## Что сделано
- добавил graceful release `running` leases при shutdown worker pod;
- добавил SQL-path `release_owned_running_leases` в runqueue repository;
- добавил `Service.ReleaseOwnedRunLeasesOnShutdown()` и вызов в shutdown-path worker;
- добавил unit-тест на graceful handoff owned leases.

## В чем была проблема
На run `8ca33b13-2084-4173-ad4c-dab58bc2fe7f` runtime deploy в production завершился успешно, но сам run позже завершился `failed` уже после этого.

Проблема проявляется в окне production rollout:
- worker уже перевел run в `running`;
- full-env runtime успел подготовиться или почти подготовился;
- worker pod получает `SIGTERM` во время self-deploy/rollout;
- owned `running` lease остается на завершающемся worker и не передается следующему worker сразу;
- recovery откладывается на stale-sweep path и становится чувствительной к гонкам вокруг restart/reconcile.

Из-за этого периодически падают runs во время production deploy, хотя root cause не в агенте и не в миграциях.

## Почему этот фикс корректный
Теперь worker на shutdown делает best-effort release всех своих owned `running` leases до `markWorkerStopped`.
Это дает следующему worker возможность сразу забрать run и пройти уже существующий recovery-path (`recovering run without job ...`), не дожидаясь stale-lease sweep.

Это уменьшает окно гонки именно там, где production rollout сейчас периодически ломает runs.

## Проверки
- `go test ./services/jobs/worker/internal/domain/worker ./services/jobs/worker/internal/repository/postgres/runqueue ./services/jobs/worker/internal/app`
- `git diff --check`

## Self-check
- `docs/design-guidelines/common/check_list.md` — релевантные пункты выполнены
- `docs/design-guidelines/go/check_list.md` — релевантные пункты выполнены

## Что не зелёное вне diff
- `make lint-go` падает на pre-existing проблемах вне этого diff:
  - `services/external/api-gateway/internal/transport/http/interaction_callback_handler_test.go:54`
  - `services/external/api-gateway/internal/transport/http/staff_list_realtime_handler.go:122`
  - `services/external/api-gateway/internal/transport/http/staff_realtime_handler.go:117`
  - `services/external/api-gateway/internal/transport/http/staff_realtime_mission_control.go:36`
  - `services/jobs/agent-runner/internal/runner/codex_auth.go:189`
  - `libs/go/k8s/joblauncher/runtime_namespace.go:206`
  - `libs/go/servicescfg/load_validation.go:315`
  - `services/internal/control-plane/internal/domain/missioncontrol/service_helpers.go:519`
- `make dupl-go` показывает pre-existing duplicate между repository interface файлами:
  - `services/internal/control-plane/internal/domain/repository/runtimedeploytask/repository.go`
  - `services/jobs/worker/internal/domain/repository/runqueue/repository.go`
