### PR TITLE
Issue #503: открыть built-in user interaction tools и убрать namespace-local MCP routing (#503)

### DIFF
--- a/docs/architecture/agent_runtime_rbac.md
+++ b/docs/architecture/agent_runtime_rbac.md
@@ -68,6 +68,7 @@ approvals:
   - `run:dev` создаёт новый candidate namespace или продолжает уже существующий candidate lineage текущей Issue/PR;
   - `run:qa` и `run:release` обязаны продолжать существующий candidate identity той же Issue/PR; fallback на default branch запрещён, при отсутствии lineage платформа публикует диагностический warning и ставит `need:input`;
   - `run:postdeploy` и `run:ops` не используют candidate namespace, а запускаются в production namespace платформы и читают production runtime с профилем `production-readonly`.
+  - run pods получают platform-scoped `CODEXK8S_CONTROL_PLANE_GRPC_TARGET` и `CODEXK8S_CONTROL_PLANE_MCP_BASE_URL`; candidate namespace не должен silently переписывать эти endpoint'ы на namespace-local `control-plane`.
 - Отдельный debug-label для manual-retention не используется.
 - В Kubernetes нет встроенного TTL-контроллера для namespace; cleanup реализуется безопасным sweeper-контуром:
   - in-band sweep в worker reconcile tick;
@@ -114,7 +115,7 @@ approvals:
   - прямой доступ к `secrets`;
   - выход за пределы своего namespace и cluster-scope операции.
 
-- MCP в MVP baseline используется для label-операций и control tools (`secret sync`, `database lifecycle`, `owner feedback`) с approval/audit контуром.
+- MCP в MVP baseline используется для label-операций, built-in user interactions (`user.notify`, `user.decision.request`) и control tools (`secret sync`, `database lifecycle`, `owner feedback`) с approval/audit контуром.
 
 Эволюция policy (Day6+):
 - effective MCP права вычисляются по связке `agent_key + run label`;
@@ -135,6 +136,7 @@ approvals:
 - Agent pod получает минимально необходимые runtime-секреты на время run:
   - `CODEXK8S_OPENAI_API_KEY` для codex auth;
   - `CODEXK8S_GIT_BOT_TOKEN` для git transport path.
+- Agent pod получает platform-scoped control-plane endpoints из env; отсутствие явного `CODEXK8S_CONTROL_PLANE_GRPC_TARGET`/`CODEXK8S_CONTROL_PLANE_MCP_BASE_URL` считается misconfiguration и не должно маскироваться namespace-local fallback'ом.
 - Для `full-env` pod формируется `KUBECONFIG` из namespaced ServiceAccount.
 - Прямой доступ агента к Kubernetes `secrets` запрещён RBAC (read/write).
 - Создание/обновление секретов с генерацией значений и approver-политикой выполняется через MCP control tools.

--- a/docs/architecture/mcp_approval_and_audit_flow.md
+++ b/docs/architecture/mcp_approval_and_audit_flow.md
@@ -19,7 +19,7 @@ approvals:
 # MCP Approval and Audit Flow
 
 ## TL;DR
-- MCP в MVP baseline используется для GitHub label-операций, progress-feedback (`run_status_report`), built-in user interactions (`user.decision.request`), self-improve diagnostics tools и control tools (secret sync, database lifecycle, owner feedback).
+- MCP в MVP baseline используется для GitHub label-операций, progress-feedback (`run_status_report`), built-in user interactions (`user.notify`, `user.decision.request`), self-improve diagnostics tools и control tools (secret sync, database lifecycle, owner feedback).
 - GitHub issue/PR/comments и Kubernetes runtime-операции выполняются агентом напрямую через `gh`/`kubectl`.
 - Approval gate в MCP управляется policy matrix: для label-инструментов возможен `approval:none`, для privileged control tools — `approval:required`.
 - Все действия логируются в единый audit-контур (`flow_events`, `agent_sessions`, `links`, `token_usage`).
@@ -36,8 +36,9 @@ approvals:
 - Для MCP label-инструментов (`github_labels_list|add|remove|transition`) используется `approval:none`.
 - Для MCP progress-feedback инструмента (`run_status_report`) используется `approval:none`;
   входной `status` ограничен 100 символами для компактного статуса.
-- Для built-in user interaction инструмента (`user.decision.request`) используется `approval:none`;
-  он создаёт типизированный interaction request и должен использоваться агентом для запросов выбора/подтверждения у пользователя вместо ad-hoc комментариев.
+- Для built-in user interaction инструментов (`user.notify`, `user.decision.request`) используется `approval:none`;
+  `user.notify` остаётся non-blocking notification path, а `user.decision.request` создаёт типизированный interaction request и должен использоваться агентом для запросов выбора/подтверждения у пользователя вместо ad-hoc комментариев.
+- В effective run-scoped catalog оба user-facing инструмента доступны для stage-run, кроме `run:self-improve*`; self-improve сохраняет только diagnostic MCP scope.
 - Для self-improve read-инструментов (`self_improve_runs_list`, `self_improve_run_lookup`, `self_improve_session_get`) используется `approval:none`.
 - Label transitions всё равно проходят через control-plane MCP, чтобы сохранять единый audit-контур.
 - Для control tools (`secret.sync.k8s`, `database.lifecycle`, `owner.feedback.request`) включается approver gate по policy.

