### PR TITLE
fix: keep telegram webhook owned by production

### DIFF
--- a/deploy/base/codex-k8s/ingress.yaml.tpl
+++ b/deploy/base/codex-k8s/ingress.yaml.tpl
@@ -45,6 +45,7 @@ spec:
                   number: 4180
 {{- end }}
 ---
+{{- if not $isAI }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -67,3 +68,4 @@ spec:
                 name: codex-k8s-telegram-interaction-adapter
                 port:
                   number: 8080
+{{- end }}

--- a/deploy/base/telegram-interaction-adapter/telegram-interaction-adapter.yaml.tpl
+++ b/deploy/base/telegram-interaction-adapter/telegram-interaction-adapter.yaml.tpl
@@ -51,6 +51,8 @@ spec:
           env:
             - name: CODEXK8S_HTTP_ADDR
               value: ":8080"
+            - name: CODEXK8S_ENV
+              value: '{{ envOr "CODEXK8S_ENV" "production" }}'
             - name: CODEXK8S_PUBLIC_BASE_URL
               valueFrom:
                 secretKeyRef:

--- a/services/external/telegram-interaction-adapter/internal/app/app.go
+++ b/services/external/telegram-interaction-adapter/internal/app/app.go
@@ -83,8 +83,10 @@ func Run() error {
 		return fmt.Errorf("init telegram adapter service: %w", err)
 	}
 
-	if err := adapterService.SyncWebhook(appCtx); err != nil {
-		logger.Warn("telegram webhook sync failed", "err", err)
+	if telegramWebhookSyncEnabled(cfg.Environment) {
+		if err := adapterService.SyncWebhook(appCtx); err != nil {
+			logger.Warn("telegram webhook sync failed", "err", err)
+		}
 	}
 
 	server, err := httptransport.NewServer(httptransport.ServerConfig{
@@ -106,6 +108,10 @@ func Run() error {
 	}()
 
 	return waitForServerLifecycle(ctx, appCtx, logger, serverErr, "telegram-interaction-adapter", server.Shutdown)
+}
+
+func telegramWebhookSyncEnabled(environment string) bool {
+	return !strings.EqualFold(strings.TrimSpace(environment), "ai")
 }
 
 func waitForServerLifecycle(ctx context.Context, appCtx context.Context, logger *slog.Logger, serverErr <-chan error, component string, shutdown func(context.Context) error) error {

--- a/services/external/telegram-interaction-adapter/internal/app/config.go
+++ b/services/external/telegram-interaction-adapter/internal/app/config.go
@@ -10,6 +10,8 @@ import (
 type Config struct {
 	HTTPAddr string `env:"CODEXK8S_HTTP_ADDR" envDefault:":8080"`
 
+	Environment string `env:"CODEXK8S_ENV" envDefault:"production"`
+
 	PublicBaseURL string `env:"CODEXK8S_PUBLIC_BASE_URL"`
 
 	ControlPlaneGRPCTarget string `env:"CODEXK8S_CONTROL_PLANE_GRPC_TARGET,required,notEmpty"`

--- a/services/external/telegram-interaction-adapter/internal/app/config_test.go
+++ b/services/external/telegram-interaction-adapter/internal/app/config_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 func TestLoadConfigDefaults(t *testing.T) {
 	t.Setenv("CODEXK8S_HTTP_ADDR", "")
+	t.Setenv("CODEXK8S_ENV", "")
 	t.Setenv("CODEXK8S_CONTROL_PLANE_GRPC_TARGET", "codex-k8s-control-plane:9090")
 	t.Setenv("CODEXK8S_TELEGRAM_INTERACTION_ADAPTER_HTTP_TIMEOUT", "")
 	t.Setenv("CODEXK8S_TELEGRAM_INTERACTION_ADAPTER_STT_MODEL", "")
@@ -16,6 +17,9 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.HTTPAddr != ":8080" {
 		t.Fatalf("HTTPAddr = %q, want :8080", cfg.HTTPAddr)
 	}
+	if cfg.Environment != "production" {
+		t.Fatalf("Environment = %q, want production", cfg.Environment)
+	}
 	if cfg.ControlPlaneGRPCTarget != "codex-k8s-control-plane:9090" {
 		t.Fatalf("ControlPlaneGRPCTarget = %q", cfg.ControlPlaneGRPCTarget)
 	}
@@ -27,5 +31,19 @@ func TestLoadConfigDefaults(t *testing.T) {
 	}
 	if cfg.TelegramSTTTimeout != "30s" {
 		t.Fatalf("TelegramSTTTimeout = %q, want 30s", cfg.TelegramSTTTimeout)
+	}
+}
+
+func TestTelegramWebhookSyncEnabled(t *testing.T) {
+	t.Parallel()
+
+	if !telegramWebhookSyncEnabled("production") {
+		t.Fatal("production environment must own telegram webhook sync")
+	}
+	if telegramWebhookSyncEnabled("ai") {
+		t.Fatal("ai environment must not own telegram webhook sync")
+	}
+	if !telegramWebhookSyncEnabled("") {
+		t.Fatal("empty environment should keep production-compatible behavior")
 	}
 }

--- a/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go
+++ b/services/internal/control-plane/internal/domain/runtimedeploy/service_templates_test.go
@@ -153,6 +153,45 @@ func TestRenderTelegramAdapterTemplate_UsesLocalControlPlaneDefaultWhenVarsMissi
 	if !strings.Contains(output, "value: 'codex-k8s-control-plane:9090'") {
 		t.Fatalf("rendered telegram adapter template does not contain local grpc target default:\n%s", output)
 	}
+	if !strings.Contains(output, "name: CODEXK8S_ENV") {
+		t.Fatalf("rendered telegram adapter template does not contain CODEXK8S_ENV:\n%s", output)
+	}
+}
+
+func TestRenderIngressTemplate_OmitsTelegramWebhookIngressForAI(t *testing.T) {
+	t.Setenv("CODEXK8S_CONTROL_PLANE_GRPC_TARGET", "")
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "..", "..", "deploy", "base", "codex-k8s", "ingress.yaml.tpl"))
+	if err != nil {
+		t.Fatalf("read ingress template: %v", err)
+	}
+
+	rendered, err := manifesttpl.Render("ingress", raw, (&Service{}).buildTemplateVars(PrepareParams{TargetEnv: "ai"}, "codex-issue-503"))
+	if err != nil {
+		t.Fatalf("render ingress template: %v", err)
+	}
+
+	output := string(rendered)
+	if strings.Contains(output, "name: codex-k8s-telegram-webhook") {
+		t.Fatalf("rendered ai ingress must not contain telegram webhook ingress:\n%s", output)
+	}
+}
+
+func TestRenderIngressTemplate_ContainsTelegramWebhookIngressForProduction(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "..", "..", "deploy", "base", "codex-k8s", "ingress.yaml.tpl"))
+	if err != nil {
+		t.Fatalf("read ingress template: %v", err)
+	}
+
+	rendered, err := manifesttpl.Render("ingress", raw, (&Service{}).buildTemplateVars(PrepareParams{TargetEnv: "production"}, "codex-k8s-prod"))
+	if err != nil {
+		t.Fatalf("render ingress template: %v", err)
+	}
+
+	output := string(rendered)
+	if !strings.Contains(output, "name: codex-k8s-telegram-webhook") {
+		t.Fatalf("rendered production ingress must contain telegram webhook ingress:\n%s", output)
+	}
 }
 
 func TestResolveServicesConfigPath_PrefersRepoSnapshotWhenConfigPathIsAbsolute(t *testing.T) {


### PR DESCRIPTION
## Что исправлено
- production `telegram-interaction-adapter` остаётся единственным владельцем `SetWebhook` для общего Telegram bot token;
- AI/full-env adapter больше не публикуют публичный Telegram webhook ingress;
- в adapter deployment явно прокинут `CODEXK8S_ENV`, чтобы runtime корректно понимал production vs ai.

## Production root cause
Разбор по `Issue #532` / `run 8d8e52cc-7fee-4b14-90e5-8d092eabbade` показал два связанных факта:
1. Общий Telegram bot token использовался и в production, и в full-env namespace.
2. Каждый adapter на старте делал `SetWebhook` на свой `CODEXK8S_PUBLIC_BASE_URL`.

Из-за этого webhook уводился в последний поднявшийся full-env adapter, а не в production.
Фактическое evidence:
- ingress-nginx логировал `POST /api/v1/telegram/interactions/webhook` в issue namespace `codex-issue-3278207d1cd3-i516-r706e10ca3d23`;
- у discussion run `8d8e52cc-7fee-4b14-90e5-8d092eabbade` в production не появилось ни одного `interaction_callback_event` и `interaction_response_record`;
- в issue namespace adapter при этом было видно `401 invalid_api_key` на OpenAI transcription, что и давало STT failures и повторы пользовательских сообщений.

## Почему это чинит проблему
- webhook больше не будет перехватываться full-env окружениями;
- callback buttons и voice replies будут всегда приходить в production adapter, который работает с production control-plane/DB;
- случайный AI namespace больше не сможет сломать discussion interactions своим локальным состоянием или устаревшим secret.

## Проверки
- `go test ./services/external/telegram-interaction-adapter/internal/app ./services/internal/control-plane/internal/domain/runtimedeploy`
- `git diff --check`
