### PR TITLE
agent-5/bootstrap: local bootstrap без operator SSH key

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -36,7 +36,8 @@ cp bootstrap/host/config.env.example bootstrap/host/config.env
 
 Минимально важные группы параметров:
 
-- `TARGET_*` и `OPERATOR_*` для удалённого режима;
+- `TARGET_*` и operator public key для удалённого режима;
+- `OPERATOR_USER` для локального и удалённого режима; в локальном режиме operator public key можно не задавать, тогда bootstrap создаёт пользователя без `authorized_keys`;
 - `KODEX_PRODUCTION_NAMESPACE`;
 - `KODEX_PRODUCTION_DOMAIN` и `KODEX_INGRESS_HOST_NETWORK` как входные предпосылки будущего ingress-контура;
 - `KODEX_INTERNAL_REGISTRY_*`;

--- a/bootstrap/host/config.env.example
+++ b/bootstrap/host/config.env.example
@@ -11,6 +11,8 @@ KODEX_REMOTE_BOOTSTRAP_DIR=""
 
 # New operator user created on target host
 OPERATOR_USER="codex"
+# Required for remote mode. Optional for local mode; if not readable and
+# OPERATOR_SSH_PUBKEY is empty, local bootstrap skips authorized_keys setup.
 OPERATOR_SSH_PUBKEY_PATH="${HOME}/.ssh/id_rsa.pub"
 
 # Platform repository with kodex source (owner/name).

--- a/bootstrap/remote/05_preflight.sh
+++ b/bootstrap/remote/05_preflight.sh
@@ -60,7 +60,12 @@ esac
 if [ -z "${OPERATOR_SSH_PUBKEY:-}" ] && [ -n "${OPERATOR_SSH_PUBKEY_PATH:-}" ] && [ -f "${OPERATOR_SSH_PUBKEY_PATH}" ]; then
   OPERATOR_SSH_PUBKEY="$(cat "${OPERATOR_SSH_PUBKEY_PATH}")"
 fi
-[ -n "${OPERATOR_SSH_PUBKEY:-}" ] || die "OPERATOR_SSH_PUBKEY is required"
+if [ -z "${OPERATOR_SSH_PUBKEY:-}" ]; then
+  if [ "$KODEX_BOOTSTRAP_MODE" = "remote" ]; then
+    die "OPERATOR_SSH_PUBKEY is required for remote mode"
+  fi
+  log "Operator SSH public key is not configured; local mode will skip authorized_keys provisioning"
+fi
 
 if [ -n "${KODEX_PRODUCTION_DOMAIN:-}" ] && [ "$KODEX_BOOTSTRAP_SKIP_DNS_CHECK" != "true" ]; then
   if [ -n "${TARGET_HOST:-}" ]; then

--- a/bootstrap/remote/10_create_operator_user.sh
+++ b/bootstrap/remote/10_create_operator_user.sh
@@ -8,10 +8,17 @@ load_env_file "${BOOTSTRAP_ENV_FILE:?}"
 require_root
 
 : "${OPERATOR_USER:?OPERATOR_USER is required}"
+KODEX_BOOTSTRAP_MODE="${KODEX_BOOTSTRAP_MODE:-local}"
+case "$KODEX_BOOTSTRAP_MODE" in
+  local|remote) ;;
+  *) die "KODEX_BOOTSTRAP_MODE must be local or remote";;
+esac
 if [ -z "${OPERATOR_SSH_PUBKEY:-}" ] && [ -n "${OPERATOR_SSH_PUBKEY_PATH:-}" ] && [ -f "${OPERATOR_SSH_PUBKEY_PATH}" ]; then
   OPERATOR_SSH_PUBKEY="$(cat "${OPERATOR_SSH_PUBKEY_PATH}")"
 fi
