### PR TITLE
agent-6/governance-manager: dupl cleanup — локальная дедубликация

### DIFF
--- a/services/internal/governance-manager/internal/domain/service/service.go
+++ b/services/internal/governance-manager/internal/domain/service/service.go
@@ -83,14 +83,9 @@ func (s *Service) CreateRiskProfile(ctx context.Context, input CreateRiskProfile
 		return entity.RiskProfile{}, err
 	}
 	if replayed {
-		profile, err := s.repository.GetRiskProfile(ctx, result.AggregateID)
-		if err != nil {
-			return entity.RiskProfile{}, err
-		}
-		if !sameExternalRef(profile.Scope, input.Scope) || profile.Slug != strings.TrimSpace(input.Slug) {
-			return entity.RiskProfile{}, errs.ErrConflict
-		}
-		return profile, nil
+		return replayedEntity(ctx, result, s.repository.GetRiskProfile, func(profile entity.RiskProfile) bool {
+			return sameExternalRef(profile.Scope, input.Scope) && profile.Slug == strings.TrimSpace(input.Slug)
+		})
 	}
 	now := s.clock.Now()
 	profile := entity.RiskProfile{
@@ -324,14 +319,9 @@ func (s *Service) RecordReviewSignal(ctx context.Context, input RecordReviewSign
 		return entity.ReviewSignal{}, err
 	}
 	if replayed {
-		signal, err := s.repository.GetReviewSignal(ctx, result.AggregateID)
-		if err != nil {
-			return entity.ReviewSignal{}, err
-		}
-		if !sameExternalRef(signal.Target, input.Target) || signal.AuthorRef != strings.TrimSpace(input.AuthorRef) {
-			return entity.ReviewSignal{}, errs.ErrConflict
-		}
-		return signal, nil
+		return replayedEntity(ctx, result, s.repository.GetReviewSignal, func(signal entity.ReviewSignal) bool {
+			return sameExternalRef(signal.Target, input.Target) && signal.AuthorRef == strings.TrimSpace(input.AuthorRef)
+		})
 	}
 	if input.Target.Type == "" || input.Target.Ref == "" || strings.TrimSpace(input.AuthorRef) == "" {
 		return entity.ReviewSignal{}, errs.ErrInvalidArgument
@@ -411,12 +401,9 @@ func (s *Service) RequestGate(ctx context.Context, input RequestGateInput) (enti
 		Status:                 enum.GateRequestStatusRequested,
 	}
 	result = commandResult(input.Meta, enum.OperationRequestGate.String(), aggregateGateRequest, request.ID, now)
-	event := outboxEvent(s.idGenerator.New(), governanceevents.EventGateRequested, governanceevents.AggregateGate, request.ID, now, governanceevents.Payload{
-		GateRequestID:    request.ID.String(),
-		RiskAssessmentID: optionalUUIDString(request.RiskAssessmentID),
-		Status:           string(request.Status),
-		Version:          request.Version,
-	})
+	eventPayload := statusPayload("gate_request", request.ID, string(request.Status), request.Version)
+	eventPayload.RiskAssessmentID = optionalUUIDString(request.RiskAssessmentID)
+	event := outboxEvent(s.idGenerator.New(), governanceevents.EventGateRequested, governanceevents.AggregateGate, request.ID, now, eventPayload)
 	if err := s.repository.CreateGateRequest(ctx, request, result, event); err != nil {
 		return entity.GateRequest{}, err
 	}
@@ -912,12 +899,9 @@ func (s *Service) RecordBlockingSignal(ctx context.Context, input RecordBlocking
 		Status:        enum.BlockingSignalStatusActive,
 	}
 	result = commandResult(input.Meta, enum.OperationRecordBlockingSignal.String(), governanceevents.AggregateBlockingSignal, signal.ID, now)
-	event := outboxEvent(s.idGenerator.New(), governanceevents.EventBlockingSignalRecorded, governanceevents.AggregateBlockingSignal, signal.ID, now, governanceevents.Payload{
-		BlockingSignalID: signal.ID.String(),
-		Status:           string(signal.Status),
-		ReasonCode:       string(signal.SourceType),
-		Version:          signal.Version,
-	})
+	eventPayload := statusPayload("blocking_signal", signal.ID, string(signal.Status), signal.Version)
+	eventPayload.ReasonCode = string(signal.SourceType)
+	event := outboxEvent(s.idGenerator.New(), governanceevents.EventBlockingSignalRecorded, governanceevents.AggregateBlockingSignal, signal.ID, now, eventPayload)
 	if err := s.repository.RecordBlockingSignal(ctx, signal, result, event); err != nil {
 		return entity.BlockingSignal{}, err
 	}
@@ -1861,6 +1845,19 @@ func validateCommandReplay(result entity.CommandResult, meta CommandMeta, operat
 	return nil
 }
 
+func replayedEntity[T any](ctx context.Context, result entity.CommandResult, load func(context.Context, uuid.UUID) (T, error), matches func(T) bool) (T, error) {
+	item, err := load(ctx, result.AggregateID)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	if !matches(item) {
+		var zero T
+		return zero, errs.ErrConflict
+	}
+	return item, nil
+}
+
 func commandResult(meta CommandMeta, operation string, aggregateType string, aggregateID uuid.UUID, now time.Time) entity.CommandResult {
 	return commandResultWithPayload(meta, operation, aggregateType, aggregateID, now, nil)
 }
@@ -1919,6 +1916,17 @@ func outboxEvent(id uuid.UUID, eventType string, aggregateType string, aggregate
 		),
 		NextAttemptAt: occurredAt,
 	}
+}
+
+func statusPayload(idKind string, id uuid.UUID, status string, version int64) governanceevents.Payload {
+	payload := governanceevents.Payload{Status: status, Version: version}
+	switch idKind {
+	case "gate_request":
+		payload.GateRequestID = id.String()
+	case "blocking_signal":
+		payload.BlockingSignalID = id.String()
+	}
+	return payload
 }
 
 func optionalUUIDString(id *uuid.UUID) string {

--- a/services/internal/governance-manager/internal/repository/postgres/governance/args.go
+++ b/services/internal/governance-manager/internal/repository/postgres/governance/args.go
@@ -365,19 +365,15 @@ func reviewSignalFilterArgs(filter query.ReviewSignalFilter) pageQueryArgs {
 }
 
 func gateRequestFilterArgs(filter query.GateRequestFilter) pageQueryArgs {
-	return withPage(filter.Page, pgx.NamedArgs{
+	return withGateTargetPage(filter.Page, filter.Target.Type, filter.Target.Ref, pgx.NamedArgs{
 		"risk_assessment_id": postgreslib.NullableUUID(filter.RiskAssessmentID),
-		"target_type":        filter.Target.Type,
-		"target_ref":         filter.Target.Ref,
 		"status":             string(filter.Status),
 	})
 }
 
 func gateDecisionFilterArgs(filter query.GateDecisionFilter) pageQueryArgs {
-	return withPage(filter.Page, pgx.NamedArgs{
+	return withGateTargetPage(filter.Page, filter.Target.Type, filter.Target.Ref, pgx.NamedArgs{
 		"gate_request_id": postgreslib.NullableUUID(filter.GateRequestID),
-		"target_type":     filter.Target.Type,
-		"target_ref":      filter.Target.Ref,
 		"outcome":         string(filter.Outcome),
 	})
 }
@@ -404,6 +400,12 @@ func withPage(page query.PageRequest, args pgx.NamedArgs) pageQueryArgs {
 	args["limit"] = limit + 1
 	args["offset"] = offset
 	return pageQueryArgs{NamedArgs: args, PageSize: limit, Offset: offset}
+}
+
+func withGateTargetPage(page query.PageRequest, targetType string, targetRef string, args pgx.NamedArgs) pageQueryArgs {
+	args["target_type"] = targetType
+	args["target_ref"] = targetRef
+	return withPage(page, args)
 }
 
 func pageResult[T any](items []T, page pageQueryArgs) ([]T, query.PageResult) {

--- a/services/internal/governance-manager/internal/repository/postgres/governance/repository.go
+++ b/services/internal/governance-manager/internal/repository/postgres/governance/repository.go
@@ -44,6 +44,12 @@ type Repository struct {
 	db database
 }
 
+type mutationStep struct {
+	query           string
+	args            pgx.NamedArgs
+	requireAffected bool
+}
+
 const (
 	operationActivateRiskProfileVersion  = "domain.Repository.ActivateRiskProfileVersion"
 	operationArchiveRiskProfile          = "domain.Repository.ArchiveRiskProfile"
@@ -127,25 +133,14 @@ func (r *Repository) CreateRiskProfileVersion(ctx context.Context, version entit
 
 // ActivateRiskProfileVersion activates a profile version and records an event.
 func (r *Repository) ActivateRiskProfileVersion(ctx context.Context, profile entity.RiskProfile, previousProfileVersion int64, activatedVersion entity.RiskProfileVersion, result entity.CommandResult, event entity.OutboxEvent) error {
-	err := postgreslib.WithTx(ctx, r.db, func(tx pgx.Tx) error {
-		if err := runMutation(ctx, tx, queryRiskProfileVersionSupersede, pgx.NamedArgs{
+	return r.mutateStepsWithResult(ctx, operationActivateRiskProfileVersion, result, &event,
+		optionalMutation(queryRiskProfileVersionSupersede, pgx.NamedArgs{
 			"risk_profile_id": activatedVersion.RiskProfileID,
 			"profile_version": activatedVersion.ProfileVersion,
-		}, false); err != nil {
-			return err
-		}
-		if err := runMutation(ctx, tx, queryRiskProfileVersionActivate, riskProfileVersionArgs(activatedVersion), true); err != nil {
-			return err
-		}
-		if err := runMutation(ctx, tx, queryRiskProfileUpdate, riskProfileUpdateArgs(profile, previousProfileVersion), true); err != nil {
-			return err
-		}
-		if err := runCommandResult(ctx, tx, result); err != nil {
-			return err
-		}
-		return runOutboxEvent(ctx, tx, event)
-	})
-	return wrapError(operationActivateRiskProfileVersion, err)
+		}),
+		requiredMutation(queryRiskProfileVersionActivate, riskProfileVersionArgs(activatedVersion)),
+		requiredMutation(queryRiskProfileUpdate, riskProfileUpdateArgs(profile, previousProfileVersion)),
+	)
 }
 
 // ArchiveRiskProfile archives a profile without deleting historical decisions.
@@ -266,24 +261,22 @@ func (r *Repository) CreateGateRequest(ctx context.Context, request entity.GateR
 
 // UpdateGateRequestStatus stores a terminal gate request lifecycle transition.
 func (r *Repository) UpdateGateRequestStatus(ctx context.Context, request entity.GateRequest, previousVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
-	return r.mutateWithResult(ctx, operationUpdateGateRequestStatus, queryGateRequestUpdate, gateRequestUpdateArgs(request, previousVersion), result, &event)
+	return r.updateGateRequestLifecycle(ctx, request, previousVersion, result, event)
+}
+
+func (r *Repository) updateGateRequestLifecycle(ctx context.Context, request entity.GateRequest, previousVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
+	args := gateRequestUpdateArgs(request, previousVersion)
+	eventRef := &event
+	return r.mutateWithResult(ctx, operationUpdateGateRequestStatus, queryGateRequestUpdate, args, result, eventRef)
 }
 
 // UpdateGateRequestWithDecision stores a final gate decision and resolves the request.
 func (r *Repository) UpdateGateRequestWithDecision(ctx context.Context, request entity.GateRequest, previousVersion int64, decision entity.GateDecision, result entity.CommandResult, event entity.OutboxEvent) error {
-	err := postgreslib.WithTx(ctx, r.db, func(tx pgx.Tx) error {
-		if err := runMutation(ctx, tx, queryGateRequestUpdate, gateRequestUpdateArgs(request, previousVersion), true); err != nil {
-			return err
-		}
-		if err := runMutation(ctx, tx, queryGateDecisionCreate, gateDecisionArgs(decision), true); err != nil {
-			return err
-		}
-		if err := runCommandResult(ctx, tx, result); err != nil {
-			return err
-		}
-		return runOutboxEvent(ctx, tx, event)
-	})
-	return wrapError(operationSubmitGateDecision, err)
+	steps := []mutationStep{
+		requiredMutation(queryGateRequestUpdate, gateRequestUpdateArgs(request, previousVersion)),
+		requiredMutation(queryGateDecisionCreate, gateDecisionArgs(decision)),
+	}
+	return r.mutateStepsWithResult(ctx, operationSubmitGateDecision, result, &event, steps...)
 }
 
 // GetGateRequest returns a gate request by id.
@@ -313,7 +306,12 @@ func (r *Repository) CreateReleaseDecisionPackage(ctx context.Context, item enti
 
 // UpdateReleaseDecisionPackageStatus updates release package lifecycle status.
 func (r *Repository) UpdateReleaseDecisionPackageStatus(ctx context.Context, item entity.ReleaseDecisionPackage, previousVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
-	return r.mutateWithResult(ctx, operationUpdateReleasePackageStatus, queryReleaseDecisionPackageUpdate, releaseDecisionPackageUpdateArgs(item, previousVersion), result, &event)
+	return r.updateReleasePackageStatus(ctx, item, previousVersion, result, event)
+}
+
+func (r *Repository) updateReleasePackageStatus(ctx context.Context, item entity.ReleaseDecisionPackage, previousVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
+	args := releaseDecisionPackageUpdateArgs(item, previousVersion)
+	return r.mutateWithResult(ctx, operationUpdateReleasePackageStatus, queryReleaseDecisionPackageUpdate, args, result, &event)
 }
 
 // GetReleaseDecisionPackage returns a release decision package by id.
@@ -328,36 +326,24 @@ func (r *Repository) ListReleaseDecisionPackages(ctx context.Context, filter que
 
 // CreateReleaseDecision stores a requested release decision and advances the package.
 func (r *Repository) CreateReleaseDecision(ctx context.Context, pkg entity.ReleaseDecisionPackage, previousPackageVersion int64, decision entity.ReleaseDecision, result entity.CommandResult, event entity.OutboxEvent) error {
-	err := postgreslib.WithTx(ctx, r.db, func(tx pgx.Tx) error {
-		if err := runMutation(ctx, tx, queryReleaseDecisionPackageUpdate, releaseDecisionPackageUpdateArgs(pkg, previousPackageVersion), true); err != nil {
-			return err
-		}
-		if err := runMutation(ctx, tx, queryReleaseDecisionCreate, releaseDecisionArgs(decision), true); err != nil {
-			return err
-		}
-		if err := runCommandResult(ctx, tx, result); err != nil {
-			return err
-		}
-		return runOutboxEvent(ctx, tx, event)
-	})
-	return wrapError(operationCreateReleaseDecision, err)
+	packageUpdate := requiredMutation(queryReleaseDecisionPackageUpdate, releaseDecisionPackageUpdateArgs(pkg, previousPackageVersion))
+	decisionCreate := requiredMutation(queryReleaseDecisionCreate, releaseDecisionArgs(decision))
+	return r.mutateStepsWithResult(ctx, operationCreateReleaseDecision, result, &event,
+		packageUpdate,
+		decisionCreate,
+	)
 }
 
 // UpdateReleaseDecision stores a terminal release decision and closes the package.
 func (r *Repository) UpdateReleaseDecision(ctx context.Context, pkg entity.ReleaseDecisionPackage, previousPackageVersion int64, decision entity.ReleaseDecision, previousDecisionVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
-	err := postgreslib.WithTx(ctx, r.db, func(tx pgx.Tx) error {
-		if err := runMutation(ctx, tx, queryReleaseDecisionPackageUpdate, releaseDecisionPackageUpdateArgs(pkg, previousPackageVersion), true); err != nil {
-			return err
-		}
-		if err := runMutation(ctx, tx, queryReleaseDecisionUpdate, releaseDecisionUpdateArgs(decision, previousDecisionVersion), true); err != nil {
-			return err
-		}
-		if err := runCommandResult(ctx, tx, result); err != nil {
-			return err
-		}
-		return runOutboxEvent(ctx, tx, event)
-	})
-	return wrapError(operationUpdateReleaseDecision, err)
+	return r.mutateReleaseDecisionUpdate(ctx, pkg, previousPackageVersion, decision, previousDecisionVersion, result, event)
+}
+
+func (r *Repository) mutateReleaseDecisionUpdate(ctx context.Context, pkg entity.ReleaseDecisionPackage, previousPackageVersion int64, decision entity.ReleaseDecision, previousDecisionVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
+	return r.mutateStepsWithResult(ctx, operationUpdateReleaseDecision, result, &event,
+		requiredMutation(queryReleaseDecisionPackageUpdate, releaseDecisionPackageUpdateArgs(pkg, previousPackageVersion)),
+		requiredMutation(queryReleaseDecisionUpdate, releaseDecisionUpdateArgs(decision, previousDecisionVersion)),
+	)
 }
 
 // GetReleaseDecision returns one release decision by id.
@@ -382,7 +368,8 @@ func (r *Repository) RecordReleaseSafetyState(ctx context.Context, state entity.
 
 // UpdateReleaseSafetyState updates the current safety-loop state.
 func (r *Repository) UpdateReleaseSafetyState(ctx context.Context, state entity.ReleaseSafetyState, previousVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
-	return r.mutateWithResult(ctx, operationUpdateReleaseSafetyState, queryReleaseSafetyStateUpdate, releaseSafetyStateUpdateArgs(state, previousVersion), result, &event)
+	step := requiredMutation(queryReleaseSafetyStateUpdate, releaseSafetyStateUpdateArgs(state, previousVersion))
+	return r.mutateStepsWithResult(ctx, operationUpdateReleaseSafetyState, result, &event, step)
 }
 
 // GetReleaseSafetyStateByPackage returns current safety-loop state for a package.
@@ -397,7 +384,9 @@ func (r *Repository) RecordBlockingSignal(ctx context.Context, signal entity.Blo
 
 // UpdateBlockingSignal stores a terminal blocking signal transition.
 func (r *Repository) UpdateBlockingSignal(ctx context.Context, signal entity.BlockingSignal, previousVersion int64, result entity.CommandResult, event entity.OutboxEvent) error {
-	return r.mutateWithResult(ctx, operationUpdateBlockingSignal, queryBlockingSignalUpdate, blockingSignalUpdateArgs(signal, previousVersion), result, &event)
+	eventRef := &event
+	updateArgs := blockingSignalUpdateArgs(signal, previousVersion)
+	return r.mutateWithResult(ctx, operationUpdateBlockingSignal, queryBlockingSignalUpdate, updateArgs, result, eventRef)
 }
 
 // GetBlockingSignal returns one blocking signal by id.
@@ -439,18 +428,29 @@ func (r *Repository) MarkOutboxEventPublished(ctx context.Context, id uuid.UUID,
 
 // MarkOutboxEventFailed schedules an outbox retry.
 func (r *Repository) MarkOutboxEventFailed(ctx context.Context, id uuid.UUID, attemptCount int, nextAttemptAt time.Time, lastError string) error {
-	return wrapError(operationOutboxMarkFailed, postgreslib.ApplyOutboxDeliveryFailure(ctx, r.db, queryOutboxEventMarkFailed, errs.ErrInvalidArgument, id, attemptCount, "next_attempt_at", nextAttemptAt, lastError))
+	return r.markOutboxFailure(ctx, operationOutboxMarkFailed, queryOutboxEventMarkFailed, id, attemptCount, "next_attempt_at", nextAttemptAt, lastError)
 }
 
 // MarkOutboxEventPermanentlyFailed marks an outbox event terminally failed.
 func (r *Repository) MarkOutboxEventPermanentlyFailed(ctx context.Context, id uuid.UUID, attemptCount int, failedAt time.Time, lastError string) error {
-	return wrapError(operationOutboxMarkPermanent, postgreslib.ApplyOutboxDeliveryFailure(ctx, r.db, queryOutboxEventMarkPermanent, errs.ErrInvalidArgument, id, attemptCount, "failed_permanently_at", failedAt, lastError))
+	return r.markOutboxFailure(ctx, operationOutboxMarkPermanent, queryOutboxEventMarkPermanent, id, attemptCount, "failed_permanently_at", failedAt, lastError)
+}
+
+func (r *Repository) markOutboxFailure(ctx context.Context, operation string, sqlText string, id uuid.UUID, attemptCount int, timestampColumn string, timestamp time.Time, lastError string) error {
+	err := postgreslib.ApplyOutboxDeliveryFailure(ctx, r.db, sqlText, errs.ErrInvalidArgument, id, attemptCount, timestampColumn, timestamp, lastError)
+	return wrapError(operation, err)
 }
 
 func (r *Repository) mutateWithResult(ctx context.Context, operation string, mutationQuery string, mutationArgs pgx.NamedArgs, result entity.CommandResult, event *entity.OutboxEvent) error {
+	return r.mutateStepsWithResult(ctx, operation, result, event, requiredMutation(mutationQuery, mutationArgs))
+}
+
+func (r *Repository) mutateStepsWithResult(ctx context.Context, operation string, result entity.CommandResult, event *entity.OutboxEvent, steps ...mutationStep) error {
 	err := postgreslib.WithTx(ctx, r.db, func(tx pgx.Tx) error {
-		if err := runMutation(ctx, tx, mutationQuery, mutationArgs, true); err != nil {
-			return err
+		for _, step := range steps {
+			if err := runMutation(ctx, tx, step.query, step.args, step.requireAffected); err != nil {
+				return err
+			}
 		}
 		if err := runCommandResult(ctx, tx, result); err != nil {
 			return err
@@ -463,46 +463,53 @@ func (r *Repository) mutateWithResult(ctx context.Context, operation string, mut
 	return wrapError(operation, err)
 }
 
+func requiredMutation(query string, args pgx.NamedArgs) mutationStep {
+	return mutationStep{query: query, args: args, requireAffected: true}
+}
+
+func optionalMutation(query string, args pgx.NamedArgs) mutationStep {
+	return mutationStep{query: query, args: args}
+}
+
 func queueGatePolicies(ctx context.Context, tx pgx.Tx, policies []entity.GatePolicy) error {
-	if len(policies) == 0 {
-		return nil
-	}
-	batch := &pgx.Batch{}
-	for _, policy := range policies {
-		batch.Queue(queryGatePolicyCreate, gatePolicyArgs(policy))
-	}
-	return execBatch(ctx, tx, batch)
+	return queueBatch(ctx, tx, policies, queueGatePolicy)
 }
 
 func queueRiskRules(ctx context.Context, tx pgx.Tx, rules []entity.RiskRule) error {
-	if len(rules) == 0 {
-		return nil
-	}
-	batch := &pgx.Batch{}
-	for _, rule := range rules {
-		batch.Queue(queryRiskRuleCreate, riskRuleArgs(rule))
-	}
-	return execBatch(ctx, tx, batch)
+	return queueBatch(ctx, tx, rules, queueRiskRule)
 }
 
 func queueRiskFactors(ctx context.Context, tx pgx.Tx, factors []entity.RiskFactor) error {
-	if len(factors) == 0 {
-		return nil
-	}
-	batch := &pgx.Batch{}
-	for _, factor := range factors {
-		batch.Queue(queryRiskFactorCreate, riskFactorArgs(factor))
-	}
-	return execBatch(ctx, tx, batch)
+	return queueBatch(ctx, tx, factors, queueRiskFactor)
 }
 
 func queueOutboxEvents(ctx context.Context, tx pgx.Tx, events []entity.OutboxEvent) error {
-	if len(events) == 0 {
+	return queueBatch(ctx, tx, events, queueOutboxEvent)
+}
+
+func queueGatePolicy(batch *pgx.Batch, policy entity.GatePolicy) {
+	batch.Queue(queryGatePolicyCreate, gatePolicyArgs(policy))
+}
+
+func queueRiskRule(batch *pgx.Batch, rule entity.RiskRule) {
+	batch.Queue(queryRiskRuleCreate, riskRuleArgs(rule))
+}
+
+func queueRiskFactor(batch *pgx.Batch, factor entity.RiskFactor) {
+	batch.Queue(queryRiskFactorCreate, riskFactorArgs(factor))
+}
+
+func queueOutboxEvent(batch *pgx.Batch, event entity.OutboxEvent) {
+	batch.Queue(queryOutboxEventCreate, outboxEventArgs(event))
+}
+
+func queueBatch[T any](ctx context.Context, tx pgx.Tx, items []T, queue func(*pgx.Batch, T)) error {
+	if len(items) == 0 {
 		return nil
 	}
 	batch := &pgx.Batch{}
-	for _, event := range events {
-		batch.Queue(queryOutboxEventCreate, outboxEventArgs(event))
+	for _, item := range items {
+		queue(batch, item)
 	}
 	return execBatch(ctx, tx, batch)
 }

--- a/services/internal/governance-manager/internal/transport/grpc/casters.go
+++ b/services/internal/governance-manager/internal/transport/grpc/casters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	governancev1 "github.com/codex-k8s/kodex/proto/gen/go/kodex/governance/v1"
 	"github.com/codex-k8s/kodex/services/internal/governance-manager/internal/domain/errs"
@@ -20,6 +21,36 @@ import (
 )
 
 var protoJSON = protojson.MarshalOptions{UseProtoNames: true}
+
+type protoEnum interface {
+	~int32
+	String() string
+	Descriptor() protoreflect.EnumDescriptor
+}
+
+func protoEnumDomain[D ~string, E protoEnum](item E, prefix string, fallback D) D {
+	return protoEnumDomainWith(item, prefix, fallback, strings.ToLower)
+}
+
+func protoEnumDomainWith[D ~string, E protoEnum](item E, prefix string, fallback D, normalize func(string) string) D {
+	suffix, ok := strings.CutPrefix(item.String(), prefix)
+	if !ok || suffix == "" || suffix == "UNSPECIFIED" {
+		return fallback
+	}
+	return D(normalize(suffix))
+}
+
+func domainProtoEnum[D ~string, E protoEnum](item D, prefix string, unspecified E) E {
+	value := strings.TrimSpace(string(item))
+	if value == "" {
+		return unspecified
+	}
+	descriptor := unspecified.Descriptor().Values().ByName(protoreflect.Name(prefix + strings.ToUpper(value)))
+	if descriptor == nil {
+		return unspecified
+	}
+	return E(descriptor.Number())
+}
 
 func commandMeta(meta *governancev1.CommandMeta) (governanceservice.CommandMeta, error) {
 	if meta == nil {
@@ -118,12 +149,12 @@ func interactionDeliveryRef(item *governancev1.InteractionDeliveryRef) value.Int
 	if item == nil {
 		return value.InteractionDeliveryRef{}
 	}
-	return value.InteractionDeliveryRef{
-		RequestRef:  item.GetRequestRef(),
-		DeliveryRef: item.GetDeliveryRef(),
-		CallbackRef: item.GetCallbackRef(),
-		DecisionRef: item.GetDecisionRef(),
-	}
+	result := value.InteractionDeliveryRef{}
+	result.RequestRef = item.GetRequestRef()
+	result.DeliveryRef = item.GetDeliveryRef()
+	result.CallbackRef = item.GetCallbackRef()
+	result.DecisionRef = item.GetDecisionRef()
+	return result
 }
 
 func localizedTexts(items []*governancev1.LocalizedText) []value.LocalizedText {
@@ -725,28 +756,21 @@ func runtimeContextFromJSON(payload []byte) *governancev1.RuntimeContextRef {
 }
 
 func providerRefsFromJSON(payload []byte) []*governancev1.ProviderContextRef {
-	var raw []json.RawMessage
-	if len(payload) == 0 || json.Unmarshal(payload, &raw) != nil {
-		return nil
-	}
-	result := make([]*governancev1.ProviderContextRef, 0, len(raw))
-	for _, body := range raw {
-		item := &governancev1.ProviderContextRef{}
-		if unmarshalProtoJSON(body, item) {
-			result = append(result, item)
-		}
-	}
-	return result
+	return protoRefsFromJSONArray(payload, func() *governancev1.ProviderContextRef { return &governancev1.ProviderContextRef{} })
 }
 
 func runtimeRefsFromJSON(payload []byte) []*governancev1.RuntimeContextRef {
+	return protoRefsFromJSONArray(payload, func() *governancev1.RuntimeContextRef { return &governancev1.RuntimeContextRef{} })
+}
+
+func protoRefsFromJSONArray[T proto.Message](payload []byte, create func() T) []T {
 	var raw []json.RawMessage
 	if len(payload) == 0 || json.Unmarshal(payload, &raw) != nil {
 		return nil
 	}
-	result := make([]*governancev1.RuntimeContextRef, 0, len(raw))
+	result := make([]T, 0, len(raw))
 	for _, body := range raw {
-		item := &governancev1.RuntimeContextRef{}
+		item := create()
 		if unmarshalProtoJSON(body, item) {
 			result = append(result, item)
 		}
@@ -923,768 +947,165 @@ func toTargetType(item string) governancev1.GovernanceTargetType {
 }
 
 func riskClass(item governancev1.RiskClass) enum.RiskClass {
-	switch item {
-	case governancev1.RiskClass_RISK_CLASS_R0:
-		return enum.RiskClassR0
-	case governancev1.RiskClass_RISK_CLASS_R1:
-		return enum.RiskClassR1
-	case governancev1.RiskClass_RISK_CLASS_R2:
-		return enum.RiskClassR2
-	case governancev1.RiskClass_RISK_CLASS_R3:
-		return enum.RiskClassR3
-	default:
-		return enum.RiskClassUnspecified
-	}
+	return protoEnumDomainWith(item, "RISK_CLASS_", enum.RiskClassUnspecified, strings.ToUpper)
 }
 
 func toRiskClass(item enum.RiskClass) governancev1.RiskClass {
-	switch item {
-	case enum.RiskClassR0:
-		return governancev1.RiskClass_RISK_CLASS_R0
-	case enum.RiskClassR1:
-		return governancev1.RiskClass_RISK_CLASS_R1
-	case enum.RiskClassR2:
-		return governancev1.RiskClass_RISK_CLASS_R2
-	case enum.RiskClassR3:
-		return governancev1.RiskClass_RISK_CLASS_R3
-	default:
-		return governancev1.RiskClass_RISK_CLASS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RISK_CLASS_", governancev1.RiskClass_RISK_CLASS_UNSPECIFIED)
 }
 
 func riskProfileStatus(item governancev1.RiskProfileStatus) enum.RiskProfileStatus {
-	switch item {
-	case governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_DRAFT:
-		return enum.RiskProfileStatusDraft
-	case governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_ACTIVE:
-		return enum.RiskProfileStatusActive
-	case governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_DISABLED:
-		return enum.RiskProfileStatusDisabled
-	case governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_ARCHIVED:
-		return enum.RiskProfileStatusArchived
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RISK_PROFILE_STATUS_", enum.RiskProfileStatus(""))
 }
 
 func toRiskProfileStatus(item enum.RiskProfileStatus) governancev1.RiskProfileStatus {
-	switch item {
-	case enum.RiskProfileStatusDraft:
-		return governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_DRAFT
-	case enum.RiskProfileStatusActive:
-		return governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_ACTIVE
-	case enum.RiskProfileStatusDisabled:
-		return governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_DISABLED
-	case enum.RiskProfileStatusArchived:
-		return governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_ARCHIVED
-	default:
-		return governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RISK_PROFILE_STATUS_", governancev1.RiskProfileStatus_RISK_PROFILE_STATUS_UNSPECIFIED)
 }
 
 func toRiskProfileVersionStatus(item enum.RiskProfileVersionStatus) governancev1.RiskProfileVersionStatus {
-	switch item {
-	case enum.RiskProfileVersionStatusDraft:
-		return governancev1.RiskProfileVersionStatus_RISK_PROFILE_VERSION_STATUS_DRAFT
-	case enum.RiskProfileVersionStatusActive:
-		return governancev1.RiskProfileVersionStatus_RISK_PROFILE_VERSION_STATUS_ACTIVE
-	case enum.RiskProfileVersionStatusSuperseded:
-		return governancev1.RiskProfileVersionStatus_RISK_PROFILE_VERSION_STATUS_SUPERSEDED
-	case enum.RiskProfileVersionStatusArchived:
-		return governancev1.RiskProfileVersionStatus_RISK_PROFILE_VERSION_STATUS_ARCHIVED
-	default:
-		return governancev1.RiskProfileVersionStatus_RISK_PROFILE_VERSION_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RISK_PROFILE_VERSION_STATUS_", governancev1.RiskProfileVersionStatus_RISK_PROFILE_VERSION_STATUS_UNSPECIFIED)
 }
 
 func riskRuleKind(item governancev1.RiskRuleKind) enum.RiskRuleKind {
-	switch item {
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_PATH:
-		return enum.RiskRuleKindPath
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_SERVICE:
-		return enum.RiskRuleKindService
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_API:
-		return enum.RiskRuleKindAPI
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_DATABASE:
-		return enum.RiskRuleKindDatabase
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_SECRET:
-		return enum.RiskRuleKindSecret
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_AUTH:
-		return enum.RiskRuleKindAuth
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_RUNTIME_ACTION:
-		return enum.RiskRuleKindRuntimeAction
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_RELEASE:
-		return enum.RiskRuleKindRelease
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_AUTOMATION:
-		return enum.RiskRuleKindAutomation
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_DOCUMENT:
-		return enum.RiskRuleKindDocument
-	case governancev1.RiskRuleKind_RISK_RULE_KIND_CUSTOM:
-		return enum.RiskRuleKindCustom
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RISK_RULE_KIND_", enum.RiskRuleKind(""))
 }
 
 func toRiskRuleKind(item enum.RiskRuleKind) governancev1.RiskRuleKind {
-	switch item {
-	case enum.RiskRuleKindPath:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_PATH
-	case enum.RiskRuleKindService:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_SERVICE
-	case enum.RiskRuleKindAPI:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_API
-	case enum.RiskRuleKindDatabase:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_DATABASE
-	case enum.RiskRuleKindSecret:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_SECRET
-	case enum.RiskRuleKindAuth:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_AUTH
-	case enum.RiskRuleKindRuntimeAction:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_RUNTIME_ACTION
-	case enum.RiskRuleKindRelease:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_RELEASE
-	case enum.RiskRuleKindAutomation:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_AUTOMATION
-	case enum.RiskRuleKindDocument:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_DOCUMENT
-	case enum.RiskRuleKindCustom:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_CUSTOM
-	default:
-		return governancev1.RiskRuleKind_RISK_RULE_KIND_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RISK_RULE_KIND_", governancev1.RiskRuleKind_RISK_RULE_KIND_UNSPECIFIED)
 }
 
 func ruleStatus(item governancev1.RuleStatus) enum.RuleStatus {
-	switch item {
-	case governancev1.RuleStatus_RULE_STATUS_ACTIVE:
-		return enum.RuleStatusActive
-	case governancev1.RuleStatus_RULE_STATUS_DISABLED:
-		return enum.RuleStatusDisabled
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RULE_STATUS_", enum.RuleStatus(""))
 }
 
 func toRuleStatus(item enum.RuleStatus) governancev1.RuleStatus {
-	switch item {
-	case enum.RuleStatusActive:
-		return governancev1.RuleStatus_RULE_STATUS_ACTIVE
-	case enum.RuleStatusDisabled:
-		return governancev1.RuleStatus_RULE_STATUS_DISABLED
-	default:
-		return governancev1.RuleStatus_RULE_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RULE_STATUS_", governancev1.RuleStatus_RULE_STATUS_UNSPECIFIED)
 }
 
 func gateKind(item governancev1.GateKind) enum.GateKind {
-	switch item {
-	case governancev1.GateKind_GATE_KIND_PRODUCT:
-		return enum.GateKindProduct
-	case governancev1.GateKind_GATE_KIND_ARCHITECTURE:
-		return enum.GateKindArchitecture
-	case governancev1.GateKind_GATE_KIND_TECHNICAL:
-		return enum.GateKindTechnical
-	case governancev1.GateKind_GATE_KIND_QA:
-		return enum.GateKindQA
-	case governancev1.GateKind_GATE_KIND_RELEASE:
-		return enum.GateKindRelease
-	case governancev1.GateKind_GATE_KIND_POSTDEPLOY:
-		return enum.GateKindPostdeploy
-	case governancev1.GateKind_GATE_KIND_EMERGENCY:
-		return enum.GateKindEmergency
-	case governancev1.GateKind_GATE_KIND_CUSTOM:
-		return enum.GateKindCustom
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "GATE_KIND_", enum.GateKind(""))
 }
 
 func toGateKind(item enum.GateKind) governancev1.GateKind {
-	switch item {
-	case enum.GateKindProduct:
-		return governancev1.GateKind_GATE_KIND_PRODUCT
-	case enum.GateKindArchitecture:
-		return governancev1.GateKind_GATE_KIND_ARCHITECTURE
-	case enum.GateKindTechnical:
-		return governancev1.GateKind_GATE_KIND_TECHNICAL
-	case enum.GateKindQA:
-		return governancev1.GateKind_GATE_KIND_QA
-	case enum.GateKindRelease:
-		return governancev1.GateKind_GATE_KIND_RELEASE
-	case enum.GateKindPostdeploy:
-		return governancev1.GateKind_GATE_KIND_POSTDEPLOY
-	case enum.GateKindEmergency:
-		return governancev1.GateKind_GATE_KIND_EMERGENCY
-	case enum.GateKindCustom:
-		return governancev1.GateKind_GATE_KIND_CUSTOM
-	default:
-		return governancev1.GateKind_GATE_KIND_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "GATE_KIND_", governancev1.GateKind_GATE_KIND_UNSPECIFIED)
 }
 
 func riskAssessmentStatus(item governancev1.RiskAssessmentStatus) enum.RiskAssessmentStatus {
-	switch item {
-	case governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_DRAFT:
-		return enum.RiskAssessmentStatusDraft
-	case governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_ACTIVE:
-		return enum.RiskAssessmentStatusActive
-	case governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_SUPERSEDED:
-		return enum.RiskAssessmentStatusSuperseded
-	case governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_CLOSED:
-		return enum.RiskAssessmentStatusClosed
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RISK_ASSESSMENT_STATUS_", enum.RiskAssessmentStatus(""))
 }
 
 func toRiskAssessmentStatus(item enum.RiskAssessmentStatus) governancev1.RiskAssessmentStatus {
-	switch item {
-	case enum.RiskAssessmentStatusDraft:
-		return governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_DRAFT
-	case enum.RiskAssessmentStatusActive:
-		return governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_ACTIVE
-	case enum.RiskAssessmentStatusSuperseded:
-		return governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_SUPERSEDED
-	case enum.RiskAssessmentStatusClosed:
-		return governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_CLOSED
-	default:
-		return governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RISK_ASSESSMENT_STATUS_", governancev1.RiskAssessmentStatus_RISK_ASSESSMENT_STATUS_UNSPECIFIED)
 }
 
 func riskFactorSourceType(item governancev1.RiskFactorSourceType) enum.RiskFactorSourceType {
-	switch item {
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_POLICY:
-		return enum.RiskFactorSourceTypePolicy
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_CHANGED_FILE:
-		return enum.RiskFactorSourceTypeChangedFile
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_SERVICE:
-		return enum.RiskFactorSourceTypeService
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_API:
-		return enum.RiskFactorSourceTypeAPI
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_DATABASE:
-		return enum.RiskFactorSourceTypeDatabase
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_SECRET:
-		return enum.RiskFactorSourceTypeSecret
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_RELEASE:
-		return enum.RiskFactorSourceTypeRelease
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_RUNTIME:
-		return enum.RiskFactorSourceTypeRuntime
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_REVIEW_SIGNAL:
-		return enum.RiskFactorSourceTypeReviewSignal
-	case governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_HUMAN_DECISION:
-		return enum.RiskFactorSourceTypeHumanDecision
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RISK_FACTOR_SOURCE_TYPE_", enum.RiskFactorSourceType(""))
 }
 
 func toRiskFactorSourceType(item enum.RiskFactorSourceType) governancev1.RiskFactorSourceType {
-	switch item {
-	case enum.RiskFactorSourceTypePolicy:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_POLICY
-	case enum.RiskFactorSourceTypeChangedFile:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_CHANGED_FILE
-	case enum.RiskFactorSourceTypeService:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_SERVICE
-	case enum.RiskFactorSourceTypeAPI:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_API
-	case enum.RiskFactorSourceTypeDatabase:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_DATABASE
-	case enum.RiskFactorSourceTypeSecret:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_SECRET
-	case enum.RiskFactorSourceTypeRelease:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_RELEASE
-	case enum.RiskFactorSourceTypeRuntime:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_RUNTIME
-	case enum.RiskFactorSourceTypeReviewSignal:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_REVIEW_SIGNAL
-	case enum.RiskFactorSourceTypeHumanDecision:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_HUMAN_DECISION
-	default:
-		return governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RISK_FACTOR_SOURCE_TYPE_", governancev1.RiskFactorSourceType_RISK_FACTOR_SOURCE_TYPE_UNSPECIFIED)
 }
 
 func reviewRoleKind(item governancev1.ReviewRoleKind) enum.ReviewRoleKind {
-	switch item {
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_REVIEWER:
-		return enum.ReviewRoleKindReviewer
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_QA:
-		return enum.ReviewRoleKindQA
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_LEXICAL_GATEKEEPER:
-		return enum.ReviewRoleKindLexicalGatekeeper
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_RISK_GATEKEEPER:
-		return enum.ReviewRoleKindRiskGatekeeper
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_SRE:
-		return enum.ReviewRoleKindSRE
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_SECURITY:
-		return enum.ReviewRoleKindSecurity
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_OWNER:
-		return enum.ReviewRoleKindOwner
-	case governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_CUSTOM:
-		return enum.ReviewRoleKindCustom
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "REVIEW_ROLE_KIND_", enum.ReviewRoleKind(""))
 }
 
 func toReviewRoleKind(item enum.ReviewRoleKind) governancev1.ReviewRoleKind {
-	switch item {
-	case enum.ReviewRoleKindReviewer:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_REVIEWER
-	case enum.ReviewRoleKindQA:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_QA
-	case enum.ReviewRoleKindLexicalGatekeeper:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_LEXICAL_GATEKEEPER
-	case enum.ReviewRoleKindRiskGatekeeper:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_RISK_GATEKEEPER
-	case enum.ReviewRoleKindSRE:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_SRE
-	case enum.ReviewRoleKindSecurity:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_SECURITY
-	case enum.ReviewRoleKindOwner:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_OWNER
-	case enum.ReviewRoleKindCustom:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_CUSTOM
-	default:
-		return governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "REVIEW_ROLE_KIND_", governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_UNSPECIFIED)
 }
 
 func reviewSignalOutcome(item governancev1.ReviewSignalOutcome) enum.ReviewSignalOutcome {
-	switch item {
-	case governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_PASS:
-		return enum.ReviewSignalOutcomePass
-	case governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_PASS_WITH_NOTES:
-		return enum.ReviewSignalOutcomePassWithNotes
-	case governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_BLOCK:
-		return enum.ReviewSignalOutcomeBlock
-	case governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_REQUEST_CHANGES:
-		return enum.ReviewSignalOutcomeRequestChanges
-	case governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_RAISE_RISK:
-		return enum.ReviewSignalOutcomeRaiseRisk
-	case governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_INFORMATIONAL:
-		return enum.ReviewSignalOutcomeInformational
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "REVIEW_SIGNAL_OUTCOME_", enum.ReviewSignalOutcome(""))
 }
 
 func toReviewSignalOutcome(item enum.ReviewSignalOutcome) governancev1.ReviewSignalOutcome {
-	switch item {
-	case enum.ReviewSignalOutcomePass:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_PASS
-	case enum.ReviewSignalOutcomePassWithNotes:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_PASS_WITH_NOTES
-	case enum.ReviewSignalOutcomeBlock:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_BLOCK
-	case enum.ReviewSignalOutcomeRequestChanges:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_REQUEST_CHANGES
-	case enum.ReviewSignalOutcomeRaiseRisk:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_RAISE_RISK
-	case enum.ReviewSignalOutcomeInformational:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_INFORMATIONAL
-	default:
-		return governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "REVIEW_SIGNAL_OUTCOME_", governancev1.ReviewSignalOutcome_REVIEW_SIGNAL_OUTCOME_UNSPECIFIED)
 }
 
 func signalSeverity(item governancev1.SignalSeverity) enum.SignalSeverity {
-	switch item {
-	case governancev1.SignalSeverity_SIGNAL_SEVERITY_INFO:
-		return enum.SignalSeverityInfo
-	case governancev1.SignalSeverity_SIGNAL_SEVERITY_WARNING:
-		return enum.SignalSeverityWarning
-	case governancev1.SignalSeverity_SIGNAL_SEVERITY_BLOCKING:
-		return enum.SignalSeverityBlocking
-	case governancev1.SignalSeverity_SIGNAL_SEVERITY_CRITICAL:
-		return enum.SignalSeverityCritical
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "SIGNAL_SEVERITY_", enum.SignalSeverity(""))
 }
 
 func toSignalSeverity(item enum.SignalSeverity) governancev1.SignalSeverity {
-	switch item {
-	case enum.SignalSeverityInfo:
-		return governancev1.SignalSeverity_SIGNAL_SEVERITY_INFO
-	case enum.SignalSeverityWarning:
-		return governancev1.SignalSeverity_SIGNAL_SEVERITY_WARNING
-	case enum.SignalSeverityBlocking:
-		return governancev1.SignalSeverity_SIGNAL_SEVERITY_BLOCKING
-	case enum.SignalSeverityCritical:
-		return governancev1.SignalSeverity_SIGNAL_SEVERITY_CRITICAL
-	default:
-		return governancev1.SignalSeverity_SIGNAL_SEVERITY_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "SIGNAL_SEVERITY_", governancev1.SignalSeverity_SIGNAL_SEVERITY_UNSPECIFIED)
 }
 
 func confidence(item governancev1.Confidence) enum.Confidence {
-	switch item {
-	case governancev1.Confidence_CONFIDENCE_LOW:
-		return enum.ConfidenceLow
-	case governancev1.Confidence_CONFIDENCE_MEDIUM:
-		return enum.ConfidenceMedium
-	case governancev1.Confidence_CONFIDENCE_HIGH:
-		return enum.ConfidenceHigh
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "CONFIDENCE_", enum.Confidence(""))
 }
 
 func toConfidence(item enum.Confidence) governancev1.Confidence {
-	switch item {
-	case enum.ConfidenceLow:
-		return governancev1.Confidence_CONFIDENCE_LOW
-	case enum.ConfidenceMedium:
-		return governancev1.Confidence_CONFIDENCE_MEDIUM
-	case enum.ConfidenceHigh:
-		return governancev1.Confidence_CONFIDENCE_HIGH
-	default:
-		return governancev1.Confidence_CONFIDENCE_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "CONFIDENCE_", governancev1.Confidence_CONFIDENCE_UNSPECIFIED)
 }
 
 func evidenceKindString(item governancev1.EvidenceKind) string {
-	switch item {
-	case governancev1.EvidenceKind_EVIDENCE_KIND_PROVIDER_COMMENT:
-		return "provider_comment"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_PROVIDER_REVIEW:
-		return "provider_review"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_PROVIDER_CHECK:
-		return "provider_check"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_RUNTIME_SUMMARY:
-		return "runtime_summary"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_DOCUMENT:
-		return "document"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_RISK_FACTOR:
-		return "risk_factor"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_REVIEW_SIGNAL:
-		return "review_signal"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_INTERACTION_CALLBACK:
-		return "interaction_callback"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_OBJECT_REF:
-		return "object_ref"
-	case governancev1.EvidenceKind_EVIDENCE_KIND_CUSTOM:
-		return "custom"
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "EVIDENCE_KIND_", "")
 }
 
 func toEvidenceKind(item string) governancev1.EvidenceKind {
-	switch item {
-	case "provider_comment":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_PROVIDER_COMMENT
-	case "provider_review":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_PROVIDER_REVIEW
-	case "provider_check":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_PROVIDER_CHECK
-	case "runtime_summary":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_RUNTIME_SUMMARY
-	case "document":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_DOCUMENT
-	case "risk_factor":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_RISK_FACTOR
-	case "review_signal":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_REVIEW_SIGNAL
-	case "interaction_callback":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_INTERACTION_CALLBACK
-	case "object_ref":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_OBJECT_REF
-	case "custom":
-		return governancev1.EvidenceKind_EVIDENCE_KIND_CUSTOM
-	default:
-		return governancev1.EvidenceKind_EVIDENCE_KIND_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "EVIDENCE_KIND_", governancev1.EvidenceKind_EVIDENCE_KIND_UNSPECIFIED)
 }
 
 func gateRequestStatus(item governancev1.GateRequestStatus) enum.GateRequestStatus {
-	switch item {
-	case governancev1.GateRequestStatus_GATE_REQUEST_STATUS_REQUESTED:
-		return enum.GateRequestStatusRequested
-	case governancev1.GateRequestStatus_GATE_REQUEST_STATUS_DELIVERING:
-		return enum.GateRequestStatusDelivering
-	case governancev1.GateRequestStatus_GATE_REQUEST_STATUS_AWAITING_DECISION:
-		return enum.GateRequestStatusAwaitingDecision
-	case governancev1.GateRequestStatus_GATE_REQUEST_STATUS_RESOLVED:
-		return enum.GateRequestStatusResolved
-	case governancev1.GateRequestStatus_GATE_REQUEST_STATUS_EXPIRED:
-		return enum.GateRequestStatusExpired
-	case governancev1.GateRequestStatus_GATE_REQUEST_STATUS_CANCELLED:
-		return enum.GateRequestStatusCancelled
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "GATE_REQUEST_STATUS_", enum.GateRequestStatus(""))
 }
 
 func toGateRequestStatus(item enum.GateRequestStatus) governancev1.GateRequestStatus {
-	switch item {
-	case enum.GateRequestStatusRequested:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_REQUESTED
-	case enum.GateRequestStatusDelivering:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_DELIVERING
-	case enum.GateRequestStatusAwaitingDecision:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_AWAITING_DECISION
-	case enum.GateRequestStatusResolved:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_RESOLVED
-	case enum.GateRequestStatusExpired:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_EXPIRED
-	case enum.GateRequestStatusCancelled:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_CANCELLED
-	default:
-		return governancev1.GateRequestStatus_GATE_REQUEST_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "GATE_REQUEST_STATUS_", governancev1.GateRequestStatus_GATE_REQUEST_STATUS_UNSPECIFIED)
 }
 
 func gateOutcome(item governancev1.GateOutcome) enum.GateOutcome {
-	switch item {
-	case governancev1.GateOutcome_GATE_OUTCOME_APPROVE:
-		return enum.GateOutcomeApprove
-	case governancev1.GateOutcome_GATE_OUTCOME_APPROVE_WITH_CONDITIONS:
-		return enum.GateOutcomeApproveWithConditions
-	case governancev1.GateOutcome_GATE_OUTCOME_REVISE:
-		return enum.GateOutcomeRevise
-	case governancev1.GateOutcome_GATE_OUTCOME_REJECT:
-		return enum.GateOutcomeReject
-	case governancev1.GateOutcome_GATE_OUTCOME_HOLD:
-		return enum.GateOutcomeHold
-	case governancev1.GateOutcome_GATE_OUTCOME_ROLLBACK:
-		return enum.GateOutcomeRollback
-	case governancev1.GateOutcome_GATE_OUTCOME_ESCALATE:
-		return enum.GateOutcomeEscalate
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "GATE_OUTCOME_", enum.GateOutcome(""))
 }
 
 func toGateOutcome(item enum.GateOutcome) governancev1.GateOutcome {
-	switch item {
-	case enum.GateOutcomeApprove:
-		return governancev1.GateOutcome_GATE_OUTCOME_APPROVE
-	case enum.GateOutcomeApproveWithConditions:
-		return governancev1.GateOutcome_GATE_OUTCOME_APPROVE_WITH_CONDITIONS
-	case enum.GateOutcomeRevise:
-		return governancev1.GateOutcome_GATE_OUTCOME_REVISE
-	case enum.GateOutcomeReject:
-		return governancev1.GateOutcome_GATE_OUTCOME_REJECT
-	case enum.GateOutcomeHold:
-		return governancev1.GateOutcome_GATE_OUTCOME_HOLD
-	case enum.GateOutcomeRollback:
-		return governancev1.GateOutcome_GATE_OUTCOME_ROLLBACK
-	case enum.GateOutcomeEscalate:
-		return governancev1.GateOutcome_GATE_OUTCOME_ESCALATE
-	default:
-		return governancev1.GateOutcome_GATE_OUTCOME_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "GATE_OUTCOME_", governancev1.GateOutcome_GATE_OUTCOME_UNSPECIFIED)
 }
 
 func releaseDecisionPackageStatus(item governancev1.ReleaseDecisionPackageStatus) enum.ReleaseDecisionPackageStatus {
-	switch item {
-	case governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_DRAFT:
-		return enum.ReleaseDecisionPackageStatusDraft
-	case governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_READY:
-		return enum.ReleaseDecisionPackageStatusReady
-	case governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_DECISION_REQUESTED:
-		return enum.ReleaseDecisionPackageStatusDecisionRequested
-	case governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_CLOSED:
-		return enum.ReleaseDecisionPackageStatusClosed
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RELEASE_DECISION_PACKAGE_STATUS_", enum.ReleaseDecisionPackageStatus(""))
 }
 
 func toReleaseDecisionPackageStatus(item enum.ReleaseDecisionPackageStatus) governancev1.ReleaseDecisionPackageStatus {
-	switch item {
-	case enum.ReleaseDecisionPackageStatusDraft:
-		return governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_DRAFT
-	case enum.ReleaseDecisionPackageStatusReady:
-		return governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_READY
-	case enum.ReleaseDecisionPackageStatusDecisionRequested:
-		return governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_DECISION_REQUESTED
-	case enum.ReleaseDecisionPackageStatusClosed:
-		return governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_CLOSED
-	default:
-		return governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RELEASE_DECISION_PACKAGE_STATUS_", governancev1.ReleaseDecisionPackageStatus_RELEASE_DECISION_PACKAGE_STATUS_UNSPECIFIED)
 }
 
 func releaseDecisionStatus(item governancev1.ReleaseDecisionStatus) enum.ReleaseDecisionStatus {
-	switch item {
-	case governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_REQUESTED:
-		return enum.ReleaseDecisionStatusRequested
-	case governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_RESOLVED:
-		return enum.ReleaseDecisionStatusResolved
-	case governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_CANCELLED:
-		return enum.ReleaseDecisionStatusCancelled
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RELEASE_DECISION_STATUS_", enum.ReleaseDecisionStatus(""))
 }
 
 func toReleaseDecisionStatus(item enum.ReleaseDecisionStatus) governancev1.ReleaseDecisionStatus {
-	switch item {
-	case enum.ReleaseDecisionStatusRequested:
-		return governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_REQUESTED
-	case enum.ReleaseDecisionStatusResolved:
-		return governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_RESOLVED
-	case enum.ReleaseDecisionStatusCancelled:
-		return governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_CANCELLED
-	default:
-		return governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RELEASE_DECISION_STATUS_", governancev1.ReleaseDecisionStatus_RELEASE_DECISION_STATUS_UNSPECIFIED)
 }
 
 func releaseDecisionOutcome(item governancev1.ReleaseDecisionOutcome) enum.ReleaseDecisionOutcome {
-	switch item {
-	case governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_GO:
-		return enum.ReleaseDecisionOutcomeGo
-	case governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_GO_WITH_CONDITIONS:
-		return enum.ReleaseDecisionOutcomeGoWithConditions
-	case governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_NO_GO:
-		return enum.ReleaseDecisionOutcomeNoGo
-	case governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_HOLD:
-		return enum.ReleaseDecisionOutcomeHold
-	case governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_ROLLBACK:
-		return enum.ReleaseDecisionOutcomeRollback
-	case governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_FOLLOW_UP_REQUIRED:
-		return enum.ReleaseDecisionOutcomeFollowUpRequired
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RELEASE_DECISION_OUTCOME_", enum.ReleaseDecisionOutcome(""))
 }
 
 func toReleaseDecisionOutcome(item enum.ReleaseDecisionOutcome) governancev1.ReleaseDecisionOutcome {
-	switch item {
-	case enum.ReleaseDecisionOutcomeGo:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_GO
-	case enum.ReleaseDecisionOutcomeGoWithConditions:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_GO_WITH_CONDITIONS
-	case enum.ReleaseDecisionOutcomeNoGo:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_NO_GO
-	case enum.ReleaseDecisionOutcomeHold:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_HOLD
-	case enum.ReleaseDecisionOutcomeRollback:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_ROLLBACK
-	case enum.ReleaseDecisionOutcomeFollowUpRequired:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_FOLLOW_UP_REQUIRED
-	default:
-		return governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RELEASE_DECISION_OUTCOME_", governancev1.ReleaseDecisionOutcome_RELEASE_DECISION_OUTCOME_UNSPECIFIED)
 }
 
 func releaseSafetyStateKind(item governancev1.ReleaseSafetyStateKind) enum.ReleaseSafetyStateKind {
-	switch item {
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_RELEASE_CANDIDATE:
-		return enum.ReleaseSafetyStateKindReleaseCandidate
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_AWAITING_RELEASE_GATE:
-		return enum.ReleaseSafetyStateKindAwaitingReleaseGate
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_DEPLOYING:
-		return enum.ReleaseSafetyStateKindDeploying
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_POSTDEPLOY_OBSERVATION:
-		return enum.ReleaseSafetyStateKindPostdeployObservation
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_STABLE:
-		return enum.ReleaseSafetyStateKindStable
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_HOLD:
-		return enum.ReleaseSafetyStateKindHold
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_ROLLBACK:
-		return enum.ReleaseSafetyStateKindRollback
-	case governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_FOLLOW_UP_REQUIRED:
-		return enum.ReleaseSafetyStateKindFollowUpRequired
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "RELEASE_SAFETY_STATE_KIND_", enum.ReleaseSafetyStateKind(""))
 }
 
 func toReleaseSafetyStateKind(item enum.ReleaseSafetyStateKind) governancev1.ReleaseSafetyStateKind {
-	switch item {
-	case enum.ReleaseSafetyStateKindReleaseCandidate:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_RELEASE_CANDIDATE
-	case enum.ReleaseSafetyStateKindAwaitingReleaseGate:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_AWAITING_RELEASE_GATE
-	case enum.ReleaseSafetyStateKindDeploying:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_DEPLOYING
-	case enum.ReleaseSafetyStateKindPostdeployObservation:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_POSTDEPLOY_OBSERVATION
-	case enum.ReleaseSafetyStateKindStable:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_STABLE
-	case enum.ReleaseSafetyStateKindHold:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_HOLD
-	case enum.ReleaseSafetyStateKindRollback:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_ROLLBACK
-	case enum.ReleaseSafetyStateKindFollowUpRequired:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_FOLLOW_UP_REQUIRED
-	default:
-		return governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "RELEASE_SAFETY_STATE_KIND_", governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_UNSPECIFIED)
 }
 
 func blockingSignalSourceType(item governancev1.BlockingSignalSourceType) enum.BlockingSignalSourceType {
-	switch item {
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_ACCEPTANCE:
-		return enum.BlockingSignalSourceTypeAcceptance
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_REVIEW_SIGNAL:
-		return enum.BlockingSignalSourceTypeReviewSignal
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_RUNTIME:
-		return enum.BlockingSignalSourceTypeRuntime
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_PROVIDER:
-		return enum.BlockingSignalSourceTypeProvider
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_INTERACTION:
-		return enum.BlockingSignalSourceTypeInteraction
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_HUMAN:
-		return enum.BlockingSignalSourceTypeHuman
-	case governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_MONITORING:
-		return enum.BlockingSignalSourceTypeMonitoring
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "BLOCKING_SIGNAL_SOURCE_TYPE_", enum.BlockingSignalSourceType(""))
 }
 
 func toBlockingSignalSourceType(item enum.BlockingSignalSourceType) governancev1.BlockingSignalSourceType {
-	switch item {
-	case enum.BlockingSignalSourceTypeAcceptance:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_ACCEPTANCE
-	case enum.BlockingSignalSourceTypeReviewSignal:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_REVIEW_SIGNAL
-	case enum.BlockingSignalSourceTypeRuntime:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_RUNTIME
-	case enum.BlockingSignalSourceTypeProvider:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_PROVIDER
-	case enum.BlockingSignalSourceTypeInteraction:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_INTERACTION
-	case enum.BlockingSignalSourceTypeHuman:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_HUMAN
-	case enum.BlockingSignalSourceTypeMonitoring:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_MONITORING
-	default:
-		return governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "BLOCKING_SIGNAL_SOURCE_TYPE_", governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_UNSPECIFIED)
 }
 
 func blockingSignalStatus(item governancev1.BlockingSignalStatus) enum.BlockingSignalStatus {
-	switch item {
-	case governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_ACTIVE:
-		return enum.BlockingSignalStatusActive
-	case governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_RESOLVED:
-		return enum.BlockingSignalStatusResolved
-	case governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_DISMISSED:
-		return enum.BlockingSignalStatusDismissed
-	default:
-		return ""
-	}
+	return protoEnumDomain(item, "BLOCKING_SIGNAL_STATUS_", enum.BlockingSignalStatus(""))
 }
 
 func toBlockingSignalStatus(item enum.BlockingSignalStatus) governancev1.BlockingSignalStatus {
-	switch item {
-	case enum.BlockingSignalStatusActive:
-		return governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_ACTIVE
-	case enum.BlockingSignalStatusResolved:
-		return governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_RESOLVED
-	case enum.BlockingSignalStatusDismissed:
-		return governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_DISMISSED
-	default:
-		return governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_UNSPECIFIED
-	}
+	return domainProtoEnum(item, "BLOCKING_SIGNAL_STATUS_", governancev1.BlockingSignalStatus_BLOCKING_SIGNAL_STATUS_UNSPECIFIED)
 }

--- a/services/internal/governance-manager/internal/transport/grpc/server.go
+++ b/services/internal/governance-manager/internal/transport/grpc/server.go
@@ -85,12 +85,71 @@ type terminalGateCommandInput struct {
 
 type terminalGateHandler func(context.Context, terminalGateCommandInput) (entity.GateRequest, error)
 
-func terminalGateCommand(gateRequestID string, reason string, ref *governancev1.InteractionDeliveryRef, meta *governancev1.CommandMeta) (terminalGateCommandInput, error) {
+func commandMetaAndID(meta *governancev1.CommandMeta, rawID string) (governanceservice.CommandMeta, uuid.UUID, error) {
 	metaValue, err := commandMeta(meta)
+	return requiredMetaID(metaValue, err, rawID)
+}
+
+func queryMetaAndID(meta *governancev1.QueryMeta, rawID string) (governanceservice.QueryMeta, uuid.UUID, error) {
+	metaValue, err := queryMeta(meta)
+	return requiredMetaID(metaValue, err, rawID)
+}
+
+func requiredMetaID[T any](metaValue T, err error, rawID string) (T, uuid.UUID, error) {
 	if err != nil {
-		return terminalGateCommandInput{}, err
+		var zero T
+		return zero, uuid.Nil, err
 	}
-	id, err := requiredUUID(gateRequestID)
+	id, err := requiredUUID(rawID)
+	if err != nil {
+		var zero T
+		return zero, uuid.Nil, err
+	}
+	return metaValue, id, nil
+}
+
+func queryMetaAndOptionalID(meta *governancev1.QueryMeta, rawID string) (governanceservice.QueryMeta, *uuid.UUID, error) {
+	metaValue, err := queryMeta(meta)
+	if err != nil {
+		return governanceservice.QueryMeta{}, nil, err
+	}
+	id, err := optionalUUID(rawID)
+	if err != nil {
+		return governanceservice.QueryMeta{}, nil, err
+	}
+	return metaValue, id, nil
+}
+
+func queryIDResponse[T any, R any](ctx context.Context, metaValue *governancev1.QueryMeta, rawID string, load func(context.Context, governanceservice.QueryMeta, uuid.UUID) (T, error), response func(T) R) (R, error) {
+	meta, id, err := queryMetaAndID(metaValue, rawID)
+	if err != nil {
+		var zero R
+		return zero, err
+	}
+	item, err := load(ctx, meta, id)
+	if err != nil {
+		var zero R
+		return zero, err
+	}
+	return response(item), nil
+}
+
+func listOptionalIDResponse[T any, R any](ctx context.Context, metaValue *governancev1.QueryMeta, rawID string, load func(context.Context, governanceservice.QueryMeta, *uuid.UUID) ([]T, query.PageResult, error), response func([]T, query.PageResult) R) (R, error) {
+	meta, id, err := queryMetaAndOptionalID(metaValue, rawID)
+	if err != nil {
+		var zero R
+		return zero, err
+	}
+	items, page, err := load(ctx, meta, id)
+	if err != nil {
+		var zero R
+		return zero, err
+	}
+	return response(items, page), nil
+}
+
+func terminalGateCommand(gateRequestID string, reason string, ref *governancev1.InteractionDeliveryRef, meta *governancev1.CommandMeta) (terminalGateCommandInput, error) {
+	metaValue, id, err := commandMetaAndID(meta, gateRequestID)
 	if err != nil {
 		return terminalGateCommandInput{}, err
 	}
@@ -165,11 +224,7 @@ func (server *Server) CreateRiskProfile(ctx context.Context, req *governancev1.C
 
 // CreateRiskProfileVersion creates an immutable policy version.
 func (server *Server) CreateRiskProfileVersion(ctx context.Context, req *governancev1.CreateRiskProfileVersionRequest) (*governancev1.RiskProfileVersionResponse, error) {
-	meta, err := commandMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	riskProfileID, err := requiredUUID(req.GetRiskProfileId())
+	meta, riskProfileID, err := commandMetaAndID(req.GetMeta(), req.GetRiskProfileId())
 	if err != nil {
 		return nil, err
 	}
@@ -191,11 +246,7 @@ func (server *Server) CreateRiskProfileVersion(ctx context.Context, req *governa
 
 // ActivateRiskProfileVersion activates one profile version.
 func (server *Server) ActivateRiskProfileVersion(ctx context.Context, req *governancev1.ActivateRiskProfileVersionRequest) (*governancev1.RiskProfileVersionResponse, error) {
-	meta, err := commandMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	riskProfileID, err := requiredUUID(req.GetRiskProfileId())
+	meta, riskProfileID, err := commandMetaAndID(req.GetMeta(), req.GetRiskProfileId())
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +263,11 @@ func (server *Server) ActivateRiskProfileVersion(ctx context.Context, req *gover
 
 // ArchiveRiskProfile archives profile metadata.
 func (server *Server) ArchiveRiskProfile(ctx context.Context, req *governancev1.ArchiveRiskProfileRequest) (*governancev1.RiskProfileResponse, error) {
-	meta, err := commandMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	riskProfileID, err := requiredUUID(req.GetRiskProfileId())
+	return server.archiveRiskProfileResponse(ctx, req)
+}
+
+func (server *Server) archiveRiskProfileResponse(ctx context.Context, req *governancev1.ArchiveRiskProfileRequest) (*governancev1.RiskProfileResponse, error) {
+	meta, riskProfileID, err := commandMetaAndID(req.GetMeta(), req.GetRiskProfileId())
 	if err != nil {
 		return nil, err
 	}
@@ -295,23 +346,31 @@ func (server *Server) ListRiskRules(ctx context.Context, req *governancev1.ListR
 
 // ListGatePolicies returns gate policies by profile version.
 func (server *Server) ListGatePolicies(ctx context.Context, req *governancev1.ListGatePoliciesRequest) (*governancev1.ListGatePoliciesResponse, error) {
-	id, err := requiredUUID(req.GetRiskProfileId())
+	filter, err := gatePolicyFilter(req)
 	if err != nil {
 		return nil, err
 	}
 	items, page, err := server.service.ListGatePolicies(ctx, governanceservice.ListGatePoliciesInput{
-		Filter: query.GatePolicyFilter{
-			RiskProfileID:  id,
-			ProfileVersion: req.GetProfileVersion(),
-			GateKind:       gateKind(req.GetGateKind()),
-			Status:         ruleStatus(req.GetStatus()),
-			Page:           pageRequest(req.GetPage()),
-		},
+		Filter: filter,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return &governancev1.ListGatePoliciesResponse{GatePolicies: toGatePolicies(items), Page: pageResponse(page)}, nil
+}
+
+func gatePolicyFilter(req *governancev1.ListGatePoliciesRequest) (query.GatePolicyFilter, error) {
+	id, err := requiredUUID(req.GetRiskProfileId())
+	if err != nil {
+		return query.GatePolicyFilter{}, err
+	}
+	return query.GatePolicyFilter{
+		RiskProfileID:  id,
+		ProfileVersion: req.GetProfileVersion(),
+		GateKind:       gateKind(req.GetGateKind()),
+		Status:         ruleStatus(req.GetStatus()),
+		Page:           pageRequest(req.GetPage()),
+	}, nil
 }
 
 // EvaluateRisk stores a deterministic assessment produced from safe summaries and refs.
@@ -499,28 +558,24 @@ func (server *Server) RecordReviewSignal(ctx context.Context, req *governancev1.
 
 // ListReviewSignals returns review signals by target, assessment, role or outcome.
 func (server *Server) ListReviewSignals(ctx context.Context, req *governancev1.ListReviewSignalsRequest) (*governancev1.ListReviewSignalsResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
+	filter := query.ReviewSignalFilter{
+		Target:   targetRef(req.GetTarget()),
+		RoleKind: reviewRoleKind(req.GetRoleKind()),
+		Outcome:  reviewSignalOutcome(req.GetOutcome()),
+		Page:     pageRequest(req.GetPage()),
 	}
-	riskAssessmentID, err := optionalUUID(req.GetRiskAssessmentId())
-	if err != nil {
-		return nil, err
-	}
-	items, page, err := server.service.ListReviewSignals(ctx, governanceservice.ListReviewSignalsInput{
-		Filter: query.ReviewSignalFilter{
-			RiskAssessmentID: riskAssessmentID,
-			Target:           targetRef(req.GetTarget()),
-			RoleKind:         reviewRoleKind(req.GetRoleKind()),
-			Outcome:          reviewSignalOutcome(req.GetOutcome()),
-			Page:             pageRequest(req.GetPage()),
+	return listOptionalIDResponse(ctx, req.GetMeta(), req.GetRiskAssessmentId(),
+		func(ctx context.Context, meta governanceservice.QueryMeta, riskAssessmentID *uuid.UUID) ([]entity.ReviewSignal, query.PageResult, error) {
+			filter.RiskAssessmentID = riskAssessmentID
+			return server.service.ListReviewSignals(ctx, governanceservice.ListReviewSignalsInput{
+				Filter: filter,
+				Meta:   meta,
+			})
 		},
-		Meta: meta,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &governancev1.ListReviewSignalsResponse{ReviewSignals: toReviewSignals(items), Page: pageResponse(page)}, nil
+		func(items []entity.ReviewSignal, page query.PageResult) *governancev1.ListReviewSignalsResponse {
+			return &governancev1.ListReviewSignalsResponse{ReviewSignals: toReviewSignals(items), Page: pageResponse(page)}
+		},
+	)
 }
 
 // RequestGate creates a governance gate request reference.
@@ -613,27 +668,22 @@ func (server *Server) GetGateDecision(ctx context.Context, req *governancev1.Get
 
 // ListGateDecisions returns gate decisions by gate request or target, optionally refined by outcome.
 func (server *Server) ListGateDecisions(ctx context.Context, req *governancev1.ListGateDecisionsRequest) (*governancev1.ListGateDecisionsResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	gateRequestID, err := optionalUUID(req.GetGateRequestId())
-	if err != nil {
-		return nil, err
-	}
-	items, page, err := server.service.ListGateDecisions(ctx, governanceservice.ListGateDecisionsInput{
-		Filter: query.GateDecisionFilter{
-			GateRequestID: gateRequestID,
-			Target:        targetRef(req.GetTarget()),
-			Outcome:       gateOutcome(req.GetOutcome()),
-			Page:          pageRequest(req.GetPage()),
+	return listOptionalIDResponse(ctx, req.GetMeta(), req.GetGateRequestId(),
+		func(ctx context.Context, meta governanceservice.QueryMeta, gateRequestID *uuid.UUID) ([]entity.GateDecision, query.PageResult, error) {
+			return server.service.ListGateDecisions(ctx, governanceservice.ListGateDecisionsInput{
+				Filter: query.GateDecisionFilter{
+					GateRequestID: gateRequestID,
+					Target:        targetRef(req.GetTarget()),
+					Outcome:       gateOutcome(req.GetOutcome()),
+					Page:          pageRequest(req.GetPage()),
+				},
+				Meta: meta,
+			})
 		},
-		Meta: meta,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &governancev1.ListGateDecisionsResponse{GateDecisions: toGateDecisions(items), Page: pageResponse(page)}, nil
+		func(items []entity.GateDecision, page query.PageResult) *governancev1.ListGateDecisionsResponse {
+			return &governancev1.ListGateDecisionsResponse{GateDecisions: toGateDecisions(items), Page: pageResponse(page)}
+		},
+	)
 }
 
 // GetGateRequest returns one gate request.
@@ -665,11 +715,7 @@ func (server *Server) GetGateRequest(ctx context.Context, req *governancev1.GetG
 
 // ListGateRequests returns gate requests by target or assessment, optionally refined by status.
 func (server *Server) ListGateRequests(ctx context.Context, req *governancev1.ListGateRequestsRequest) (*governancev1.ListGateRequestsResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	riskAssessmentID, err := optionalUUID(req.GetRiskAssessmentId())
+	meta, riskAssessmentID, err := queryMetaAndOptionalID(req.GetMeta(), req.GetRiskAssessmentId())
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +731,9 @@ func (server *Server) ListGateRequests(ctx context.Context, req *governancev1.Li
 	if err != nil {
 		return nil, err
 	}
-	return &governancev1.ListGateRequestsResponse{GateRequests: toGateRequests(items), Page: pageResponse(page)}, nil
+	response := &governancev1.ListGateRequestsResponse{Page: pageResponse(page)}
+	response.GateRequests = toGateRequests(items)
+	return response, nil
 }
 
 // BuildReleaseDecisionPackage stores bounded release evidence refs.
@@ -736,19 +784,14 @@ func (server *Server) BuildReleaseDecisionPackage(ctx context.Context, req *gove
 
 // GetReleaseDecisionPackage returns one release decision package.
 func (server *Server) GetReleaseDecisionPackage(ctx context.Context, req *governancev1.GetReleaseDecisionPackageRequest) (*governancev1.ReleaseDecisionPackageResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	id, err := requiredUUID(req.GetReleaseDecisionPackageId())
-	if err != nil {
-		return nil, err
-	}
-	item, err := server.service.GetReleaseDecisionPackage(ctx, governanceservice.GetReleaseDecisionPackageInput{ReleaseDecisionPackageID: id, Meta: meta})
-	if err != nil {
-		return nil, err
-	}
-	return &governancev1.ReleaseDecisionPackageResponse{ReleaseDecisionPackage: toReleaseDecisionPackage(item)}, nil
+	return queryIDResponse(ctx, req.GetMeta(), req.GetReleaseDecisionPackageId(),
+		func(ctx context.Context, meta governanceservice.QueryMeta, id uuid.UUID) (entity.ReleaseDecisionPackage, error) {
+			return server.service.GetReleaseDecisionPackage(ctx, governanceservice.GetReleaseDecisionPackageInput{ReleaseDecisionPackageID: id, Meta: meta})
+		},
+		func(item entity.ReleaseDecisionPackage) *governancev1.ReleaseDecisionPackageResponse {
+			return &governancev1.ReleaseDecisionPackageResponse{ReleaseDecisionPackage: toReleaseDecisionPackage(item)}
+		},
+	)
 }
 
 // ListReleaseDecisionPackages returns release packages by project, candidate or status.
@@ -774,11 +817,7 @@ func (server *Server) ListReleaseDecisionPackages(ctx context.Context, req *gove
 
 // RequestReleaseDecision starts release decision lifecycle.
 func (server *Server) RequestReleaseDecision(ctx context.Context, req *governancev1.RequestReleaseDecisionRequest) (*governancev1.ReleaseDecisionResponse, error) {
-	meta, err := commandMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	packageID, err := requiredUUID(req.GetReleaseDecisionPackageId())
+	meta, packageID, err := commandMetaAndID(req.GetMeta(), req.GetReleaseDecisionPackageId())
 	if err != nil {
 		return nil, err
 	}
@@ -825,14 +864,14 @@ func (server *Server) SubmitReleaseDecision(ctx context.Context, req *governance
 
 // GetReleaseDecision returns one release decision.
 func (server *Server) GetReleaseDecision(ctx context.Context, req *governancev1.GetReleaseDecisionRequest) (*governancev1.ReleaseDecisionResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
+	meta, id, err := queryMetaAndID(req.GetMeta(), req.GetReleaseDecisionId())
 	if err != nil {
 		return nil, err
 	}
-	id, err := requiredUUID(req.GetReleaseDecisionId())
-	if err != nil {
-		return nil, err
-	}
+	return server.releaseDecisionResponse(ctx, id, meta)
+}
+
+func (server *Server) releaseDecisionResponse(ctx context.Context, id uuid.UUID, meta governanceservice.QueryMeta) (*governancev1.ReleaseDecisionResponse, error) {
 	decision, err := server.service.GetReleaseDecision(ctx, governanceservice.GetReleaseDecisionInput{ReleaseDecisionID: id, Meta: meta})
 	if err != nil {
 		return nil, err
@@ -842,11 +881,7 @@ func (server *Server) GetReleaseDecision(ctx context.Context, req *governancev1.
 
 // ListReleaseDecisions returns release decisions by package or project context.
 func (server *Server) ListReleaseDecisions(ctx context.Context, req *governancev1.ListReleaseDecisionsRequest) (*governancev1.ListReleaseDecisionsResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	packageID, err := optionalUUID(req.GetReleaseDecisionPackageId())
+	meta, packageID, err := queryMetaAndOptionalID(req.GetMeta(), req.GetReleaseDecisionPackageId())
 	if err != nil {
 		return nil, err
 	}
@@ -888,11 +923,7 @@ func (server *Server) RecordBlockingSignal(ctx context.Context, req *governancev
 
 // ResolveBlockingSignal resolves or dismisses a blocking signal.
 func (server *Server) ResolveBlockingSignal(ctx context.Context, req *governancev1.ResolveBlockingSignalRequest) (*governancev1.BlockingSignalResponse, error) {
-	meta, err := commandMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	id, err := requiredUUID(req.GetBlockingSignalId())
+	meta, id, err := commandMetaAndID(req.GetMeta(), req.GetBlockingSignalId())
 	if err != nil {
 		return nil, err
 	}
@@ -931,11 +962,7 @@ func (server *Server) ListBlockingSignals(ctx context.Context, req *governancev1
 
 // RecordReleaseSafetyState records current safety-loop state.
 func (server *Server) RecordReleaseSafetyState(ctx context.Context, req *governancev1.RecordReleaseSafetyStateRequest) (*governancev1.ReleaseSafetyStateResponse, error) {
-	meta, err := commandMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	packageID, err := requiredUUID(req.GetReleaseDecisionPackageId())
+	meta, packageID, err := commandMetaAndID(req.GetMeta(), req.GetReleaseDecisionPackageId())
 	if err != nil {
 		return nil, err
 	}
@@ -954,11 +981,7 @@ func (server *Server) RecordReleaseSafetyState(ctx context.Context, req *governa
 
 // GetReleaseSafetyState returns current safety-loop state.
 func (server *Server) GetReleaseSafetyState(ctx context.Context, req *governancev1.GetReleaseSafetyStateRequest) (*governancev1.ReleaseSafetyStateResponse, error) {
-	meta, err := queryMeta(req.GetMeta())
-	if err != nil {
-		return nil, err
-	}
-	packageID, err := requiredUUID(req.GetReleaseDecisionPackageId())
+	meta, packageID, err := queryMetaAndID(req.GetMeta(), req.GetReleaseDecisionPackageId())
 	if err != nil {
 		return nil, err
 	}
@@ -966,5 +989,7 @@ func (server *Server) GetReleaseSafetyState(ctx context.Context, req *governance
 	if err != nil {
 		return nil, err
 	}
-	return &governancev1.ReleaseSafetyStateResponse{ReleaseSafetyState: toReleaseSafetyState(state)}, nil
+	response := &governancev1.ReleaseSafetyStateResponse{}
+	response.ReleaseSafetyState = toReleaseSafetyState(state)
+	return response, nil
 }

--- a/services/internal/governance-manager/internal/transport/grpc/server_test.go
+++ b/services/internal/governance-manager/internal/transport/grpc/server_test.go
@@ -35,6 +35,26 @@ func TestNewServerRequiresService(t *testing.T) {
 	_ = NewServer(nil)
 }
 
+func TestEnumCastersUseProtoDescriptors(t *testing.T) {
+	t.Parallel()
+
+	if got := riskClass(governancev1.RiskClass_RISK_CLASS_R0); got != enum.RiskClassR0 {
+		t.Fatalf("riskClass(R0) = %q", got)
+	}
+	if got := toRiskRuleKind(enum.RiskRuleKindAPI); got != governancev1.RiskRuleKind_RISK_RULE_KIND_API {
+		t.Fatalf("toRiskRuleKind(api) = %s", got)
+	}
+	if got := reviewRoleKind(governancev1.ReviewRoleKind_REVIEW_ROLE_KIND_SRE); got != enum.ReviewRoleKindSRE {
+		t.Fatalf("reviewRoleKind(SRE) = %q", got)
+	}
+	if got := toReleaseSafetyStateKind(enum.ReleaseSafetyStateKindFollowUpRequired); got != governancev1.ReleaseSafetyStateKind_RELEASE_SAFETY_STATE_KIND_FOLLOW_UP_REQUIRED {
+		t.Fatalf("toReleaseSafetyStateKind(follow_up_required) = %s", got)
+	}
+	if got := blockingSignalSourceType(governancev1.BlockingSignalSourceType_BLOCKING_SIGNAL_SOURCE_TYPE_REVIEW_SIGNAL); got != enum.BlockingSignalSourceTypeReviewSignal {
+		t.Fatalf("blockingSignalSourceType(review_signal) = %q", got)
+	}
+}
+
 func TestReevaluateRiskRoutesSafeSummaryToDomainService(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Выполнено

- Убраны локальные повторы `dupl-go` внутри `services/internal/governance-manager/**` без изменений общих библиотек и соседних сервисов.
- `casters.go` переведён на локальные helper-функции для proto enum descriptor mapping и JSON-array proto refs.
- В `server.go`, repository и domain service выделены приватные helper-ы для повторяющихся meta/id, list/get response, transactional mutation, replay и safe status payload блоков.
- Добавлен regression-тест на enum caster round-trip для разных governance enum значений.

## Проверки

- `go test ./services/internal/governance-manager/...` — успешно.
- `make lint-go` — успешно.
- `git diff --check` — успешно.
- `make dupl-go` — ожидаемо завершился с ошибкой на общем отчёте; внутренних дублей `governance-manager` не осталось (`internal_governance_duplicates=0`). Оставшиеся строки с `governance-manager` — кросс-сервисный boilerplate с access/runtime/project/package/interaction зонами, которые не менялись в этом срезе.