--- a/docs/product/labels_and_trigger_policy.md
+++ b/docs/product/labels_and_trigger_policy.md
@@ -189,7 +189,8 @@ approvals:
 ## Оркестрационный flow для `run:dev` / `run:dev:revise`
 
 - Для каждого запуска MCP выдает только run-scoped список ручек:
-  - для `run:dev`/`run:dev:revise` baseline = только label-ручки;
+  - для всех stage-run, кроме `run:self-improve*`, baseline = label/status ручки + built-in user interactions (`user.notify`, `user.decision.request`);
+  - для `run:self-improve`/`run:self-improve:revise` baseline остаётся label/status + self-improve diagnostics без user-facing interaction tools;
   - недоступные ручки скрываются из `tools/list` и блокируются на `tools/call`.
 - На issue одновременно допускается только один активный trigger label из группы `run:*`.
 - `run:dev` используется для первичного запуска цикла разработки и создания PR.

--- a/services/internal/control-plane/internal/domain/mcp/prompt_context_tools_test.go
+++ b/services/internal/control-plane/internal/domain/mcp/prompt_context_tools_test.go
@@ -1,12 +1,17 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	agentdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/agent"
 	"github.com/codex-k8s/codex-k8s/libs/go/servicescfg"
+	agentrunrepo "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/repository/agentrun"
+	repocfgrepo "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/repository/repocfg"
 	entitytypes "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/types/entity"
 	querytypes "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/types/query"
 )
