### PR TITLE
fix: correct telegram interaction continuation lifecycle

### DIFF
--- a/services/external/telegram-interaction-adapter/internal/service/service.go
+++ b/services/external/telegram-interaction-adapter/internal/service/service.go
@@ -17,6 +17,8 @@ import (
 
 const telegramWebhookPath = "/api/v1/telegram/interactions/webhook"
 
+var errTelegramVoiceHandledNoRetry = errors.New("telegram voice webhook handled without retry")
+
 // Config wires runtime dependencies for adapter service.
 type Config struct {
 	PublicBaseURL  string
@@ -369,6 +371,10 @@ func (s *Service) handleMessage(ctx context.Context, update telego.Update) error
 	locale := telegramLocale(message.From)
 	freeText, err := s.resolveMessageText(ctx, message, locale)
 	if err != nil {
+		if errors.Is(err, errTelegramVoiceHandledNoRetry) {
+			recordCallbackEvent(CallbackKindFreeTextReceived, metricStatusFailed)
+			return nil
+		}
 		recordCallbackEvent(CallbackKindFreeTextReceived, metricStatusFailed)
 		return err
 	}
@@ -428,31 +434,34 @@ func (s *Service) resolveMessageText(ctx context.Context, message *telego.Messag
 
 	file, err := s.bot.DownloadFile(ctx, message.Voice.FileID)
 	if err != nil {
-		_, _ = s.bot.SendMessage(ctx, SendMessageRequest{
-			ChatID: message.Chat.ID,
-			Text:   s.messages.Render(locale, "transcription_failed", nil),
-		})
-		return "", fmt.Errorf("download telegram voice file: %w", err)
+		s.sendBestEffortChatMessage(ctx, message.Chat.ID, s.messages.Render(locale, "transcription_failed", nil))
+		return "", errTelegramVoiceHandledNoRetry
 	}
 
 	normalized, err := s.audioConverter.Convert(ctx, AudioPayload(file))
 	if err != nil {
-		_, _ = s.bot.SendMessage(ctx, SendMessageRequest{
-			ChatID: message.Chat.ID,
-			Text:   s.messages.Render(locale, "transcription_failed", nil),
-		})
-		return "", fmt.Errorf("normalize telegram voice file: %w", err)
+		s.sendBestEffortChatMessage(ctx, message.Chat.ID, s.messages.Render(locale, "transcription_failed", nil))
+		return "", errTelegramVoiceHandledNoRetry
 	}
 
 	transcript, err := s.speechToText.Transcribe(ctx, normalized, telegramSTTLanguage(locale))
 	if err != nil {
-		_, _ = s.bot.SendMessage(ctx, SendMessageRequest{
-			ChatID: message.Chat.ID,
-			Text:   s.messages.Render(locale, "transcription_failed", nil),
-		})
-		return "", fmt.Errorf("transcribe telegram voice file: %w", err)
+		s.sendBestEffortChatMessage(ctx, message.Chat.ID, s.messages.Render(locale, "transcription_failed", nil))
+		return "", errTelegramVoiceHandledNoRetry
 	}
 	return strings.TrimSpace(transcript), nil
+}
+
+func (s *Service) sendBestEffortChatMessage(ctx context.Context, chatID int64, text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	if _, err := s.bot.SendMessage(ctx, SendMessageRequest{
+		ChatID: chatID,
+		Text:   text,
+	}); err != nil {
+		s.logger.Warn("best-effort telegram message failed", "chat_id", chatID, "err", err)
+	}
 }
 
 func (s *Service) forwardCallback(ctx context.Context, envelope CallbackEnvelope) (CallbackOutcome, error) {

--- a/services/external/telegram-interaction-adapter/internal/service/service_voice_test.go
+++ b/services/external/telegram-interaction-adapter/internal/service/service_voice_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mymmrac/telego"
+)
+
+type testBotClient struct {
+	sendRequests []SendMessageRequest
+	downloadErr  error
+}
+
+func (b *testBotClient) Ready() bool { return true }
+func (b *testBotClient) SendMessage(_ context.Context, req SendMessageRequest) (SentMessage, error) {
+	b.sendRequests = append(b.sendRequests, req)
+	return SentMessage{ChatID: req.ChatID, MessageID: len(b.sendRequests), SentAt: time.Now().UTC()}, nil
+}
+func (b *testBotClient) EditMessageKeyboard(context.Context, EditMessageKeyboardRequest) error { return nil }
+func (b *testBotClient) AnswerCallbackQuery(context.Context, AnswerCallbackQueryRequest) error  { return nil }
+func (b *testBotClient) DownloadFile(context.Context, string) (DownloadedFile, error) {
+	return DownloadedFile{}, b.downloadErr
+}
+func (b *testBotClient) SetWebhook(context.Context, SetWebhookRequest) error { return nil }
+
+type testCallbackSink struct{}
+
+func (testCallbackSink) Submit(context.Context, CallbackEnvelope) (CallbackOutcome, error) {
+	return CallbackOutcome{}, nil
+}
+
+type testAudioConverter struct{}
+
+func (testAudioConverter) Convert(_ context.Context, payload AudioPayload) (AudioPayload, error) {
+	return AudioPayload{
+		Content:     payload.Content,
+		ContentType: "audio/mpeg",
+		FileName:    "voice.mp3",
+	}, nil
+}
+
+type testSpeechToText struct{}
+
+func (testSpeechToText) Transcribe(context.Context, AudioPayload, string) (string, error) {
+	return "", errors.New("stt unavailable")
+}
+
+func TestHandleWebhook_AcksVoiceTranscriptionFailuresWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	bot := &testBotClient{downloadErr: errors.New("stt unavailable")}
+	recipients, err := NewRecipientResolver("989530970", "")
+	if err != nil {
+		t.Fatalf("NewRecipientResolver() error = %v", err)
+	}
+	svc, err := New(Config{
+		Recipients:     recipients,
+		Bot:            bot,
+		CallbackSink:   testCallbackSink{},
+		AudioConverter: testAudioConverter{},
+		SpeechToText:   testSpeechToText{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	update := telego.Update{
+		UpdateID: 77,
+		Message: &telego.Message{
+			MessageID: 55,
+			Chat:      telego.Chat{ID: 989530970},
+			From:      &telego.User{ID: 1, LanguageCode: "ru"},
+			Voice:     &telego.Voice{FileID: "voice-file"},
+		},
+	}
+	raw, err := json.Marshal(update)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	if err := svc.HandleWebhook(context.Background(), raw); err != nil {
+		t.Fatalf("HandleWebhook() error = %v, want nil", err)
+	}
+	if len(bot.sendRequests) != 1 {
+		t.Fatalf("sendRequests len = %d, want 1", len(bot.sendRequests))
+	}
+	if got, want := bot.sendRequests[0].Text, "🎙️ Не удалось распознать голосовой ответ. Попробуйте еще раз или отправьте текст."; got != want {
+		t.Fatalf("notification text = %q, want %q", got, want)
+	}
+}

--- a/services/internal/control-plane/internal/repository/postgres/interactionrequest/repository_test.go
+++ b/services/internal/control-plane/internal/repository/postgres/interactionrequest/repository_test.go
@@ -57,6 +57,17 @@ func TestCreateDeliveryAttemptSQLHasMatchingTargetColumnsAndValues(t *testing.T)
 	}
 }
 
+func TestUpdateDispatchBindingSQLKeepsContinuationPendingUntilCallbackApplied(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(queryUpdateDispatchBinding, "continuation_state = 'pending_primary_delivery'") {
+		t.Fatalf("update_dispatch_binding.sql must keep continuation_state pending_primary_delivery after primary dispatch")
+	}
+	if strings.Contains(queryUpdateDispatchBinding, "'ready_for_edit'") || strings.Contains(queryUpdateDispatchBinding, "'follow_up_required'") {
+		t.Fatalf("update_dispatch_binding.sql must not arm continuation before callback evidence is applied")
+	}
+}
+
 func countCommaSeparatedSQLItems(source string) int {
 	items := strings.Split(source, ",")
 	count := 0

--- a/services/internal/control-plane/internal/repository/postgres/interactionrequest/sql/update_dispatch_binding.sql
+++ b/services/internal/control-plane/internal/repository/postgres/interactionrequest/sql/update_dispatch_binding.sql
@@ -5,10 +5,7 @@ SET
     provider_message_ref_json = $2::jsonb,
     edit_capability = $3,
     callback_token_expires_at = COALESCE($4, callback_token_expires_at),
-    continuation_state = CASE
-        WHEN $3 = 'follow_up_only' THEN 'follow_up_required'
-        ELSE 'ready_for_edit'
-    END,
+    continuation_state = 'pending_primary_delivery',
     updated_at = NOW()
 WHERE id = $1
 RETURNING


### PR DESCRIPTION
## Что исправлено
- decision request больше не запускает continuation (`message_edit` / `follow_up_notify`) сразу после accepted primary dispatch;
- voice transcription failure в Telegram adapter теперь завершает webhook без retry, чтобы Telegram не ретраил один и тот же update и не спамил сообщением `Не удалось распознать голосовой ответ...`.

## Корень проблемы
1. В `interactionrequest` binding переводился в `ready_for_edit/follow_up_required` уже на этапе primary dispatch ack, то есть ещё до любого callback/response evidence от пользователя.
2. В `telegram-interaction-adapter` STT/download/convert error возвращал ошибку наружу после отправки user-facing сообщения. HTTP handler отвечал `503`, Telegram ретраил тот же voice update и получался спам.

## Что изменено
- `services/internal/control-plane/internal/repository/postgres/interactionrequest/sql/update_dispatch_binding.sql`
  - после accepted primary dispatch binding остаётся в `pending_primary_delivery`;
  - continuation arm происходит только после реально применённого callback.
- `services/external/telegram-interaction-adapter/internal/service/service.go`
  - введён no-retry path для voice transcription failures;
  - сообщение пользователю отправляется best-effort, webhook подтверждается без повторной обработки одного и того же update.
- добавлены регрессионные тесты.

## Проверки
- `go test ./services/external/telegram-interaction-adapter/... ./services/internal/control-plane/internal/domain/mcp ./services/internal/control-plane/internal/repository/postgres/interactionrequest/...`
- `git diff --check`

## Контекст
Симптом воспроизводился на discussion run `0bf6fd55-8453-43b6-abd0-705683efa708` для `#532`.
