### PR TITLE
Исправление pending run: SQL insert delivery attempts

### DIFF
--- a/services/internal/control-plane/internal/repository/postgres/interactionrequest/repository_test.go
+++ b/services/internal/control-plane/internal/repository/postgres/interactionrequest/repository_test.go
@@ -2,6 +2,7 @@ package interactionrequest
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +39,34 @@ func TestClassifyDecisionResponsePayloadAcceptsKnownOption(t *testing.T) {
 	if decision.selectedOptionID != "approve" {
 		t.Fatalf("selected option id = %q, want approve", decision.selectedOptionID)
 	}
+}
+
+func TestCreateDeliveryAttemptSQLHasMatchingTargetColumnsAndValues(t *testing.T) {
+	t.Parallel()
+
+	re := regexp.MustCompile(`(?is)INSERT\s+INTO\s+interaction_delivery_attempts\s*\((.*?)\)\s*VALUES\s*\((.*?)\)`)
+	matches := re.FindStringSubmatch(queryCreateDeliveryAttempt)
+	if len(matches) != 3 {
+		t.Fatalf("expected INSERT ... VALUES structure in create_delivery_attempt.sql")
+	}
+
+	columnCount := countCommaSeparatedSQLItems(matches[1])
+	valueCount := countCommaSeparatedSQLItems(matches[2])
+	if columnCount != valueCount {
+		t.Fatalf("target columns count = %d, values count = %d", columnCount, valueCount)
+	}
+}
+
+func countCommaSeparatedSQLItems(source string) int {
+	items := strings.Split(source, ",")
+	count := 0
+	for _, item := range items {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 func TestClassifyDecisionResponsePayloadRejectsUnknownOption(t *testing.T) {

--- a/services/internal/control-plane/internal/repository/postgres/interactionrequest/sql/create_delivery_attempt.sql
+++ b/services/internal/control-plane/internal/repository/postgres/interactionrequest/sql/create_delivery_attempt.sql
@@ -17,7 +17,7 @@ INSERT INTO interaction_delivery_attempts (
     started_at,
     finished_at
 )
-VALUES ($1::uuid, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10::jsonb, $11, $12, $13, $14, $15)
+VALUES ($1::uuid, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10::jsonb, $11, $12, $13, $14, $15, $16)
 RETURNING
     id,
     interaction_id::text AS interaction_id,


### PR DESCRIPTION
## Что исправлено
- синхронизирован `create_delivery_attempt.sql` с актуальной схемой `interaction_delivery_attempts`
- добавлен регрессионный тест на совпадение количества target columns и values

## Причина
`worker` падал на каждом tick с ошибкой `INSERT has more target columns than expressions` при создании `interaction delivery attempt`. Из-за этого новые run оставались в `pending` и не доходили до claim/runtime_deploy.

## Проверки
- `go test ./services/internal/control-plane/internal/repository/postgres/interactionrequest/...`
- `git diff --check`