@@ -188,4 +193,178 @@ func TestBuildPromptRoleContext_DefaultAndKnownRole(t *testing.T) {
 	if len(unknown.Capabilities) != 1 {
 		t.Fatalf("unknown role capabilities len=%d, want 1", len(unknown.Capabilities))
 	}
+}
+
+func TestPromptContextIncludesBuiltInUserInteractionToolsForDevRun(t *testing.T) {
+	t.Parallel()
+
+	runPayload, err := json.Marshal(querytypes.RunPayload{
+		Project: querytypes.RunPayloadProject{
+			ID:           "project-1",
+			RepositoryID: "repo-1",
+		},
+		Repository: querytypes.RunPayloadRepository{
+			FullName: "codex-k8s/codex-k8s",
+		},
+		Agent: &querytypes.RunPayloadAgent{
+			Key: "dev",
+		},
+		Trigger: &querytypes.RunPayloadTrigger{
+			Kind: "dev",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal run payload: %v", err)
+	}
+
+	service := &Service{
+		cfg: Config{
+			ServerName:         "codex-k8s-control-plane-mcp",
+			InternalMCPBaseURL: "http://platform-control-plane.example/mcp",
+			RepositoryRoot:     t.TempDir(),
+		},
+		runs: &promptContextTestRunsRepository{
+			run: agentrunrepo.Run{
+				ID:            "run-1",
+				CorrelationID: "corr-1",
+				ProjectID:     "project-1",
+				Status:        "running",
+				RunPayload:    runPayload,
+			},
+		},
+		repos: &promptContextTestReposRepository{
+			repository: repocfgrepo.RepositoryBinding{
+				ID:               "repo-1",
+				ProjectID:        "project-1",
+				Provider:         "github",
+				Owner:            "codex-k8s",
+				Name:             "codex-k8s",
+				ServicesYAMLPath: "services.yaml",
+			},
+		},
+		toolCatalog: DefaultToolCatalog(),
+		now:         time.Now,
+	}
+
+	result, err := service.PromptContext(context.Background(), SessionContext{
+		RunID:         "run-1",
+		CorrelationID: "corr-1",
+		ProjectID:     "project-1",
+		RuntimeMode:   agentdomain.RuntimeModeFullEnv,
+	})
+	if err != nil {
+		t.Fatalf("PromptContext() error = %v", err)
+	}
+
+	if !promptContextHasTool(result.Context.MCP.Tools, ToolMCPUserNotify) {
+		t.Fatalf("prompt context tools do not include %q", ToolMCPUserNotify)
+	}
+	if !promptContextHasTool(result.Context.MCP.Tools, ToolMCPUserDecisionRequest) {
+		t.Fatalf("prompt context tools do not include %q", ToolMCPUserDecisionRequest)
+	}
+}
+
+func promptContextHasTool(tools []ToolCapability, name ToolName) bool {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+type promptContextTestRunsRepository struct {
+	run agentrunrepo.Run
+}
+
+func (r *promptContextTestRunsRepository) CreatePendingIfAbsent(context.Context, agentrunrepo.CreateParams) (agentrunrepo.CreateResult, error) {
+	return agentrunrepo.CreateResult{}, nil
+}
+
+func (r *promptContextTestRunsRepository) GetByID(context.Context, string) (agentrunrepo.Run, bool, error) {
+	return r.run, true, nil
+}
+
+func (r *promptContextTestRunsRepository) CancelActiveByID(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (r *promptContextTestRunsRepository) ListRecentByProject(context.Context, string, string, int, int) ([]agentrunrepo.RunLookupItem, error) {
+	return nil, nil
+}
+
+func (r *promptContextTestRunsRepository) SearchRecentByProjectIssueOrPullRequest(context.Context, string, string, int64, int64, int) ([]agentrunrepo.RunLookupItem, error) {
+	return nil, nil
+}
+
+func (r *promptContextTestRunsRepository) ListRunIDsByRepositoryIssue(context.Context, string, int64, int) ([]string, error) {
+	return nil, nil
+}
+
+func (r *promptContextTestRunsRepository) ListRunIDsByRepositoryPullRequest(context.Context, string, int64, int) ([]string, error) {
+	return nil, nil
+}
+
+func (r *promptContextTestRunsRepository) SetWaitContext(context.Context, agentrunrepo.SetWaitContextParams) (bool, error) {
+	return false, nil
+}
+
+func (r *promptContextTestRunsRepository) ClearWaitContextIfMatches(context.Context, agentrunrepo.ClearWaitContextParams) (bool, error) {
+	return false, nil
+}
+
+type promptContextTestReposRepository struct {
+	repository repocfgrepo.RepositoryBinding
+}
+
+func (r *promptContextTestReposRepository) ListForProject(context.Context, string, int) ([]repocfgrepo.RepositoryBinding, error) {
+	return nil, nil
+}
+
+func (r *promptContextTestReposRepository) GetByID(context.Context, string) (repocfgrepo.RepositoryBinding, bool, error) {
+	return r.repository, true, nil
+}
+
+func (r *promptContextTestReposRepository) Upsert(context.Context, repocfgrepo.UpsertParams) (repocfgrepo.RepositoryBinding, error) {
+	return repocfgrepo.RepositoryBinding{}, nil
+}
+
+func (r *promptContextTestReposRepository) Delete(context.Context, string, string) error {
+	return nil
+}
+
+func (r *promptContextTestReposRepository) FindByProviderExternalID(context.Context, string, int64) (repocfgrepo.FindResult, bool, error) {
+	return repocfgrepo.FindResult{}, false, nil
+}
+
+func (r *promptContextTestReposRepository) FindByProviderOwnerName(context.Context, string, string, string) (repocfgrepo.FindResult, bool, error) {
+	return repocfgrepo.FindResult{}, false, nil
+}
+
+func (r *promptContextTestReposRepository) GetTokenEncrypted(context.Context, string) ([]byte, bool, error) {
+	return nil, false, nil
+}
+
+func (r *promptContextTestReposRepository) GetBotTokenEncrypted(context.Context, string) ([]byte, bool, error) {
+	return nil, false, nil
+}
+
+func (r *promptContextTestReposRepository) UpsertBotParams(context.Context, repocfgrepo.RepositoryBotParamsUpsertParams) error {
+	return nil
+}
+
+func (r *promptContextTestReposRepository) UpsertPreflightReport(context.Context, repocfgrepo.RepositoryPreflightReportUpsertParams) error {
+	return nil
+}
+
+func (r *promptContextTestReposRepository) AcquirePreflightLock(context.Context, repocfgrepo.RepositoryPreflightLockAcquireParams) (string, bool, error) {
+	return "", false, nil
+}
+
+func (r *promptContextTestReposRepository) ReleasePreflightLock(context.Context, string, string) error {
+	return nil
+}
+
+func (r *promptContextTestReposRepository) SetTokenEncryptedForAll(context.Context, []byte) (int64, error) {
+	return 0, nil
 }

--- a/services/internal/control-plane/internal/domain/mcp/tool_access_policy.go
+++ b/services/internal/control-plane/internal/domain/mcp/tool_access_policy.go
@@ -15,6 +15,10 @@ var (
 		ToolGitHubLabelsTransition,
 		ToolRunStatusReport,
 	}
+	userInteractionTools = []ToolName{
+		ToolMCPUserNotify,
+		ToolMCPUserDecisionRequest,
+	}
 	selfImproveDiagnosticTools = []ToolName{
 		ToolSelfImproveRunsList,
 		ToolSelfImproveRunLookup,
@@ -51,7 +55,7 @@ func (s *Service) IsToolAllowed(ctx context.Context, session SessionContext, too
 }
 
 func (s *Service) allowedToolsForRunContext(runCtx resolvedRunContext) []ToolCapability {
-	allowedNames := make(map[ToolName]struct{}, len(baseLabelTools)+len(selfImproveDiagnosticTools)+len(controlPlaneControlTools))
+	allowedNames := make(map[ToolName]struct{}, len(baseLabelTools)+len(userInteractionTools)+len(selfImproveDiagnosticTools)+len(controlPlaneControlTools))
 	addAllowedToolNames(allowedNames, baseLabelTools...)
 
 	triggerKind := webhookdomain.TriggerKindDev
@@ -61,6 +65,10 @@ func (s *Service) allowedToolsForRunContext(runCtx resolvedRunContext) []ToolCap
 	agentKey := ""
 	if runCtx.Payload.Agent != nil {
 		agentKey = strings.ToLower(strings.TrimSpace(runCtx.Payload.Agent.Key))
+	}
+
+	if triggerKind != webhookdomain.TriggerKindSelfImprove && triggerKind != webhookdomain.TriggerKindSelfImproveRevise {
+		addAllowedToolNames(allowedNames, userInteractionTools...)
 	}
 
 	switch triggerKind {

--- a/services/internal/control-plane/internal/domain/mcp/tool_access_policy_test.go
+++ b/services/internal/control-plane/internal/domain/mcp/tool_access_policy_test.go
@@ -16,7 +16,7 @@ func TestAllowedToolsForRunContext(t *testing.T) {
 		wantAllowedTools []ToolName
 	}{
 		{
-			name:        "dev gets labels only",
+			name:        "dev gets labels and user interactions",
 			triggerKind: "dev",
 			agentKey:    "dev",
 			wantAllowedTools: []ToolName{
@@ -25,6 +25,8 @@ func TestAllowedToolsForRunContext(t *testing.T) {
 				ToolGitHubLabelsRemove,
 				ToolGitHubLabelsTransition,
 				ToolRunStatusReport,
+				ToolMCPUserDecisionRequest,
+				ToolMCPUserNotify,
 			},
 		},
 		{
@@ -43,7 +45,7 @@ func TestAllowedToolsForRunContext(t *testing.T) {
 			},
 		},
 		{
-			name:        "ops sre gets labels and control tools",
+			name:        "ops sre gets labels, user interactions and control tools",
 			triggerKind: "ops",
 			agentKey:    "sre",
 			wantAllowedTools: []ToolName{
@@ -55,10 +57,12 @@ func TestAllowedToolsForRunContext(t *testing.T) {
 				ToolMCPOwnerFeedbackRequest,
 				ToolRunStatusReport,
 				ToolMCPSecretSyncEnv,
+				ToolMCPUserDecisionRequest,
+				ToolMCPUserNotify,
 			},
 		},
 		{
-			name:        "ops qa gets labels only",
+			name:        "ops qa gets labels and user interactions",
 			triggerKind: "ops",
 			agentKey:    "qa",
 			wantAllowedTools: []ToolName{
@@ -67,10 +71,12 @@ func TestAllowedToolsForRunContext(t *testing.T) {
 				ToolGitHubLabelsRemove,
 				ToolGitHubLabelsTransition,
 				ToolRunStatusReport,
+				ToolMCPUserDecisionRequest,
+				ToolMCPUserNotify,
 			},
 		},
 		{
-			name:        "ai-repair sre gets labels and control tools",
+			name:        "ai-repair sre gets labels, user interactions and control tools",
 			triggerKind: "ai_repair",
 			agentKey:    "sre",
 			wantAllowedTools: []ToolName{
@@ -82,6 +88,8 @@ func TestAllowedToolsForRunContext(t *testing.T) {
 				ToolMCPOwnerFeedbackRequest,
 				ToolRunStatusReport,
 				ToolMCPSecretSyncEnv,
+				ToolMCPUserDecisionRequest,
+				ToolMCPUserNotify,
 			},
 		},
 	}

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_templates.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_templates.go
@@ -1,7 +1,6 @@
 package runtimedeploy
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -93,12 +92,6 @@ func (s *Service) buildTemplateVars(params PrepareParams, namespace string) map[
 	if targetNamespace != "" {
 		vars["CODEXK8S_PRODUCTION_NAMESPACE"] = targetNamespace
 		vars["CODEXK8S_WORKER_K8S_NAMESPACE"] = targetNamespace
-		if strings.TrimSpace(vars["CODEXK8S_CONTROL_PLANE_GRPC_TARGET"]) == "" {
-			vars["CODEXK8S_CONTROL_PLANE_GRPC_TARGET"] = fmt.Sprintf("codex-k8s-control-plane.%s.svc.cluster.local:9090", targetNamespace)
-		}
-		if strings.TrimSpace(vars["CODEXK8S_CONTROL_PLANE_MCP_BASE_URL"]) == "" {
-			vars["CODEXK8S_CONTROL_PLANE_MCP_BASE_URL"] = fmt.Sprintf("http://codex-k8s-control-plane.%s.svc.cluster.local:8081/mcp", targetNamespace)
-		}
 	}
 
 	publicDomain := resolvePublicDomain(targetEnv, targetNamespace, vars)

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go
@@ -82,6 +82,34 @@ func TestBuildTemplateVars_ProductionPreservesKanikoCleanupValue(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateVars_PreservesExplicitPlatformControlPlaneEndpoints(t *testing.T) {
+	t.Setenv("CODEXK8S_CONTROL_PLANE_GRPC_TARGET", "codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:9090")
+	t.Setenv("CODEXK8S_CONTROL_PLANE_MCP_BASE_URL", "http://codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:8081/mcp")
+
+	svc := &Service{}
+	vars := svc.buildTemplateVars(PrepareParams{TargetEnv: "ai"}, "codex-issue-503")
+	if got, want := vars["CODEXK8S_CONTROL_PLANE_GRPC_TARGET"], "codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:9090"; got != want {
+		t.Fatalf("grpc target = %q, want %q", got, want)
+	}
+	if got, want := vars["CODEXK8S_CONTROL_PLANE_MCP_BASE_URL"], "http://codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:8081/mcp"; got != want {
+		t.Fatalf("mcp base url = %q, want %q", got, want)
+	}
+}
+
+func TestBuildTemplateVars_DoesNotInventNamespaceLocalControlPlaneEndpoints(t *testing.T) {
+	t.Setenv("CODEXK8S_CONTROL_PLANE_GRPC_TARGET", "")
+	t.Setenv("CODEXK8S_CONTROL_PLANE_MCP_BASE_URL", "")
+
+	svc := &Service{}
+	vars := svc.buildTemplateVars(PrepareParams{TargetEnv: "ai"}, "codex-issue-503")
+	if got := vars["CODEXK8S_CONTROL_PLANE_GRPC_TARGET"]; got != "" {
+		t.Fatalf("grpc target = %q, want empty value", got)
+	}
+	if got := vars["CODEXK8S_CONTROL_PLANE_MCP_BASE_URL"]; got != "" {
+		t.Fatalf("mcp base url = %q, want empty value", got)
+	}
+}
+
 func TestResolveServicesConfigPath_PrefersRepoSnapshotWhenConfigPathIsAbsolute(t *testing.T) {
 	t.Parallel()
 

--- a/services/internal/control-plane/internal/transport/mcp/tool_access_middleware_test.go
+++ b/services/internal/control-plane/internal/transport/mcp/tool_access_middleware_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	mcpdomain "github.com/codex-k8s/codex-k8s/services/internal/control-plane/internal/domain/mcp"
+)
+
+func TestHandleToolsListAccessFiltersToAllowedCatalog(t *testing.T) {
+	t.Parallel()
+
+	req := &sdkmcp.ServerRequest[*sdkmcp.ListToolsParams]{
+		Params: &sdkmcp.ListToolsParams{},
+		Extra: &sdkmcp.RequestExtra{
+			TokenInfo: &auth.TokenInfo{
+				Extra: map[string]any{
+					tokenInfoSessionKey: mcpdomain.SessionContext{RunID: "run-1"},
+				},
+			},
+		},
+	}
+	service := toolAccessMiddlewareTestService{
+		allowedTools: []mcpdomain.ToolCapability{
+			{Name: mcpdomain.ToolGitHubLabelsList},
+			{Name: mcpdomain.ToolMCPUserNotify},
+			{Name: mcpdomain.ToolMCPUserDecisionRequest},
+		},
+	}
+
+	result, err := handleToolsListAccess(context.Background(), mcpMethodToolsList, req, service, func(context.Context, string, sdkmcp.Request) (sdkmcp.Result, error) {
+		return &sdkmcp.ListToolsResult{
+			Tools: []*sdkmcp.Tool{
+				{Name: string(mcpdomain.ToolGitHubLabelsList)},
+				{Name: string(mcpdomain.ToolMCPUserNotify)},
+				{Name: string(mcpdomain.ToolMCPUserDecisionRequest)},
+				{Name: "not.allowed"},
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("handleToolsListAccess() error = %v", err)
+	}
+
+	toolsResult, ok := result.(*sdkmcp.ListToolsResult)
+	if !ok {
+		t.Fatalf("result type = %T, want *sdkmcp.ListToolsResult", result)
+	}
+	if len(toolsResult.Tools) != 3 {
+		t.Fatalf("tools/list filtered count = %d, want 3", len(toolsResult.Tools))
+	}
+	if toolsResult.Tools[1].Name != string(mcpdomain.ToolMCPUserNotify) {
+		t.Fatalf("filtered tool[1] = %q, want %q", toolsResult.Tools[1].Name, mcpdomain.ToolMCPUserNotify)
+	}
+	if toolsResult.Tools[2].Name != string(mcpdomain.ToolMCPUserDecisionRequest) {
+		t.Fatalf("filtered tool[2] = %q, want %q", toolsResult.Tools[2].Name, mcpdomain.ToolMCPUserDecisionRequest)
+	}
+}
+
+type toolAccessMiddlewareTestService struct {
+	allowedTools []mcpdomain.ToolCapability
+}
+
+func (s toolAccessMiddlewareTestService) VerifyRunToken(context.Context, string) (mcpdomain.SessionContext, error) {
+	return mcpdomain.SessionContext{}, nil
+}
+
+func (s toolAccessMiddlewareTestService) AllowedTools(context.Context, mcpdomain.SessionContext) ([]mcpdomain.ToolCapability, error) {
+	return s.allowedTools, nil
+}
+
+func (s toolAccessMiddlewareTestService) IsToolAllowed(_ context.Context, _ mcpdomain.SessionContext, toolName mcpdomain.ToolName) (bool, error) {
+	for _, tool := range s.allowedTools {
+		if tool.Name == toolName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (toolAccessMiddlewareTestService) GitHubLabelsList(context.Context, mcpdomain.SessionContext, mcpdomain.GitHubLabelsListInput) (mcpdomain.GitHubLabelsListResult, error) {
+	return mcpdomain.GitHubLabelsListResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) GitHubLabelsAdd(context.Context, mcpdomain.SessionContext, mcpdomain.GitHubLabelsAddInput) (mcpdomain.GitHubLabelsMutationResult, error) {
+	return mcpdomain.GitHubLabelsMutationResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) GitHubLabelsRemove(context.Context, mcpdomain.SessionContext, mcpdomain.GitHubLabelsRemoveInput) (mcpdomain.GitHubLabelsMutationResult, error) {
+	return mcpdomain.GitHubLabelsMutationResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) GitHubLabelsTransition(context.Context, mcpdomain.SessionContext, mcpdomain.GitHubLabelsTransitionInput) (mcpdomain.GitHubLabelsMutationResult, error) {
+	return mcpdomain.GitHubLabelsMutationResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) RunStatusReport(context.Context, mcpdomain.SessionContext, mcpdomain.RunStatusReportInput) (mcpdomain.RunStatusReportResult, error) {
+	return mcpdomain.RunStatusReportResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) MCPSecretSyncEnv(context.Context, mcpdomain.SessionContext, mcpdomain.SecretSyncEnvInput) (mcpdomain.SecretSyncEnvResult, error) {
+	return mcpdomain.SecretSyncEnvResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) MCPDatabaseLifecycle(context.Context, mcpdomain.SessionContext, mcpdomain.DatabaseLifecycleInput) (mcpdomain.DatabaseLifecycleResult, error) {
+	return mcpdomain.DatabaseLifecycleResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) MCPOwnerFeedbackRequest(context.Context, mcpdomain.SessionContext, mcpdomain.OwnerFeedbackRequestInput) (mcpdomain.OwnerFeedbackRequestResult, error) {
+	return mcpdomain.OwnerFeedbackRequestResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) MCPUserNotify(context.Context, mcpdomain.SessionContext, mcpdomain.UserNotifyInput) (mcpdomain.UserNotifyResult, error) {
+	return mcpdomain.UserNotifyResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) MCPUserDecisionRequest(context.Context, mcpdomain.SessionContext, mcpdomain.UserDecisionRequestInput) (mcpdomain.UserDecisionRequestResult, error) {
+	return mcpdomain.UserDecisionRequestResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) SelfImproveRunsList(context.Context, mcpdomain.SessionContext, mcpdomain.SelfImproveRunsListInput) (mcpdomain.SelfImproveRunsListResult, error) {
+	return mcpdomain.SelfImproveRunsListResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) SelfImproveRunLookup(context.Context, mcpdomain.SessionContext, mcpdomain.SelfImproveRunLookupInput) (mcpdomain.SelfImproveRunLookupResult, error) {
+	return mcpdomain.SelfImproveRunLookupResult{}, nil
+}
+
+func (toolAccessMiddlewareTestService) SelfImproveSessionGet(context.Context, mcpdomain.SessionContext, mcpdomain.SelfImproveSessionGetInput) (mcpdomain.SelfImproveSessionGetResult, error) {
+	return mcpdomain.SelfImproveSessionGetResult{}, nil
+}
+
+func TestSessionFromTokenInfoRejectsMissingSession(t *testing.T) {
+	t.Parallel()
+
+	_, err := sessionFromTokenInfo(&sdkmcp.RequestExtra{TokenInfo: &auth.TokenInfo{
+		Expiration: time.Now(),
+	}})
+	if err == nil {
+		t.Fatal("expected error for missing session")
+	}
+}

--- a/services/jobs/worker/internal/domain/worker/mcp_base_url.go
+++ b/services/jobs/worker/internal/domain/worker/mcp_base_url.go
@@ -7,9 +7,8 @@ import (
 )
 
 const (
-	defaultControlPlaneMCPBaseURL = "http://codex-k8s-control-plane:8081/mcp"
-	controlPlaneMCPHTTPPort       = "8081"
-	controlPlaneMCPPath           = "/mcp"
+	controlPlaneMCPHTTPPort = "8081"
+	controlPlaneMCPPath     = "/mcp"
 )
 
 func resolveControlPlaneMCPBaseURL(explicitURL string, grpcTarget string) string {
@@ -19,7 +18,7 @@ func resolveControlPlaneMCPBaseURL(explicitURL string, grpcTarget string) string
 
 	host := strings.TrimSpace(grpcTarget)
 	if host == "" {
-		return defaultControlPlaneMCPBaseURL
+		return ""
 	}
 
 	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
@@ -27,7 +26,7 @@ func resolveControlPlaneMCPBaseURL(explicitURL string, grpcTarget string) string
 	}
 	host = strings.Trim(strings.TrimSpace(host), "[]")
 	if host == "" {
-		return defaultControlPlaneMCPBaseURL
+		return ""
 	}
 
 	return fmt.Sprintf("http://%s:%s%s", host, controlPlaneMCPHTTPPort, controlPlaneMCPPath)

--- a/services/jobs/worker/internal/domain/worker/mcp_base_url_test.go
+++ b/services/jobs/worker/internal/domain/worker/mcp_base_url_test.go
@@ -23,9 +23,9 @@ func TestResolveControlPlaneMCPBaseURL(t *testing.T) {
 			want:       "http://codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:8081/mcp",
 		},
 		{
-			name:       "falls back to default when grpc target is empty",
+			name:       "returns empty when grpc target is empty",
 			grpcTarget: "",
-			want:       defaultControlPlaneMCPBaseURL,
+			want:       "",
 		},
 	}
 


### PR DESCRIPTION
## Контекст
- Issue #503 закрывает blocker между Sprint S10 built-in MCP user interactions и Sprint S11 Telegram adapter flow: `user.notify` и `user.decision.request` были зарегистрированы в `control-plane`, но скрывались run-scoped allow-list политикой.
- Текущий run выполнялся в `full-env` candidate namespace `codex-k8s-dev-2` с `target_env=ai`, `build_ref=main`, `runtime_access_profile=candidate`.
- Дополнительно нужно было убрать silent fallback, который мог подставить namespace-local `control-plane` endpoint в candidate runtime.

## Основание для изменений
- `services/internal/control-plane/internal/domain/mcp/tool_access_policy.go` открывал только label/status tools для обычных stage-run и не добавлял built-in user interaction tools в effective catalog.
- `services/internal/control-plane/internal/domain/runtimedeploy/service_templates.go` подставлял `CODEXK8S_CONTROL_PLANE_GRPC_TARGET` и `CODEXK8S_CONTROL_PLANE_MCP_BASE_URL` из target namespace, если env были пусты.
- `services/jobs/worker/internal/domain/worker/mcp_base_url.go` молча падал обратно на namespace-local default URL, если явный MCP endpoint отсутствовал.
- `docs/product/labels_and_trigger_policy.md`, `docs/architecture/mcp_approval_and_audit_flow.md`, `docs/architecture/agent_runtime_rbac.md` требовали синхронизации с фактическим MCP scope и routing guardrails.

## Основной смысл правок
- Открыл `user.notify` и `user.decision.request` в effective MCP catalog для stage-run, кроме `run:self-improve*`.
- Зафиксировал routing-инвариант: candidate runtime больше не генерирует namespace-local MCP/gRPC endpoints из target namespace, а использует только platform-scoped значения из env либо падает в misconfiguration path.
- Добавил явные тесты на policy, `tools/list`, prompt-context catalog и routing guardrails.

## Что сделано
- Обновлён [tool_access_policy.go](/workspace/services/internal/control-plane/internal/domain/mcp/tool_access_policy.go): built-in user interaction tools добавляются во все обычные stage-run, а `run:self-improve*` сохраняет только diagnostics scope.
- Обновлены [tool_access_policy_test.go](/workspace/services/internal/control-plane/internal/domain/mcp/tool_access_policy_test.go), [prompt_context_tools_test.go](/workspace/services/internal/control-plane/internal/domain/mcp/prompt_context_tools_test.go) и добавлен [tool_access_middleware_test.go](/workspace/services/internal/control-plane/internal/transport/mcp/tool_access_middleware_test.go), чтобы проверить `AllowedTools(...)`, prompt-context `mcp.tools` и фильтрацию `tools/list`.
- Удалён namespace-local fallback из [service_templates.go](/workspace/services/internal/control-plane/internal/domain/runtimedeploy/service_templates.go); добавлены проверки в [service_templates_test.go](/workspace/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go) на сохранение platform-scoped endpoint'ов и отсутствие их автогенерации из target namespace.
- Ужесточён `resolveControlPlaneMCPBaseURL(...)` в [mcp_base_url.go](/workspace/services/jobs/worker/internal/domain/worker/mcp_base_url.go); обновлён [mcp_base_url_test.go](/workspace/services/jobs/worker/internal/domain/worker/mcp_base_url_test.go) под fail-fast поведение без local default.
- Синхронизированы документы [labels_and_trigger_policy.md](/workspace/docs/product/labels_and_trigger_policy.md), [mcp_approval_and_audit_flow.md](/workspace/docs/architecture/mcp_approval_and_audit_flow.md), [agent_runtime_rbac.md](/workspace/docs/architecture/agent_runtime_rbac.md).

## Логи и runtime-диагностика
- Выполнено `kubectl config view --minify -o 'jsonpath={..namespace}'` -> `codex-k8s-dev-2`.
- Выполнено `kubectl get pods -o wide` -> в namespace были `Running`: `codex-k8s-control-plane`, `codex-k8s-worker`, `codex-k8s`, `codex-k8s-web-console`, `codex-k8s-telegram-interaction-adapter`, `postgres`, текущий run pod; `codex-k8s-migrate-*` завершён `Completed`.
- Выполнено `kubectl get svc codex-k8s-control-plane -o wide` -> service слушает `9090/TCP,8081/TCP` внутри candidate namespace.
- Выполнено `kubectl logs deploy/codex-k8s-control-plane --tail=120 | rg 'mcp|interaction|error|warn'` и `kubectl logs deploy/codex-k8s-worker --tail=120 | rg 'mcp|interaction|error|warn'` -> совпадений в последних 120 строках не найдено.
- Live smoke через временный Go MCP client с run-bound bearer против `CODEXK8S_MCP_BASE_URL=http://codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:8081/mcp` показал, что задеплоенный `main` всё ещё возвращает только `github_labels_*` + `run_status_report`; вызов `user.notify` завершился ошибкой `tool "user.notify" is not available for current run profile`.
- Повторная попытка smoke против candidate-local `http://codex-k8s-control-plane:8081/mcp` тем же prod-issued bearer завершилась `Unauthorized` на `initialize`, поэтому live success-path для изменённого кода в этом run не подтверждён: текущий run-bound token выдан production/platform control-plane и не подходит для локального candidate control-plane.

## БД и миграции
- Миграции не добавлялись.
- Прямые запросы в БД не выполнялись.
- Схема и SQL не менялись.

## Проверки
- `go test ./services/internal/control-plane/internal/domain/mcp ./services/internal/control-plane/internal/transport/mcp ./services/internal/control-plane/internal/domain/runtimedeploy ./services/jobs/worker/internal/domain/worker` -> passed.
- `go mod tidy` -> passed, изменений в `go.mod`/`go.sum` не осталось.
- `make lint-go` -> passed.
- `make dupl-go` -> passed.
- Runtime smoke against production MCP endpoint -> executed, reproduced old deployed catalog without user tools.
- Runtime smoke against candidate-local MCP endpoint -> executed, blocked by `Unauthorized` because current bearer is production-scoped.

## Проверенные чек-листы
- `docs/design-guidelines/common/check_list.md` -> релевантные пункты по доменным границам, env naming, helper placement, Kubernetes/MCP policy и секретам сверены, нарушений не осталось.
- `docs/design-guidelines/go/check_list.md` -> релевантные пункты по MCP catalog sync, typed tests, helper placement, `go mod tidy`, `make lint-go`, `make dupl-go` сверены и выполнены.
- `docs/design-guidelines/vue/check_list.md` -> не требуется, Vue-код не затрагивался.

## Риски и ограничения
- Live success smoke для production/platform MCP не подтверждён в этом run, потому что production endpoint в `main` ещё не содержит этот коммит; после merge/redeploy нужна повторная проверка уже на задеплоенном коде.
- Candidate-local control-plane не может быть валидирован текущим prod-issued bearer, поэтому локальный namespace не даёт честного substitute для platform endpoint smoke.
- Политика по-прежнему оставляет `run:self-improve*` без user-facing interaction tools; это сделано сознательно, чтобы не расширять diagnostic scope self-improve.

## Рекомендации / следующий шаг
- После merge и обновления production/platform control-plane повторить live smoke на platform endpoint тем же MCP client path: `tools/list` должен показать `user.notify` и `user.decision.request`, а `user.notify` должен вернуть успешный queued result.
- На следующем late-stage run полезно зафиксировать отдельное QA evidence по production/platform routing, чтобы подтвердить и catalog, и non-blocking notify path уже на задеплоенном коде.

## Закрытие
Closes https://github.com/codex-k8s/codex-k8s/issues/503
