### PR TITLE
fix: route run pod callbacks to production control-plane

### DIFF
--- a/services/jobs/worker/internal/domain/worker/control_plane_targets.go
+++ b/services/jobs/worker/internal/domain/worker/control_plane_targets.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-
-	agentdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/agent"
 )
 
 const (
@@ -14,11 +12,7 @@ const (
 	controlPlaneGRPCPort    = "9090"
 )
 
-func resolveRunControlPlaneGRPCTarget(runtimeMode agentdomain.RuntimeMode, productionNamespace string, fallbackTarget string) string {
-	if runtimeMode != agentdomain.RuntimeModeFullEnv {
-		return strings.TrimSpace(fallbackTarget)
-	}
-
+func resolveRunControlPlaneGRPCTarget(productionNamespace string, fallbackTarget string) string {
 	namespace := strings.TrimSpace(productionNamespace)
 	if namespace == "" {
 		return strings.TrimSpace(fallbackTarget)

--- a/services/jobs/worker/internal/domain/worker/control_plane_targets_test.go
+++ b/services/jobs/worker/internal/domain/worker/control_plane_targets_test.go
@@ -2,8 +2,6 @@ package worker
 
 import (
 	"testing"
-
-	agentdomain "github.com/codex-k8s/codex-k8s/libs/go/domain/agent"
 )
 
 func TestResolveRunControlPlaneGRPCTarget(t *testing.T) {
@@ -11,29 +9,19 @@ func TestResolveRunControlPlaneGRPCTarget(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		runtimeMode         agentdomain.RuntimeMode
 		productionNamespace string
 		fallbackTarget      string
 		want                string
 	}{
 		{
-			name:                "full env uses production fqdn",
-			runtimeMode:         agentdomain.RuntimeModeFullEnv,
+			name:                "uses production fqdn when namespace is configured",
 			productionNamespace: "codex-k8s-prod",
 			fallbackTarget:      "codex-k8s-control-plane:9090",
 			want:                "codex-k8s-control-plane.codex-k8s-prod.svc.cluster.local:9090",
 		},
 		{
-			name:                "full env falls back when production namespace is empty",
-			runtimeMode:         agentdomain.RuntimeModeFullEnv,
+			name:                "falls back when production namespace is empty",
 			productionNamespace: "",
-			fallbackTarget:      "codex-k8s-control-plane:9090",
-			want:                "codex-k8s-control-plane:9090",
-		},
-		{
-			name:                "code only keeps fallback target",
-			runtimeMode:         agentdomain.RuntimeModeCodeOnly,
-			productionNamespace: "codex-k8s-prod",
 			fallbackTarget:      "codex-k8s-control-plane:9090",
 			want:                "codex-k8s-control-plane:9090",
 		},
@@ -44,7 +32,7 @@ func TestResolveRunControlPlaneGRPCTarget(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := resolveRunControlPlaneGRPCTarget(tc.runtimeMode, tc.productionNamespace, tc.fallbackTarget)
+			got := resolveRunControlPlaneGRPCTarget(tc.productionNamespace, tc.fallbackTarget)
 			if got != tc.want {
 				t.Fatalf("resolveRunControlPlaneGRPCTarget() = %q, want %q", got, tc.want)
 			}

--- a/services/jobs/worker/internal/domain/worker/run_job_launch.go
+++ b/services/jobs/worker/internal/domain/worker/run_job_launch.go
@@ -203,7 +203,7 @@ func (s *Service) launchPreparedRunWorkload(ctx context.Context, run runqueuerep
 		RuntimeTargetEnv:       runtimeTargetEnv,
 		RuntimeBuildRef:        runtimeBuildRef,
 		RuntimeAccessProfile:   runtimeAccessProfile,
-		ControlPlaneGRPCTarget: resolveRunControlPlaneGRPCTarget(execution.RuntimeMode, s.cfg.ProductionNamespace, s.cfg.ControlPlaneGRPCTarget),
+		ControlPlaneGRPCTarget: resolveRunControlPlaneGRPCTarget(s.cfg.ProductionNamespace, s.cfg.ControlPlaneGRPCTarget),
 		MCPBaseURL:             s.cfg.ControlPlaneMCPBaseURL,
 		MCPBearerToken:         issuedMCPToken.Token,
 		RepositoryFullName:     agentCtx.RepositoryFullName,


### PR DESCRIPTION
## Что сделано
- направил gRPC callback target всех run pod в production control-plane по FQDN
- убрал привязку callback routing к runtime mode
- оставил fallback на старый target только если production namespace не задан
- добавил unit-тесты на target resolution

## Почему
- discussion/code-only run `b4e6a994-dec9-4443-8793-91be90d24341` падал на старте с `dial control-plane callback client: wait for grpc ready "codex-k8s-control-plane:9090": context deadline exceeded`
- в issue namespace нет локального control-plane service, поэтому bare target был неверным
- canonical run state и callback API живут в production control-plane, поэтому все run pod должны говорить только с ним

## Проверки
- `go test ./services/jobs/worker/internal/domain/worker ./services/jobs/worker/internal/app`
- `git diff --check`

## Связанный run
- `b4e6a994-dec9-4443-8793-91be90d24341`
