### PR TITLE
fix: unstick fresh discussion runs with prior bot replies

### DIFF
--- a/services/jobs/agent-runner/internal/runner/discussion_comment_feedback_test.go
+++ b/services/jobs/agent-runner/internal/runner/discussion_comment_feedback_test.go
@@ -93,3 +93,27 @@ func TestProcessedDiscussionCommentIDs(t *testing.T) {
 		t.Fatalf("unexpected processed ids: %#v", processed)
 	}
 }
+
+func TestShouldRunDiscussionCycleForFreshRunWithoutNewHumanComment(t *testing.T) {
+	state := discussionIssueState{
+		HasAgentReply:           true,
+		HasHumanAfterAgentReply: false,
+		MaxHumanCommentID:       0,
+	}
+
+	if !shouldRunDiscussionCycle(state, 0, false) {
+		t.Fatal("expected fresh discussion run to execute initial cycle")
+	}
+}
+
+func TestShouldRunDiscussionCycleWaitsAfterInitialCycleWithoutNewHumanComment(t *testing.T) {
+	state := discussionIssueState{
+		HasAgentReply:           true,
+		HasHumanAfterAgentReply: false,
+		MaxHumanCommentID:       0,
+	}
+
+	if shouldRunDiscussionCycle(state, 0, true) {
+		t.Fatal("expected discussion loop to poll after initial cycle when no new human comment exists")
+	}
+}

--- a/services/jobs/agent-runner/internal/runner/discussion_loop.go
+++ b/services/jobs/agent-runner/internal/runner/discussion_loop.go
@@ -42,6 +42,7 @@ func (s *Service) runDiscussionLoop(ctx context.Context, state codexState, resul
 	}
 
 	var lastProcessedHumanCommentID int64
+	completedAtLeastOneCycle := result.restoredSessionPath != "" || result.sessionID != "" || result.sessionFilePath != ""
 	for {
 		issueState, err := s.loadDiscussionIssueState(ctx)
 		if err != nil {
@@ -71,7 +72,7 @@ func (s *Service) runDiscussionLoop(ctx context.Context, state codexState, resul
 			}
 			return nil
 		}
-		if !shouldRunDiscussionCycle(issueState, lastProcessedHumanCommentID) {
+		if !shouldRunDiscussionCycle(issueState, lastProcessedHumanCommentID, completedAtLeastOneCycle) {
 			if err := waitForDiscussionPoll(ctx, pollInterval); err != nil {
 				return err
 			}
@@ -167,6 +168,7 @@ func (s *Service) runDiscussionLoop(ctx context.Context, state codexState, resul
 
 		lastProcessedHumanCommentID = issueState.MaxHumanCommentID
 		result.restoredSessionPath = result.sessionFilePath
+		completedAtLeastOneCycle = true
 		if err := waitForDiscussionPoll(ctx, pollInterval); err != nil {
 			return err
 		}
@@ -228,7 +230,10 @@ func (s *Service) loadDiscussionIssueState(ctx context.Context) (discussionIssue
 	return deriveDiscussionIssueState(issue, comments, s.cfg.GitBotUsername), nil
 }
 
-func shouldRunDiscussionCycle(state discussionIssueState, lastProcessedHumanCommentID int64) bool {
+func shouldRunDiscussionCycle(state discussionIssueState, lastProcessedHumanCommentID int64, completedAtLeastOneCycle bool) bool {
+	if !completedAtLeastOneCycle {
+		return true
+	}
 	if !state.HasAgentReply {
 		return true
 	}


### PR DESCRIPTION
## Что сделано
- исправлен `discussion` loop в `agent-runner`: новый run теперь всегда выполняет первый цикл, даже если в issue уже есть старые bot-комментарии от предыдущих discussion-run
- добавлены регрессионные тесты на initial-cycle и последующий polling

## Почему это было нужно
- `run c3f4c05f-4917-453f-b755-ce67c1d2de61` не падал на runtime
- pod был жив, но `codex exec` не стартовал
- причина: при новом discussion-run на issue `#534` уже были старые bot replies, а новых human comments после них не было
- текущая логика сразу уходила в polling и не выполняла первый цикл нового run

## Проверки
- `gofmt -w services/jobs/agent-runner/internal/runner/discussion_loop.go services/jobs/agent-runner/internal/runner/discussion_comment_feedback_test.go`
- `go test ./services/jobs/agent-runner/internal/runner/...`
- `git diff --check`

## Что с затронутыми run
- `2823f0c7-b26a-401f-9a50-582fb1431340` не завис: там агент реально работает по `#519`
- `c3f4c05f-4917-453f-b755-ce67c1d2de61` требует перезапуска после deploy, потому что текущий pod уже находится в старом polling-сценарии
