### PR TITLE
agent-4/staff-gateway: SGW-2 — готовность owner inbox API

### DIFF
--- a/docs/delivery/issue-map/domains/console-and-operations-ux.md
+++ b/docs/delivery/issue-map/domains/console-and-operations-ux.md
@@ -18,5 +18,6 @@ updated_at: 2026-05-28
 
 | Issue/PR | Документы | Волна | Статус | Примечание |
 |---|---|---|---|---|
+| не назначено | `specs/openapi/staff-gateway.v1.yaml`<br>`services/staff/staff-gateway/**`<br>`docs/platform/architecture/service_boundaries.md`<br>`docs/domains/console-and-operations-ux/README.md` | SGW-2 | готовность-owner-inbox-api | Owner inbox API усилен для использования из `web-console`: уточнена OpenAPI-валидация path/body/status responses, проверяются парные assignee refs, idempotency/expected version остаются обязательными для ответа, покрыты filter/pagination/context/action/error edge cases без собственной бизнес-логики gateway. |
 | не назначено | `specs/openapi/staff-gateway.v1.yaml`<br>`services/staff/staff-gateway/**`<br>`docs/platform/architecture/service_boundaries.md`<br>`docs/platform/architecture/c4_container.md`<br>`docs/domains/interaction-hub/architecture/api_contract.md`<br>`docs/domains/interaction-hub/architecture/design.md`<br>`docs/domains/console-and-operations-ux/README.md` | SGW-1 | owner-inbox-gateway | Первый `staff-gateway` для консоли сотрудников: OpenAPI list/detail/respond по входящим решениям владельца, gRPC-вызовы `interaction-hub`, safe DTO без собственной бизнес-истины. |
 | не назначено | `docs/domains/console-and-operations-ux/` | wave 14 | planned | Операторская консоль и рабочие пространства. |

--- a/docs/domains/console-and-operations-ux/README.md
+++ b/docs/domains/console-and-operations-ux/README.md
@@ -19,6 +19,8 @@
 
 Первый backend-контур для консоли сотрудников — `staff-gateway`. Он отдаёт `web-console` OpenAPI для входящих решений владельца: список, карточку одного решения и отправку ответа `approve`, `reject`, `request_changes` или `answer`, если это разрешено текущим request. Gateway остаётся тонким: он принимает actor/request context, вызывает `interaction-hub` по gRPC и возвращает только safe refs, статусы, краткие summaries, timestamps и version. Собственная модель решений, прямой доступ к БД доменных сервисов, управление `Run`/session/governance decision/provider write и междоменная агрегация в этот контур не входят.
 
+Список `owner inbox` поддерживает scope-фильтр, фильтры по kind/status/source owner/assignee/correlation, `include_diagnostics` и cursor pagination. Сортировку не выбирает клиент: её фиксирует `interaction-hub`, чтобы UI получал стабильный порядок с активными и срочными карточками выше. Карточка решения возвращает безопасные детали request, delivery/callback/response summaries, `allowed_actions`, timestamps и `version`; завершённые request не должны возвращать доступные действия. Ответ владельца отправляется с `expected_version` и `command_id` или `idempotency_key`, а gateway маппит ошибки `interaction-hub` в безопасные HTTP-статусы и коды без раскрытия raw payload.
+
 ## Карта Issue
 
 - Доменная карта: `docs/delivery/issue-map/domains/console-and-operations-ux.md`.

--- a/docs/platform/architecture/service_boundaries.md
+++ b/docs/platform/architecture/service_boundaries.md
@@ -5,7 +5,7 @@ title: kodex — границы сервисов
 status: active
 owner_role: SA
 created_at: 2026-04-26
-updated_at: 2026-05-27
+updated_at: 2026-05-28
 related_issues: [599, 600, 601, 602, 655, 711, 725, 747, 753, 778, 781, 786, 852, 322, 782, 834, 865, 867, 883]
 related_prs: []
 related_adrs: []