-: "${OPERATOR_SSH_PUBKEY:?OPERATOR_SSH_PUBKEY is required}"
+if [ -z "${OPERATOR_SSH_PUBKEY:-}" ] && [ "$KODEX_BOOTSTRAP_MODE" = "remote" ]; then
+  die "OPERATOR_SSH_PUBKEY is required for remote mode"
+fi
 
 if ! id -u "$OPERATOR_USER" >/dev/null 2>&1; then
   log "Create operator user: $OPERATOR_USER"
@@ -20,15 +27,19 @@ fi
 
 usermod -aG sudo "$OPERATOR_USER"
 
-install -d -m 700 "/home/${OPERATOR_USER}/.ssh"
-printf '%s\n' "$OPERATOR_SSH_PUBKEY" > "/home/${OPERATOR_USER}/.ssh/authorized_keys"
-chmod 600 "/home/${OPERATOR_USER}/.ssh/authorized_keys"
-chown -R "${OPERATOR_USER}:${OPERATOR_USER}" "/home/${OPERATOR_USER}/.ssh"
+if [ -n "${OPERATOR_SSH_PUBKEY:-}" ]; then
+  install -d -m 700 "/home/${OPERATOR_USER}/.ssh"
+  printf '%s\n' "$OPERATOR_SSH_PUBKEY" > "/home/${OPERATOR_USER}/.ssh/authorized_keys"
+  chmod 600 "/home/${OPERATOR_USER}/.ssh/authorized_keys"
+  chown -R "${OPERATOR_USER}:${OPERATOR_USER}" "/home/${OPERATOR_USER}/.ssh"
 
-# Keep root key login but disallow root password login.
-if grep -qE '^#?PermitRootLogin' /etc/ssh/sshd_config; then
-  sed -ri 's/^#?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+  # Keep root key login but disallow root password login.
+  if grep -qE '^#?PermitRootLogin' /etc/ssh/sshd_config; then
+    sed -ri 's/^#?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+  else
+    echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
+  fi
+  systemctl reload ssh || systemctl reload sshd || true
 else
-  echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
+  log "Operator SSH public key is not configured; skip authorized_keys provisioning in local mode"
 fi
-systemctl reload ssh || systemctl reload sshd || true

--- a/docs/platform/ops/bootstrap_cluster_runbook.md
+++ b/docs/platform/ops/bootstrap_cluster_runbook.md
@@ -33,6 +33,7 @@ Runbook используется для первого Kubernetes-контура
 - Реальный env хранится вне Git в `bootstrap/host/config.env` или отдельном защищённом файле.
 - Значения `TARGET_*`, домены, адреса, email, токены, ключи и kubeconfig не публикуются в рабочих логах, Issue, PR и документации.
 - Для удалённого режима нужен SSH-доступ к target host и operator public key.
+- Для локального режима нужен `OPERATOR_USER`; operator public key не обязателен, если доступ по SSH для этого пользователя не нужен.
 - Docker daemon не требуется: registry/Kaniko smoke использует Kubernetes jobs.
 
 ## Диагностика


### PR DESCRIPTION
## Что выполнено

- local bootstrap больше не требует operator SSH public key: `OPERATOR_USER` создаётся локально через sudo/root, а `authorized_keys` пропускается, если ключ не задан.
- remote bootstrap остаётся строгим и продолжает требовать `OPERATOR_SSH_PUBKEY`/читаемый `OPERATOR_SSH_PUBKEY_PATH`.
- preflight и runbook/config comments синхронизированы с локальным режимом без SSH.

## Проверки

- `bash -n bootstrap/remote/05_preflight.sh bootstrap/remote/10_create_operator_user.sh bootstrap/remote/bootstrap_production.sh bootstrap/host/bootstrap_cluster.sh`
- `bash bootstrap/host/bootstrap_cluster.sh install --mode local --env-file bootstrap/host/config.env --dry-run`
- remote key gate на временном env: remote mode падает без operator public key
- `git diff --check`

Полная установка кластера не запускалась; install/apply/firewall/registry/Kaniko jobs не выполнялись.
