### PR TITLE
Fix full-env control-plane target defaults

### DIFF
--- a/deploy/base/codex-k8s/app.yaml.tpl
+++ b/deploy/base/codex-k8s/app.yaml.tpl
@@ -60,7 +60,7 @@ spec:
             - name: CODEXK8S_HTTP_ADDR
               value: ":8080"
             - name: CODEXK8S_CONTROL_PLANE_GRPC_TARGET
-              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "" }}'
+              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "codex-k8s-control-plane:9090" }}'
             - name: CODEXK8S_VITE_DEV_UPSTREAM
               valueFrom:
                 secretKeyRef:
@@ -356,7 +356,7 @@ spec:
                   key: CODEXK8S_RUN_HEAVY_FIELDS_RETENTION_DAYS
                   optional: true
             - name: CODEXK8S_CONTROL_PLANE_MCP_BASE_URL
-              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_MCP_BASE_URL" "" }}'
+              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_MCP_BASE_URL" "http://codex-k8s-control-plane:8081/mcp" }}'
             - name: CODEXK8S_LEARNING_MODE_DEFAULT
               valueFrom:
                 secretKeyRef:
@@ -763,9 +763,9 @@ spec:
                   name: codex-k8s-postgres
                   key: CODEXK8S_POSTGRES_PASSWORD
             - name: CODEXK8S_CONTROL_PLANE_GRPC_TARGET
-              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "" }}'
+              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "codex-k8s-control-plane:9090" }}'
             - name: CODEXK8S_CONTROL_PLANE_MCP_BASE_URL
-              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_MCP_BASE_URL" "" }}'
+              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_MCP_BASE_URL" "http://codex-k8s-control-plane:8081/mcp" }}'
             - name: CODEXK8S_TELEGRAM_INTERACTION_ADAPTER_BASE_URL
               valueFrom:
                 secretKeyRef:
@@ -1071,7 +1071,7 @@ spec:
                       name: codex-k8s-postgres
                       key: CODEXK8S_POSTGRES_PASSWORD
                 - name: CODEXK8S_CONTROL_PLANE_GRPC_TARGET
-                  value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "" }}'
+                  value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "codex-k8s-control-plane:9090" }}'
                 - name: CODEXK8S_WORKER_K8S_NAMESPACE
                   value: '{{ envOr "CODEXK8S_WORKER_K8S_NAMESPACE" "" }}'
                 - name: CODEXK8S_PRODUCTION_NAMESPACE

--- a/deploy/base/telegram-interaction-adapter/telegram-interaction-adapter.yaml.tpl
+++ b/deploy/base/telegram-interaction-adapter/telegram-interaction-adapter.yaml.tpl
@@ -57,7 +57,7 @@ spec:
                   name: codex-k8s-runtime
                   key: CODEXK8S_PUBLIC_BASE_URL
             - name: CODEXK8S_CONTROL_PLANE_GRPC_TARGET
-              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "" }}'
+              value: '{{ envOr "CODEXK8S_CONTROL_PLANE_GRPC_TARGET" "codex-k8s-control-plane:9090" }}'
             - name: CODEXK8S_OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go