@@ -104,7 +104,7 @@ Gateway-сервисы, `web-console`, `platform-mcp-server` и `codex-hook-ingr
 
 Подробный пакет границы: `docs/domains/integration-gateway/**`.
 
-Первый активный контур `staff-gateway` — OpenAPI для входящих решений владельца. Он отдаёт список `owner inbox`, карточку одного решения и принимает безопасный ответ через gRPC-вызовы `interaction-hub`: `ListOwnerInboxItems`, `GetOwnerInboxItem` и `RecordInteractionResponse`. Gateway передаёт actor/request context, маппит ошибки в HTTP-статусы и не хранит собственную модель решений, delivery lifecycle, `Run`, session, governance decision, provider write или cross-domain inbox. В ответах остаются только safe refs, статусы, краткие summaries, timestamps и version; raw provider payload, секреты, полный prompt/transcript, callback payload и большие логи не возвращаются.
+Первый активный контур `staff-gateway` — OpenAPI для входящих решений владельца. Он отдаёт список `owner inbox`, карточку одного решения и принимает безопасный ответ через gRPC-вызовы `interaction-hub`: `ListOwnerInboxItems`, `GetOwnerInboxItem` и `RecordInteractionResponse`. Gateway передаёт actor/request context, проверяет HTTP path/query/body по контракту, маппит ошибки в HTTP-статусы и не хранит собственную модель решений, delivery lifecycle, `Run`, session, governance decision, provider write или cross-domain inbox. Список использует фильтры и cursor pagination, а порядок карточек остаётся доменной политикой `interaction-hub`, без настраиваемой сортировки в gateway. В ответах остаются только safe refs, статусы, краткие summaries, timestamps и version; raw provider payload, секреты, полный prompt/transcript, callback payload и большие логи не возвращаются.
 
 ### `platform-mcp-server`
 

--- a/services/staff/staff-gateway/internal/transport/http/casters.go
+++ b/services/staff/staff-gateway/internal/transport/http/casters.go
@@ -38,7 +38,11 @@ func ListOwnerInboxItemsRequest(req *http.Request) (*interactionsv1.ListOwnerInb
 	if safeErr != nil {
 		return nil, safeErr
 	}
-	correlationRef, safeErr := externalRefFromQuery(query.Get("correlation_kind"), query.Get("correlation_ref"))
+	correlationRef, safeErr := optionalProtoRef(query.Get("correlation_kind"), query.Get("correlation_ref"), "correlation ref is invalid", newExternalRef)
+	if safeErr != nil {
+		return nil, safeErr
+	}
+	assigneeRef, safeErr := optionalProtoRef(query.Get("assignee_kind"), query.Get("assignee_ref"), "assignee ref is invalid", newActorRef)
 	if safeErr != nil {
 		return nil, safeErr
 	}
@@ -53,7 +57,7 @@ func ListOwnerInboxItemsRequest(req *http.Request) (*interactionsv1.ListOwnerInb
 		Statuses:           statuses,
 		SourceOwnerKind:    sourceOwnerKind,
 		SourceOwnerRef:     optionalString(query.Get("source_owner_ref")),
-		AssigneeRef:        actorRefFromQuery(query.Get("assignee_kind"), query.Get("assignee_ref")),
+		AssigneeRef:        assigneeRef,
 		ActorRef:           optionalString(query.Get("actor_ref")),
 		CorrelationRef:     correlationRef,
 		CorrelationId:      optionalString(query.Get("correlation_id")),
@@ -75,11 +79,15 @@ func GetOwnerInboxItemRequest(req *http.Request) (*interactionsv1.GetOwnerInboxI
 	if _, err := uuid.Parse(requestID); err != nil {
 		return nil, NewSafeError(http.StatusBadRequest, CodeInvalidRequest, "request id is invalid", false)
 	}
+	assigneeRef, safeErr := optionalProtoRef(req.URL.Query().Get("assignee_kind"), req.URL.Query().Get("assignee_ref"), "assignee ref is invalid", newActorRef)
+	if safeErr != nil {
+		return nil, safeErr
+	}
 	return &interactionsv1.GetOwnerInboxItemRequest{
 		Meta:               meta,
 		RequestId:          requestID,
 		Scope:              scope,
-		AssigneeRef:        actorRefFromQuery(req.URL.Query().Get("assignee_kind"), req.URL.Query().Get("assignee_ref")),
+		AssigneeRef:        assigneeRef,
 		IncludeDiagnostics: parseBool(req.URL.Query().Get("include_diagnostics")),
 	}, nil
 }
@@ -351,25 +359,32 @@ func responseActionProto(value string) (interactionsv1.InteractionResponseAction
 	}
 }
 
-func actorRefFromQuery(kind string, ref string) *interactionsv1.ActorRef {
-	kind = strings.TrimSpace(kind)
-	ref = strings.TrimSpace(ref)
-	if kind == "" && ref == "" {
-		return nil
+func optionalProtoRef[T any](kind string, ref string, invalidMessage string, build func(string, string) *T) (*T, *SafeError) {
+	kind, ref, safeErr := optionalRefParts(kind, ref, invalidMessage)
+	if safeErr != nil || kind == "" {
+		return nil, safeErr
 	}
+	return build(kind, ref), nil
+}
+
+func newActorRef(kind string, ref string) *interactionsv1.ActorRef {
 	return &interactionsv1.ActorRef{RefKind: kind, Ref: ref}
 }
 
-func externalRefFromQuery(kind string, ref string) (*interactionsv1.ExternalRef, *SafeError) {
+func newExternalRef(kind string, ref string) *interactionsv1.ExternalRef {
+	return &interactionsv1.ExternalRef{RefKind: kind, Ref: ref}
+}
+
+func optionalRefParts(kind string, ref string, invalidMessage string) (string, string, *SafeError) {
 	kind = strings.TrimSpace(kind)
 	ref = strings.TrimSpace(ref)
 	if kind == "" && ref == "" {
-		return nil, nil
+		return "", "", nil
 	}
 	if kind == "" || ref == "" {
-		return nil, NewSafeError(http.StatusBadRequest, CodeInvalidRequest, "correlation ref is invalid", false)
+		return "", "", NewSafeError(http.StatusBadRequest, CodeInvalidRequest, invalidMessage, false)
 	}
-	return &interactionsv1.ExternalRef{RefKind: kind, Ref: ref}, nil
+	return kind, ref, nil
 }
 
 func pageFromQuery(req *http.Request) (*interactionsv1.PageRequest, *SafeError) {

--- a/services/staff/staff-gateway/internal/transport/http/generated/openapi.gen.go
+++ b/services/staff/staff-gateway/internal/transport/http/generated/openapi.gen.go
@@ -273,7 +273,7 @@ type OwnerInboxListResponse struct {
 	RequestId     string           `json:"request_id"`
 }
 
-// OwnerInboxRespondRequest defines model for OwnerInboxRespondRequest.
+// OwnerInboxRespondRequest Для идемпотентности должен быть передан command_id или idempotency_key.
 type OwnerInboxRespondRequest struct {
 	Action           ResponseAction `json:"action"`
 	CommandId        *string        `json:"command_id,omitempty"`
@@ -432,6 +432,9 @@ type NotFound = SafeError
 
 // PermissionDenied defines model for PermissionDenied.
 type PermissionDenied = SafeError
+
+// RateLimited defines model for RateLimited.
+type RateLimited = SafeError
 
 // Unauthorized defines model for Unauthorized.
 type Unauthorized = SafeError

--- a/services/staff/staff-gateway/internal/transport/http/handlers.go
+++ b/services/staff/staff-gateway/internal/transport/http/handlers.go
@@ -3,6 +3,7 @@ package httptransport
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 )
 
@@ -24,11 +25,9 @@ func (h handlers) getOwnerInboxItem(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h handlers) respondOwnerInboxItem(w http.ResponseWriter, req *http.Request) {
-	var body OwnerInboxRespondBody
-	decoder := json.NewDecoder(req.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil {
-		WriteSafeError(w, req, NewSafeError(http.StatusBadRequest, CodeInvalidRequest, "request body is invalid", false))
+	body, safeErr := decodeOwnerInboxRespondBody(req)
+	if safeErr != nil {
+		WriteSafeError(w, req, safeErr)
 		return
 	}
 	input, err := RecordInteractionResponseRequest(req, body)
@@ -47,6 +46,20 @@ func (h handlers) respondOwnerInboxItem(w http.ResponseWriter, req *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, output)
+}
+
+func decodeOwnerInboxRespondBody(req *http.Request) (OwnerInboxRespondBody, *SafeError) {
+	var body OwnerInboxRespondBody
+	decoder := json.NewDecoder(req.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return OwnerInboxRespondBody{}, NewSafeError(http.StatusBadRequest, CodeInvalidRequest, "request body is invalid", false)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return OwnerInboxRespondBody{}, NewSafeError(http.StatusBadRequest, CodeInvalidRequest, "request body must contain one JSON object", false)
+	}
+	return body, nil
 }
 
 func (h handlers) openAPISpec(w http.ResponseWriter, req *http.Request) {

--- a/services/staff/staff-gateway/internal/transport/http/router_test.go
+++ b/services/staff/staff-gateway/internal/transport/http/router_test.go
@@ -44,6 +44,48 @@ func TestRouterListOwnerInboxItems(t *testing.T) {
 	}
 }
 
+func TestRouterListOwnerInboxItemsFiltersAndPagination(t *testing.T) {
+	client := &fakeInteractionHubClient{listResponse: &interactionsv1.ListOwnerInboxItemsResponse{
+		Items: []*interactionsv1.OwnerInboxItem{sampleOwnerInboxItem(interactionsv1.InteractionRequestStatus_INTERACTION_REQUEST_STATUS_WAITING)},
+		Page:  &interactionsv1.PageResponse{NextPageToken: stringPtr("cursor-2")},
+	}}
+	router := newTestRouter(t, client)
+	target := "/v1/owner-inbox/items?scope_type=project&scope_ref=project-1" +
+		"&request_kind=feedback,human_gate&status=created,waiting" +
+		"&source_owner_kind=agent_manager&source_owner_ref=run-1" +
+		"&assignee_kind=user&assignee_ref=owner-1&actor_ref=user/owner-1" +
+		"&correlation_kind=agent_run&correlation_ref=run-1&correlation_id=corr-1" +
+		"&include_diagnostics=true&page_size=50&page_token=cursor-1"
+	req := authenticatedRequest(http.MethodGet, target, "")
+	req.Header.Set(headerTraceID, "trace-1")
+	req.Header.Set(headerSessionID, "session-1")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	recorded := client.listRequest
+	if len(recorded.GetRequestKinds()) != 2 || len(recorded.GetStatuses()) != 2 {
+		t.Fatalf("filters = %+v/%+v, want request kinds and statuses", recorded.GetRequestKinds(), recorded.GetStatuses())
+	}
+	if recorded.GetAssigneeRef().GetRefKind() != "user" || recorded.GetCorrelationRef().GetRef() != "run-1" {
+		t.Fatalf("refs = %+v/%+v, want assignee and correlation refs", recorded.GetAssigneeRef(), recorded.GetCorrelationRef())
+	}
+	if !recorded.GetIncludeDiagnostics() || recorded.GetPage().GetPageSize() != 50 || recorded.GetPage().GetPageToken() != "cursor-1" {
+		t.Fatalf("page/diagnostics = %+v/%t, want page and diagnostics", recorded.GetPage(), recorded.GetIncludeDiagnostics())
+	}
+	if recorded.GetMeta().GetRequestContext().GetTraceId() != "trace-1" || recorded.GetMeta().GetRequestContext().GetSessionId() != "session-1" {
+		t.Fatalf("request context = %+v, want trace and session", recorded.GetMeta().GetRequestContext())
+	}
+	var body generated.OwnerInboxListResponse
+	decodeJSON(t, rec, &body)
+	if body.Page.NextPageToken == nil || *body.Page.NextPageToken != "cursor-2" {
+		t.Fatalf("page response = %+v, want next token", body.Page)
+	}
+}
+
 func TestRouterGetOwnerInboxItem(t *testing.T) {
 	item := sampleOwnerInboxItem(interactionsv1.InteractionRequestStatus_INTERACTION_REQUEST_STATUS_WAITING)
 	client := &fakeInteractionHubClient{getResponse: &interactionsv1.OwnerInboxItemResponse{Item: item}}
@@ -63,6 +105,33 @@ func TestRouterGetOwnerInboxItem(t *testing.T) {
 	decodeJSON(t, rec, &body)
 	if len(body.Item.AllowedActions) != 3 {
 		t.Fatalf("allowed actions = %+v, want 3", body.Item.AllowedActions)
+	}
+}
+
+func TestRouterGetOwnerInboxItemReturnsSafeDetailDTO(t *testing.T) {
+	item := sampleOwnerInboxItemWithDiagnostics(interactionsv1.InteractionRequestStatus_INTERACTION_REQUEST_STATUS_ANSWERED)
+	client := &fakeInteractionHubClient{getResponse: &interactionsv1.OwnerInboxItemResponse{Item: item}}
+	router := newTestRouter(t, client)
+	req := authenticatedRequest(http.MethodGet, "/v1/owner-inbox/items/"+item.GetRequestId()+"?scope_type=project&scope_ref=project-1&include_diagnostics=true", "")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	var body generated.OwnerInboxItemResponse
+	decodeJSON(t, rec, &body)
+	if body.Item.LatestCallback == nil || body.Item.LatestResponse == nil {
+		t.Fatalf("item = %+v, want callback and response summaries", body.Item)
+	}
+	if body.Item.LatestResponse.ResponseAction != generated.RequestChanges {
+		t.Fatalf("latest response action = %s, want request_changes", body.Item.LatestResponse.ResponseAction)
+	}
+	for _, forbidden := range []string{"raw_payload", "secret-token", "provider_payload"} {
+		if strings.Contains(rec.Body.String(), forbidden) {
+			t.Fatalf("response leaked %q marker: %s", forbidden, rec.Body.String())
+		}
 	}
 }
 
@@ -96,6 +165,35 @@ func TestRouterRespondOwnerInboxItem(t *testing.T) {
 	}
 }
 
+func TestRouterRespondOwnerInboxItemMapsSafeActions(t *testing.T) {
+	cases := map[string]interactionsv1.InteractionResponseAction{
+		"approve":         interactionsv1.InteractionResponseAction_INTERACTION_RESPONSE_ACTION_APPROVE,
+		"reject":          interactionsv1.InteractionResponseAction_INTERACTION_RESPONSE_ACTION_REJECT,
+		"request_changes": interactionsv1.InteractionResponseAction_INTERACTION_RESPONSE_ACTION_REQUEST_CHANGES,
+		"answer":          interactionsv1.InteractionResponseAction_INTERACTION_RESPONSE_ACTION_ANSWER,
+		"defer":           interactionsv1.InteractionResponseAction_INTERACTION_RESPONSE_ACTION_DEFER,
+	}
+	for action, want := range cases {
+		t.Run(action, func(t *testing.T) {
+			requestID := uuid.NewString()
+			client := &fakeInteractionHubClient{recordResponse: sampleInteractionResponseResponse(requestID, want)}
+			router := newTestRouter(t, client)
+			payload := `{"action":"` + action + `","expected_version":3,"command_id":"cmd-1","response_summary":"Безопасная сводка"}`
+			req := authenticatedRequest(http.MethodPost, "/v1/owner-inbox/items/"+requestID+"/response", payload)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+			}
+			if got := client.recordRequest.GetResponseAction(); got != want {
+				t.Fatalf("response action = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
 func TestRouterRejectsUnknownAction(t *testing.T) {
 	client := &fakeInteractionHubClient{}
 	router := newTestRouter(t, client)
@@ -113,6 +211,20 @@ func TestRouterRejectsUnknownAction(t *testing.T) {
 	}
 }
 
+func TestRouterRejectsIncompleteAssigneeRef(t *testing.T) {
+	client := &fakeInteractionHubClient{}
+	router := newTestRouter(t, client)
+	req := authenticatedRequest(http.MethodGet, "/v1/owner-inbox/items?scope_type=project&scope_ref=project-1&assignee_ref=owner-1", "")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	assertErrorCode(t, rec, http.StatusBadRequest, generated.SafeErrorCodeInvalidRequest)
+	if client.listRequest != nil {
+		t.Fatalf("downstream was called for incomplete assignee ref")
+	}
+}
+
 func TestRouterOpenAPIValidationRejectsInvalidQueryBoolean(t *testing.T) {
 	client := &fakeInteractionHubClient{}
 	router := newTestRouter(t, client)
@@ -124,6 +236,52 @@ func TestRouterOpenAPIValidationRejectsInvalidQueryBoolean(t *testing.T) {
 	assertErrorCode(t, rec, http.StatusBadRequest, generated.SafeErrorCodeInvalidRequest)
 	if client.listRequest != nil {
 		t.Fatalf("downstream was called after OpenAPI validation failure")
+	}
+}
+
+func TestRouterRejectsMissingCommandIdAndIdempotencyKey(t *testing.T) {
+	client := &fakeInteractionHubClient{}
+	router := newTestRouter(t, client)
+	payload := `{"action":"approve","expected_version":3}`
+	req := authenticatedRequest(http.MethodPost, "/v1/owner-inbox/items/"+uuid.NewString()+"/response", payload)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	assertErrorCode(t, rec, http.StatusBadRequest, generated.SafeErrorCodeInvalidRequest)
+	if client.recordRequest != nil {
+		t.Fatalf("downstream was called after OpenAPI validation failure")
+	}
+}
+
+func TestRouterOpenAPIValidationRejectsWrongContentType(t *testing.T) {
+	client := &fakeInteractionHubClient{}
+	router := newTestRouter(t, client)
+	payload := `{"action":"approve","expected_version":3,"idempotency_key":"owner-response-1"}`
+	req := authenticatedRequest(http.MethodPost, "/v1/owner-inbox/items/"+uuid.NewString()+"/response", payload)
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	assertErrorCode(t, rec, http.StatusBadRequest, generated.SafeErrorCodeInvalidRequest)
+	if client.recordRequest != nil {
+		t.Fatalf("downstream was called after OpenAPI validation failure")
+	}
+}
+
+func TestRouterRejectsTrailingJSONBody(t *testing.T) {
+	client := &fakeInteractionHubClient{}
+	router := newTestRouter(t, client)
+	payload := `{"action":"approve","expected_version":3,"idempotency_key":"owner-response-1"}{}`
+	req := authenticatedRequest(http.MethodPost, "/v1/owner-inbox/items/"+uuid.NewString()+"/response", payload)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	assertErrorCode(t, rec, http.StatusBadRequest, generated.SafeErrorCodeInvalidRequest)
+	if client.recordRequest != nil {
+		t.Fatalf("downstream was called for trailing JSON body")
 	}
 }
 
@@ -165,6 +323,28 @@ func TestRouterMapsPermissionDenied(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	assertErrorCode(t, rec, http.StatusForbidden, generated.SafeErrorCodePermissionDenied)
+}
+
+func TestRouterMapsNotFound(t *testing.T) {
+	client := &fakeInteractionHubClient{getErr: status.Error(codes.NotFound, "missing")}
+	router := newTestRouter(t, client)
+	req := authenticatedRequest(http.MethodGet, "/v1/owner-inbox/items/"+uuid.NewString()+"?scope_type=project&scope_ref=project-1", "")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	assertErrorCode(t, rec, http.StatusNotFound, generated.SafeErrorCodeNotFound)
+}
+
+func TestRouterMapsRateLimit(t *testing.T) {
+	client := &fakeInteractionHubClient{listErr: status.Error(codes.ResourceExhausted, "limited")}
+	router := newTestRouter(t, client)
+	req := authenticatedRequest(http.MethodGet, "/v1/owner-inbox/items?scope_type=project&scope_ref=project-1", "")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	assertErrorCode(t, rec, http.StatusTooManyRequests, generated.SafeErrorCodeRateLimited)
 }
 
 func TestRouterMapsDownstreamUnavailable(t *testing.T) {
@@ -295,6 +475,39 @@ func sampleOwnerInboxItem(status interactionsv1.InteractionRequestStatus) *inter
 			{ActionKey: "request_changes", IsTerminal: true},
 		},
 	}
+}
+
+func sampleOwnerInboxItemWithDiagnostics(status interactionsv1.InteractionRequestStatus) *interactionsv1.OwnerInboxItem {
+	item := sampleOwnerInboxItem(status)
+	now := time.Date(2026, 5, 28, 12, 2, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	item.LatestCallback = &interactionsv1.OwnerInboxCallbackSummary{
+		CallbackRef:      "callback/ref-1",
+		CallbackId:       uuid.NewString(),
+		DeliveryId:       stringPtr(uuid.NewString()),
+		SignatureStatus:  interactionsv1.CallbackSignatureStatus_CALLBACK_SIGNATURE_STATUS_TRUSTED_INTERNAL,
+		ProcessingStatus: interactionsv1.CallbackProcessingStatus_CALLBACK_PROCESSING_STATUS_ACCEPTED,
+		ActorRef:         stringPtr("user/owner-1"),
+		Action:           stringPtr("request_changes"),
+		ReceivedAt:       now,
+		GatewayRef:       stringPtr("staff-gateway/request-1"),
+		CorrelationId:    stringPtr("corr-1"),
+	}
+	item.LatestResponse = &interactionsv1.OwnerInboxResponseSummary{
+		ResponseId:             uuid.NewString(),
+		ResponseAction:         interactionsv1.InteractionResponseAction_INTERACTION_RESPONSE_ACTION_REQUEST_CHANGES,
+		RespondedByActorRef:    "user/owner-1",
+		SourceKind:             interactionsv1.InteractionResponseSourceKind_INTERACTION_RESPONSE_SOURCE_KIND_WEB_CONSOLE,
+		SourceRef:              stringPtr("staff-gateway/request-1"),
+		OwnerDecisionRef:       stringPtr("decision/ref-1"),
+		CreatedAt:              now,
+		ResponseSummary:        stringPtr("Безопасная сводка без лишних данных"),
+		ResponseSummaryDigest:  stringPtr("sha256:digest"),
+		InteractionResponseRef: stringPtr("interaction-response/ref-1"),
+	}
+	item.AllowedActions = nil
+	item.ResolvedAt = stringPtr(now)
+	item.UpdatedAt = now
+	return item
 }
 
 func sampleInteractionResponseResponse(requestID string, action interactionsv1.InteractionResponseAction) *interactionsv1.InteractionResponseResponse {

--- a/specs/openapi/staff-gateway.v1.yaml
+++ b/specs/openapi/staff-gateway.v1.yaml
@@ -21,6 +21,7 @@ paths:
       description: |
         Возвращает безопасные карточки feedback, approval и Human gate request из interaction-hub.
         Gateway не читает БД доменного сервиса и не хранит собственную модель решений.
+        Порядок фиксирует interaction-hub: активные и срочные карточки идут раньше, затем updated_at и request_id.
       parameters:
         - $ref: '#/components/parameters/RequestIdHeader'
         - $ref: '#/components/parameters/TraceIdHeader'
@@ -55,6 +56,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/PermissionDenied'
+        '429':
+          $ref: '#/components/responses/RateLimited'
         '503':
           $ref: '#/components/responses/DownstreamUnavailable'
   /v1/owner-inbox/items/{request_id}:
@@ -92,6 +95,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
         '503':
           $ref: '#/components/responses/DownstreamUnavailable'
   /v1/owner-inbox/items/{request_id}/response:
@@ -132,6 +137,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/RateLimited'
         '503':
           $ref: '#/components/responses/DownstreamUnavailable'
 components:
@@ -142,6 +149,7 @@ components:
       required: true
       schema:
         type: string
+        pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
       description: Interaction request id.
     RequestIdHeader:
       name: X-Kodex-Request-Id
@@ -327,6 +335,12 @@ components:
             $ref: '#/components/schemas/SafeError'
     Conflict:
       description: Конфликт версии, terminal lifecycle или action вне allowed actions.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SafeError'
+    RateLimited:
+      description: interaction-hub ограничил частоту запросов.
       content:
         application/json:
           schema:
@@ -663,6 +677,7 @@ components:
       type: object
       additionalProperties: false
       required: [action, expected_version]
+      description: Для идемпотентности должен быть передан command_id или idempotency_key.
       properties:
         action:
           $ref: '#/components/schemas/ResponseAction'


### PR DESCRIPTION
## Что выполнено

- Усилен OpenAPI-контракт `staff-gateway` для `owner inbox`: зафиксирован UUID-pattern для `request_id`, описана доменная сортировка списка, добавлен HTTP `429` для rate limit и уточнено требование `command_id` или `idempotency_key` для ответа владельца.
- HTTP-слой отклоняет неполные `assignee_*` refs и тело ответа с несколькими JSON-объектами, сохраняя тонкий вызов `interaction-hub` без собственной бизнес-логики.
- Расширены тесты router/handler/caster без реальных downstream-сервисов: фильтры, пагинация, request context, detail DTO, `approve`/`reject`/`request_changes`/`answer`/`defer`, stale version, not found, permission denied, rate limit, unavailable и запрет raw payload.
- Обновлена документация по роли `staff-gateway`: UI получает безопасную list/detail/respond поверхность, а сортировка и lifecycle остаются в `interaction-hub`.

## Проверки

- `make gen-openapi-go SVC=services/staff/staff-gateway`
- `go test ./services/staff/staff-gateway/...`
- `make test-go`
- `make lint-go`
- `make dupl-go`
- `git diff --check`

## Ограничения

- Доменные proto `interaction-hub`, `agent-manager` и `governance-manager` не менялись.
- `staff-gateway` не читает БД доменных сервисов, не хранит decision state и не добавляет новые бизнес-сценарии.
- Настраиваемая сортировка списка не добавлялась: порядок остаётся доменной политикой `interaction-hub`.