### PR TITLE
Исправление warmup Mission Control: uuid/text в summary query

### DIFF
--- a/services/internal/control-plane/internal/repository/postgres/missioncontrol/repository_test.go
+++ b/services/internal/control-plane/internal/repository/postgres/missioncontrol/repository_test.go
@@ -59,6 +59,7 @@ func TestWarmupSummaryQueryCountsAllFoundationTables(t *testing.T) {
 		"mission_control_relations",
 		"mission_control_timeline_entries",
 		"mission_control_commands",
+		"project_id = $1::uuid",
 	}
 	for _, item := range required {
 		if !strings.Contains(queryGetWarmupSummary, item) {

--- a/services/internal/control-plane/internal/repository/postgres/missioncontrol/sql/get_warmup_summary.sql
+++ b/services/internal/control-plane/internal/repository/postgres/missioncontrol/sql/get_warmup_summary.sql
@@ -1,8 +1,8 @@
 -- name: missioncontrol__get_warmup_summary :one
 SELECT
     $1::text AS project_id,
-    COALESCE((SELECT COUNT(*) FROM mission_control_entities WHERE project_id = $1), 0) AS entity_count,
-    COALESCE((SELECT COUNT(*) FROM mission_control_relations WHERE project_id = $1), 0) AS relation_count,
-    COALESCE((SELECT COUNT(*) FROM mission_control_timeline_entries WHERE project_id = $1), 0) AS timeline_entry_count,
-    COALESCE((SELECT COUNT(*) FROM mission_control_commands WHERE project_id = $1), 0) AS command_count,
-    COALESCE((SELECT MAX(projection_version) FROM mission_control_entities WHERE project_id = $1), 0) AS max_projection_version;
+    COALESCE((SELECT COUNT(*) FROM mission_control_entities WHERE project_id = $1::uuid), 0) AS entity_count,
+    COALESCE((SELECT COUNT(*) FROM mission_control_relations WHERE project_id = $1::uuid), 0) AS relation_count,
+    COALESCE((SELECT COUNT(*) FROM mission_control_timeline_entries WHERE project_id = $1::uuid), 0) AS timeline_entry_count,
+    COALESCE((SELECT COUNT(*) FROM mission_control_commands WHERE project_id = $1::uuid), 0) AS command_count,
+    COALESCE((SELECT MAX(projection_version) FROM mission_control_entities WHERE project_id = $1::uuid), 0) AS max_projection_version;


### PR DESCRIPTION
## Что исправлено
- в `get_warmup_summary.sql` все сравнения `project_id` приведены к `uuid`
- добавлен регрессионный тест на явное использование `$1::uuid` в warmup summary query

## Причина
`Mission Control warmup` падал на production с ошибкой `operator does not exist: uuid = text`, потому что summary query сравнивал `project_id UUID` с текстовым аргументом без приведения типа.

## Проверки
- `go test ./services/internal/control-plane/internal/repository/postgres/missioncontrol/... ./services/internal/control-plane/internal/domain/missioncontrolworker ./services/jobs/worker/internal/domain/worker`
- `git diff --check`