@@ -3,7 +3,10 @@ package runtimedeploy
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/codex-k8s/codex-k8s/libs/go/manifesttpl"
 )
 
 func TestDefaultWorkerReplicas(t *testing.T) {
@@ -107,6 +110,48 @@ func TestBuildTemplateVars_DoesNotInventNamespaceLocalControlPlaneEndpoints(t *t
 	}
 	if got := vars["CODEXK8S_CONTROL_PLANE_MCP_BASE_URL"]; got != "" {
 		t.Fatalf("mcp base url = %q, want empty value", got)
+	}
+}
+
+func TestRenderAppTemplate_UsesLocalControlPlaneDefaultsWhenVarsMissing(t *testing.T) {
+	t.Setenv("CODEXK8S_CONTROL_PLANE_GRPC_TARGET", "")
+	t.Setenv("CODEXK8S_CONTROL_PLANE_MCP_BASE_URL", "")
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "..", "..", "deploy", "base", "codex-k8s", "app.yaml.tpl"))
+	if err != nil {
+		t.Fatalf("read app template: %v", err)
+	}
+
+	rendered, err := manifesttpl.Render("app", raw, (&Service{}).buildTemplateVars(PrepareParams{TargetEnv: "ai"}, "codex-issue-503"))
+	if err != nil {
+		t.Fatalf("render app template: %v", err)
+	}
+
+	output := string(rendered)
+	if !strings.Contains(output, "value: 'codex-k8s-control-plane:9090'") {
+		t.Fatalf("rendered app template does not contain local grpc target default:\n%s", output)
+	}
+	if !strings.Contains(output, "value: 'http://codex-k8s-control-plane:8081/mcp'") {
+		t.Fatalf("rendered app template does not contain local mcp base url default:\n%s", output)
+	}
+}
+
+func TestRenderTelegramAdapterTemplate_UsesLocalControlPlaneDefaultWhenVarsMissing(t *testing.T) {
+	t.Setenv("CODEXK8S_CONTROL_PLANE_GRPC_TARGET", "")
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "..", "..", "deploy", "base", "telegram-interaction-adapter", "telegram-interaction-adapter.yaml.tpl"))
+	if err != nil {
+		t.Fatalf("read telegram adapter template: %v", err)
+	}
+
+	rendered, err := manifesttpl.Render("telegram-adapter", raw, (&Service{}).buildTemplateVars(PrepareParams{TargetEnv: "ai"}, "codex-issue-503"))
+	if err != nil {
+		t.Fatalf("render telegram adapter template: %v", err)
+	}
+
+	output := string(rendered)
+	if !strings.Contains(output, "value: 'codex-k8s-control-plane:9090'") {
+		t.Fatalf("rendered telegram adapter template does not contain local grpc target default:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Что сделано
- добавлены безопасные дефолты для `CODEXK8S_CONTROL_PLANE_GRPC_TARGET` в runtime-манифестах `api-gateway`, `worker`, cleanup job и `telegram-interaction-adapter`
- добавлены безопасные дефолты для `CODEXK8S_CONTROL_PLANE_MCP_BASE_URL` в runtime-манифестах `control-plane` и `worker`
- добавлены регрессионные тесты на рендер шаблонов с пустыми template vars

## В чем была проблема
Для full-env runtime шаблоны рендерили `CODEXK8S_CONTROL_PLANE_GRPC_TARGET` через `envOr(..., "")`.
Если в production `control-plane` этот env был пустым, он наследовался в generated manifests как пустая строка.
Из-за этого новые `api-gateway` и `worker` pod в runtime namespace падали на старте с ошибкой про пустой `CODEXK8S_CONTROL_PLANE_GRPC_TARGET`, а `runtime_deploy` зависал в ожидании readiness.

Это воспроизводилось на run:
- `5bec4b11-6389-4054-a4ac-a745d64b24d2`
- `2bc049eb-4a07-4d68-9532-a99121179eed`
- `eb06bc5b-dcaa-447a-b1bc-972b15596270`

## Как проверено
- `go test ./services/internal/control-plane/internal/domain/runtimedeploy/...`
- `git diff --check`
- `make dupl-go`
- `make lint-go` падает только на pre-existing проблемах вне этого diff:
  - `services/external/api-gateway/internal/transport/http/interaction_callback_handler_test.go:54`
  - `services/external/api-gateway/internal/transport/http/staff_list_realtime_handler.go:122`
  - `services/external/api-gateway/internal/transport/http/staff_realtime_handler.go:126`
  - `services/external/api-gateway/internal/transport/http/staff_realtime_mission_control.go:36`
  - `services/jobs/agent-runner/internal/runner/codex_auth.go:189`
  - `libs/go/k8s/joblauncher/runtime_namespace.go:206`
  - `libs/go/servicescfg/load_validation.go:315`
  - `services/internal/control-plane/internal/domain/missioncontrol/service_helpers.go:519`

## Self-check
- `docs/design-guidelines/common/check_list.md` — релевантные пункты выполнены
- `docs/design-guidelines/go/check_list.md` — релевантные пункты выполнены
