### PR TITLE
agent-5/bootstrap: fix manifest-render cwd для install

### DIFF
--- a/bootstrap/host/smoke_registry_kaniko.sh
+++ b/bootstrap/host/smoke_registry_kaniko.sh
@@ -14,6 +14,7 @@ require_cmd() { command -v "$1" >/dev/null 2>&1 || die "Missing required command
 [ -f "$ENV_FILE" ] || die "Env file not found"
 require_cmd go
 require_cmd kubectl
+ENV_FILE_ABS="$(cd "$(dirname "$ENV_FILE")" && pwd)/$(basename "$ENV_FILE")"
 
 set -a
 # shellcheck disable=SC1090
@@ -39,14 +40,17 @@ cleanup() {
 trap cleanup EXIT
 
 log "Render registry and Kaniko smoke manifests"
-go run "${PROJECT_ROOT}/cmd/manifest-render" \
-  --env-file "$ENV_FILE" \
-  --source "${PROJECT_ROOT}/deploy/base/bootstrap-foundation" \
-  --output "${RENDER_DIR}/bootstrap-foundation"
-go run "${PROJECT_ROOT}/cmd/manifest-render" \
-  --env-file "$ENV_FILE" \
-  --source "${PROJECT_ROOT}/deploy/base/bootstrap-builder-smoke" \
-  --output "${RENDER_DIR}/bootstrap-builder-smoke"
+(
+  cd "$PROJECT_ROOT"
+  go run ./cmd/manifest-render \
+    --env-file "$ENV_FILE_ABS" \
+    --source deploy/base/bootstrap-foundation \
+    --output "${RENDER_DIR}/bootstrap-foundation"
+  go run ./cmd/manifest-render \
+    --env-file "$ENV_FILE_ABS" \
+    --source deploy/base/bootstrap-builder-smoke \
+    --output "${RENDER_DIR}/bootstrap-builder-smoke"
+)
 
 if [ "$DRY_RUN" = "true" ]; then
   log "Dry-run only: smoke manifests rendered but not applied"

--- a/bootstrap/remote/50_install_registry_and_builder.sh
+++ b/bootstrap/remote/50_install_registry_and_builder.sh
@@ -13,6 +13,7 @@ REPO_DIR="$(repo_dir)"
 RENDER_ROOT="/var/lib/kodex/bootstrap-render"
 KODEX_PRODUCTION_NAMESPACE="${KODEX_PRODUCTION_NAMESPACE:-kodex-prod}"
 KODEX_ROLLOUT_TIMEOUT="${KODEX_ROLLOUT_TIMEOUT:-300s}"
+BOOTSTRAP_ENV_FILE_ABS="$(cd "$(dirname "$BOOTSTRAP_ENV_FILE")" && pwd)/$(basename "$BOOTSTRAP_ENV_FILE")"
 
 [ -d "${REPO_DIR}/deploy/base/bootstrap-foundation" ] || die "bootstrap foundation manifests are missing from repository snapshot"
 
@@ -21,10 +22,13 @@ install -d -m 700 "${RENDER_ROOT}"
 rm -rf "${RENDER_ROOT}/bootstrap-foundation"
 
 log "Render bootstrap foundation manifests"
-go run "${REPO_DIR}/cmd/manifest-render" \
-  --env-file "${BOOTSTRAP_ENV_FILE}" \
-  --source "${REPO_DIR}/deploy/base/bootstrap-foundation" \
-  --output "${RENDER_ROOT}/bootstrap-foundation"
+(
+  cd "$REPO_DIR"
+  go run ./cmd/manifest-render \
+    --env-file "${BOOTSTRAP_ENV_FILE_ABS}" \
+    --source deploy/base/bootstrap-foundation \
+    --output "${RENDER_ROOT}/bootstrap-foundation"
+)
 
 log "Apply production namespace and internal registry"
 kubectl create namespace "${KODEX_PRODUCTION_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
## Что выполнено

- `bootstrap/remote/50_install_registry_and_builder.sh` запускает `manifest-render` из корня Go module в `/opt/kodex`, а env передаёт абсолютным путём.
- `bootstrap/host/smoke_registry_kaniko.sh` использует тот же безопасный паттерн для render dry-run/smoke.

## Почему

Реальный local bootstrap остановился на шаге `50_install_registry_and_builder.sh`: абсолютный `go run /opt/kodex/cmd/manifest-render` выполнялся снаружи выбранного Go module и падал до применения registry foundation.

## Проверки

- `bash -n bootstrap/remote/50_install_registry_and_builder.sh bootstrap/host/smoke_registry_kaniko.sh`
- `git diff --check`
- render check из `/opt/kodex` с `go run ./cmd/manifest-render`
- `KODEX_SMOKE_DRY_RUN=true bash bootstrap/host/smoke_registry_kaniko.sh`

Install/apply после этого фикса не продолжался; registry/Kaniko jobs не запускались.
