### PR TITLE
fix: синкать source snapshot runtime deploy в platform namespace

### DIFF
--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync.go
@@ -65,15 +65,9 @@ func (s *Service) resolveRunRepositoryRoot(ctx context.Context, params PreparePa
 		valueOr(vars, "CODEXK8S_AGENT_BASE_BRANCH", ""),
 	)
 
-	syncNamespace := strings.TrimSpace(params.Namespace)
+	syncNamespace := resolveSourceRepoSyncNamespace(params.Namespace, vars)
 	if syncNamespace == "" {
-		syncNamespace = strings.TrimSpace(valueOr(vars, "CODEXK8S_PRODUCTION_NAMESPACE", ""))
-	}
-	if syncNamespace == "" {
-		syncNamespace = strings.TrimSpace(valueOr(vars, "CODEXK8S_PLATFORM_NAMESPACE", ""))
-	}
-	if syncNamespace == "" {
-		return "", fmt.Errorf("target namespace is required for repo sync")
+		return "", fmt.Errorf("source namespace is required for repo sync")
 	}
 
 	repoRoot := s.repoSnapshotPath(params.TargetEnv, owner, name, buildRef)
@@ -117,6 +111,16 @@ func looksLikeRepositoryRoot(root string) bool {
 
 func shouldUseDirectRepositoryRoot(configuredRoot string, repositoryFullName string) bool {
 	return looksLikeRepositoryRoot(configuredRoot) && strings.TrimSpace(repositoryFullName) == ""
+}
+
+func resolveSourceRepoSyncNamespace(targetNamespace string, vars map[string]string) string {
+	if platformNamespace := strings.TrimSpace(valueOr(vars, "CODEXK8S_PLATFORM_NAMESPACE", "")); platformNamespace != "" {
+		return platformNamespace
+	}
+	if productionNamespace := strings.TrimSpace(valueOr(vars, "CODEXK8S_PRODUCTION_NAMESPACE", "")); productionNamespace != "" {
+		return productionNamespace
+	}
+	return strings.TrimSpace(targetNamespace)
 }
 
 func isImmutableGitRef(ref string) bool {

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_repo_sync_test.go
@@ -31,6 +31,50 @@ func TestShouldUseDirectRepositoryRoot_FalseForNonRepositoryPath(t *testing.T) {
 	}
 }
 
+func TestResolveSourceRepoSyncNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		targetNamespace string
+		vars            map[string]string
+		want            string
+	}{
+		{
+			name:            "prefers platform namespace for full env source snapshot",
+			targetNamespace: "codex-issue-3278207d1cd3-i473-r4a5958f0757f",
+			vars: map[string]string{
+				"CODEXK8S_PLATFORM_NAMESPACE":   "codex-k8s-prod",
+				"CODEXK8S_PRODUCTION_NAMESPACE": "codex-issue-3278207d1cd3-i473-r4a5958f0757f",
+			},
+			want: "codex-k8s-prod",
+		},
+		{
+			name:            "falls back to production namespace when platform missing",
+			targetNamespace: "codex-issue-3278207d1cd3-i473-r4a5958f0757f",
+			vars: map[string]string{
+				"CODEXK8S_PRODUCTION_NAMESPACE": "codex-k8s-prod",
+			},
+			want: "codex-k8s-prod",
+		},
+		{
+			name:            "falls back to target namespace when no platform vars available",
+			targetNamespace: "codex-k8s-dev-1",
+			vars:            map[string]string{},
+			want:            "codex-k8s-dev-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveSourceRepoSyncNamespace(tt.targetNamespace, tt.vars); got != tt.want {
+				t.Fatalf("resolveSourceRepoSyncNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldSyncRepoSnapshotToRuntimeNamespace(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Что исправлено
- source snapshot для `runtime_deploy` теперь синкается в `platform namespace`, а не в `target runtime namespace`;
- hot-reload sync в runtime namespace оставлен отдельно и не смешивается с source snapshot для control-plane;
- добавлены регрессионные тесты на выбор namespace для source snapshot.

## Корень проблемы
После прошлого фикса snapshot стал привязываться к `build_ref`, но `resolveRunRepositoryRoot()` продолжал запускать `repo-sync` в `target namespace` full-env run.

При этом сам control-plane сразу после `repo-sync` проверял локальный путь `/repo-cache/github/<owner>/<repo>/<build_ref>/.git` в своём собственном PVC. Это разные namespace/PVC, поэтому:
- job `repo-sync` в target namespace успешно отрабатывал;
- локальная проверка в production control-plane не находила `.git`;
- run падал ошибкой вида:
  - `repo snapshot is missing after repo sync: /repo-cache/github/.../.git: no such file or directory`

Это и произошло у `run 7b688639-c175-4ec3-969f-ebd050235bbb`.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy/... ./services/internal/control-plane/internal/app`
- `git diff --check`
- `make lint-go` падает только на pre-existing проблемах вне diff
- `make dupl-go` падает только на pre-existing дубле вне diff
