### PR TITLE
fix: привязать runtime deploy snapshot к build ref

### DIFF
--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync.go
@@ -142,9 +142,6 @@ func (s *Service) repoSnapshotPath(targetEnv string, owner string, name string, 
 	if cacheRoot == "" {
 		return ""
 	}
-	if isAIEnv(targetEnv) {
-		return cacheRoot
-	}
 	refToken := sanitizeNameToken(buildRef, 120)
 	if refToken == "" {
 		refToken = "main"

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync_test.go
@@ -109,3 +109,35 @@ func TestShouldSyncRepoSnapshotToRuntimeNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestRepoSnapshotPath_UsesBuildRefScopedSnapshotForAIEnv(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		cfg: Config{
+			RepositoryRoot: "/repo-cache",
+		},
+	}
+
+	got := svc.repoSnapshotPath("ai", "codex-k8s", "codex-k8s", "3e7c26a0470fbab877607df5f82f5874a8119b5f")
+	want := "/repo-cache/github/codex-k8s/codex-k8s/3e7c26a0470fbab877607df5f82f5874a8119b5f"
+	if got != want {
+		t.Fatalf("repoSnapshotPath(ai) = %q, want %q", got, want)
+	}
+}
+
+func TestRepoSnapshotPath_FallsBackToMainWhenBuildRefIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		cfg: Config{
+			RepositoryRoot: "/repo-cache",
+		},
+	}
+
+	got := svc.repoSnapshotPath("ai", "codex-k8s", "codex-k8s", "")
+	want := "/repo-cache/github/codex-k8s/codex-k8s/main"
+	if got != want {
+		t.Fatalf("repoSnapshotPath(empty build ref) = %q, want %q", got, want)
+	}
+}

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_reuse_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_reuse_test.go
@@ -69,7 +69,7 @@ func TestEvaluateRuntimeReuse_ReturnsFingerprintMismatchWhenRenderedManifestsDri
 		t.Fatalf("persistRuntimeFingerprint() error = %v", err)
 	}
 
-	manifestPath := filepath.Join(svc.cfg.RepositoryRoot, "deploy", "base", "app.yaml")
+	manifestPath := filepath.Join(svc.repoSnapshotPath(params.TargetEnv, "codex-k8s", "codex-k8s", params.BuildRef), "deploy", "base", "app.yaml")
 	if err := os.WriteFile(manifestPath, []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -206,9 +206,10 @@ func TestBuildRuntimeFingerprint_EnrichesMissingScopeFromRunPayload(t *testing.T
 func newRuntimeReuseTestService(t *testing.T) (*Service, EvaluateReuseParams, *fakeRuntimeReuseKubernetesClient) {
 	t.Helper()
 
-	repoRoot := t.TempDir()
+	repoRoot := filepath.Join(t.TempDir(), "repo-cache")
 	commitSHA := "0123456789abcdef0123456789abcdef01234567"
-	mustWriteRuntimeReuseTestRepo(t, repoRoot, commitSHA)
+	snapshotRoot := filepath.Join(repoRoot, "github", "codex-k8s", "codex-k8s", commitSHA)
+	mustWriteRuntimeReuseTestRepo(t, snapshotRoot, commitSHA)
 
 	namespace := "codex-k8s-dev-1"
 	k8s := &fakeRuntimeReuseKubernetesClient{


### PR DESCRIPTION
## Что сделано
- убран special-case, при котором `ai/full-env` runtime deploy использовал общий mutable repo cache root как source snapshot;
- control-plane теперь всегда читает `services.yaml` и шаблоны из snapshot-каталога, привязанного к конкретному `build_ref`;
- добавлены регрессионные тесты на build-ref scoped snapshot для `ai` и обновлены reuse-тесты.

## В чем была проблема
Для `ai/full-env` `resolveRunRepositoryRoot()` сводил source snapshot к общему `/repo-cache`. Из-за этого параллельные run и свежий `main` периодически перетирали snapshot, а build/apply принимали решения по чужому или stale `services.yaml`. Именно поэтому в проблемном run для `#473 / PR #483` `repo-sync` уже имел правильный `services.yaml`, но `runtime_deploy` продолжал проверять и использовать старые image tags.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy/...`
- `go test ./services/internal/control-plane/internal/app ./services/internal/control-plane/internal/domain/runtimedeploy/...`
- `git diff --check`
- `make dupl-go` падает на pre-existing duplicate вне этого diff:
  - `services/internal/control-plane/internal/domain/repository/runtimedeploytask/repository.go:11-23`
  - `services/jobs/worker/internal/domain/repository/runqueue/repository.go:9-21`
