### PR TITLE
fix: route full-env runner callbacks to production control-plane

### DIFF
--- a/services/jobs/worker/internal/domain/worker/control_plane_targets.go
+++ b/services/jobs/worker/internal/domain/worker/control_plane_targets.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	agentdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/agent"
+)
+
+const (
+	controlPlaneServiceName = "codex-k8s-control-plane"
+	clusterLocalSuffix      = "svc.cluster.local"
+	controlPlaneGRPCPort    = "9090"
+)
+
+func resolveRunControlPlaneGRPCTarget(runtimeMode agentdomain.RuntimeMode, productionNamespace string, fallbackTarget string) string {
+	if runtimeMode != agentdomain.RuntimeModeFullEnv {
+		return strings.TrimSpace(fallbackTarget)
+	}
+
+	namespace := strings.TrimSpace(productionNamespace)
+	if namespace == "" {
+		return strings.TrimSpace(fallbackTarget)
+	}
+
+	return net.JoinHostPort(
+		fmt.Sprintf("%s.%s.%s", controlPlaneServiceName, namespace, clusterLocalSuffix),
+		controlPlaneGRPCPort,
+	)
+}

--- a/services/jobs/worker/internal/domain/worker/control_plane_targets_test.go
+++ b/services/jobs/worker/internal/domain/worker/control_plane_targets_test.go
@@ -1,0 +1,53 @@
+package worker
+
+import (
+	"testing"
+
+	agentdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/agent"
+)
+
+func TestResolveRunControlPlaneGRPCTarget(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                string
+		runtimeMode         agentdomain.RuntimeMode
+		productionNamespace string
+		fallbackTarget      string
+		want                string
+	}{
+		{
+			name:                "full env uses production fqdn",
+			runtimeMode:         agentdomain.RuntimeModeFullEnv,
+			productionNamespace: "codex-k8s-prod",
+			fallbackTarget:      "codex-k8s-control-plane:9090",
+			want:                "codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:9090",
+		},
+		{
+			name:                "full env falls back when production namespace is empty",
+			runtimeMode:         agentdomain.RuntimeModeFullEnv,
+			productionNamespace: "",
+			fallbackTarget:      "codex-k8s-control-plane:9090",
+			want:                "codex-k8s-control-plane:9090",
+		},
+		{
+			name:                "code only keeps fallback target",
+			runtimeMode:         agentdomain.RuntimeModeCodeOnly,
+			productionNamespace: "codex-k8s-prod",
+			fallbackTarget:      "codex-k8s-control-plane:9090",
+			want:                "codex-k8s-control-plane:9090",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveRunControlPlaneGRPCTarget(tc.runtimeMode, tc.productionNamespace, tc.fallbackTarget)
+			if got != tc.want {
+				t.Fatalf("resolveRunControlPlaneGRPCTarget() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/jobs/worker/internal/domain/worker/run_job_launch.go
+++ b/services/jobs/worker/internal/domain/worker/run_job_launch.go
@@ -203,7 +203,7 @@ func (s *Service) launchPreparedRunWorkload(ctx context.Context, run runqueuerep
 		RuntimeTargetEnv:       runtimeTargetEnv,
 		RuntimeBuildRef:        runtimeBuildRef,
 		RuntimeAccessProfile:   runtimeAccessProfile,
-		ControlPlaneGRPCTarget: s.cfg.ControlPlaneGRPCTarget,
+		ControlPlaneGRPCTarget: resolveRunControlPlaneGRPCTarget(execution.RuntimeMode, s.cfg.ProductionNamespace, s.cfg.ControlPlaneGRPCTarget),
 		MCPBaseURL:             s.cfg.ControlPlaneMCPBaseURL,
 		MCPBearerToken:         issuedMCPToken.Token,
 		RepositoryFullName:     agentCtx.RepositoryFullName,

--- a/services/jobs/worker/internal/domain/worker/service.go
+++ b/services/jobs/worker/internal/domain/worker/service.go
@@ -14,6 +14,7 @@ import (
 
 const defaultWorkerID = "worker"
 const defaultStateInReviewLabel = webhookdomain.DefaultStateInReviewLabel
+const defaultProductionNamespace = "codex-k8s-prod"
 
 // Config defines worker run-loop behavior.
 type Config struct {
@@ -292,6 +293,10 @@ func NewService(cfg Config, deps Dependencies) *Service {
 	cfg.StateInReviewLabel = strings.TrimSpace(cfg.StateInReviewLabel)
 	if cfg.StateInReviewLabel == "" {
 		cfg.StateInReviewLabel = defaultStateInReviewLabel
+	}
+	cfg.ProductionNamespace = strings.TrimSpace(cfg.ProductionNamespace)
+	if cfg.ProductionNamespace == "" {
+		cfg.ProductionNamespace = defaultProductionNamespace
 	}
 	cfg.ControlPlaneGRPCTarget = strings.TrimSpace(cfg.ControlPlaneGRPCTarget)
 	if cfg.ControlPlaneGRPCTarget == "" {

--- a/services/jobs/worker/internal/domain/worker/service_test.go
+++ b/services/jobs/worker/internal/domain/worker/service_test.go
@@ -51,6 +51,7 @@ func TestTickLaunchesPendingRun(t *testing.T) {
 		RunningCheckLimit:      10,
 		SlotsPerProject:        2,
 		SlotLeaseTTL:           time.Minute,
+		ProductionNamespace:    "codex-k8s-prod",
 		ControlPlaneMCPBaseURL: "http://codex-k8s-control-plane.test.svc:8081/mcp",
 	}, Dependencies{
 		Runs:            runs,
@@ -72,6 +73,9 @@ func TestTickLaunchesPendingRun(t *testing.T) {
 	}
 	if launcher.launched[0].MCPBaseURL != "http://codex-k8s-control-plane.test.svc:8081/mcp" {
 		t.Fatalf("expected mcp base url to be propagated, got %q", launcher.launched[0].MCPBaseURL)
+	}
+	if launcher.launched[0].ControlPlaneGRPCTarget != "codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:9090" {
+		t.Fatalf("expected production gRPC target, got %q", launcher.launched[0].ControlPlaneGRPCTarget)
 	}
 	if launcher.launched[0].MCPBearerToken != "token-run-1" {
 		t.Fatalf("expected mcp token to be propagated, got %q", launcher.launched[0].MCPBearerToken)


### PR DESCRIPTION
## Что сделано
- отвязал callback gRPC target run pod от slot-local control-plane
- для full-env run pod направил gRPC callbacks в production control-plane по FQDN
- оставил внутренний target самого worker без изменений
- добавил unit-тесты на routing callback target

## Почему
- full-env agent-runner стартовал в slot namespace и ходил по gRPC в slot-local control-plane
- slot-local control-plane не владеет production agent_runs, поэтому ранние callbacks/ resume-path падали до первой session snapshot
- из-за этого run выглядели как `kubernetes job failed` после успешного runtime_deploy

## Проверки
- `go test ./services/jobs/worker/internal/domain/worker ./services/jobs/worker/internal/app`
- `git diff --check`

## Связанные run
- `03d22783-13e2-4cb3-a44c-c85ca7223ae5`
- `0439cff6-7202-429c-a8ab-39b0f3465c41`
