### PR TITLE
agent-5/deploy: MAIN-REFRESH — обновление Kubernetes-контура

### DIFF
--- a/deploy/base/access-manager/access-manager.yaml.tpl
+++ b/deploy/base/access-manager/access-manager.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: access-manager
           image: {{ image "access-manager" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/access-manager/migrations.yaml.tpl
+++ b/deploy/base/access-manager/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "access-manager-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/agent-manager/agent-manager.yaml.tpl
+++ b/deploy/base/agent-manager/agent-manager.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: agent-manager
           image: {{ image "agent-manager" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/agent-manager/migrations.yaml.tpl
+++ b/deploy/base/agent-manager/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "agent-manager-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/bootstrap-foundation/registry.yaml.tpl
+++ b/deploy/base/bootstrap-foundation/registry.yaml.tpl
@@ -44,6 +44,8 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: kodex-registry
@@ -55,6 +57,8 @@ spec:
         app.kubernetes.io/part-of: kodex
         app.kubernetes.io/component: bootstrap-foundation
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 30
       securityContext:
         fsGroup: 1000
@@ -65,8 +69,6 @@ spec:
           ports:
             - name: registry
               containerPort: 5000
-              hostPort: {{ envOr "KODEX_INTERNAL_REGISTRY_PORT" "5000" }}
-              hostIP: 127.0.0.1
           env:
             - name: REGISTRY_HTTP_ADDR
               value: "0.0.0.0:5000"

--- a/deploy/base/codex-hook-ingress/codex-hook-ingress.yaml.tpl
+++ b/deploy/base/codex-hook-ingress/codex-hook-ingress.yaml.tpl
@@ -87,7 +87,7 @@ spec:
       containers:
         - name: codex-hook-ingress
           image: {{ image "codex-hook-ingress" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/fleet-manager/fleet-manager.yaml.tpl
+++ b/deploy/base/fleet-manager/fleet-manager.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: fleet-manager
           image: {{ image "fleet-manager" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/fleet-manager/migrations.yaml.tpl
+++ b/deploy/base/fleet-manager/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "fleet-manager-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/governance-manager/governance-manager.yaml.tpl
+++ b/deploy/base/governance-manager/governance-manager.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: governance-manager
           image: {{ image "governance-manager" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/governance-manager/migrations.yaml.tpl
+++ b/deploy/base/governance-manager/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "governance-manager-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/integration-gateway/integration-gateway.yaml.tpl
+++ b/deploy/base/integration-gateway/integration-gateway.yaml.tpl
@@ -99,7 +99,7 @@ spec:
       containers:
         - name: integration-gateway
           image: {{ image "integration-gateway" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/interaction-hub/interaction-hub.yaml.tpl
+++ b/deploy/base/interaction-hub/interaction-hub.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: interaction-hub
           image: {{ image "interaction-hub" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/interaction-hub/migrations.yaml.tpl
+++ b/deploy/base/interaction-hub/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "interaction-hub-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/package-hub/migrations.yaml.tpl
+++ b/deploy/base/package-hub/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "package-hub-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/package-hub/package-hub.yaml.tpl
+++ b/deploy/base/package-hub/package-hub.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: package-hub
           image: {{ image "package-hub" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/platform-event-log/migrations.yaml.tpl
+++ b/deploy/base/platform-event-log/migrations.yaml.tpl
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "platform-event-log-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/platform-mcp-server/platform-mcp-server.yaml.tpl
+++ b/deploy/base/platform-mcp-server/platform-mcp-server.yaml.tpl
@@ -77,7 +77,7 @@ spec:
       containers:
         - name: platform-mcp-server
           image: {{ image "platform-mcp-server" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/project-catalog/migrations.yaml.tpl
+++ b/deploy/base/project-catalog/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "project-catalog-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/project-catalog/project-catalog.yaml.tpl
+++ b/deploy/base/project-catalog/project-catalog.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: project-catalog
           image: {{ image "project-catalog" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/provider-hub/migrations.yaml.tpl
+++ b/deploy/base/provider-hub/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "provider-hub-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/provider-hub/provider-hub.yaml.tpl
+++ b/deploy/base/provider-hub/provider-hub.yaml.tpl
@@ -88,7 +88,7 @@ spec:
       containers:
         - name: provider-hub
           image: {{ image "provider-hub" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/runtime-manager/migrations.yaml.tpl
+++ b/deploy/base/runtime-manager/migrations.yaml.tpl
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: migrations
           image: {{ image "runtime-manager-migrations" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 10001

--- a/deploy/base/runtime-manager/runtime-manager.yaml.tpl
+++ b/deploy/base/runtime-manager/runtime-manager.yaml.tpl
@@ -124,7 +124,7 @@ spec:
       containers:
         - name: runtime-manager
           image: {{ image "runtime-manager" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/staff-gateway/staff-gateway.yaml.tpl
+++ b/deploy/base/staff-gateway/staff-gateway.yaml.tpl
@@ -120,7 +120,7 @@ spec:
       containers:
         - name: staff-gateway
           image: {{ image "staff-gateway" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/base/web-console/web-console.yaml.tpl
+++ b/deploy/base/web-console/web-console.yaml.tpl
@@ -71,7 +71,7 @@ spec:
       containers:
         - name: web-console
           image: {{ image "web-console" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Выполнено

- Обновлён серверный Kubernetes-контур от свежего `main` через штатный `bootstrap/host/deploy_backend_ring.sh`.
- Последовательно применены rings `second`, `staff`, `web`, `web-public`.
- Исправлен bootstrap registry contour: `kodex-registry` работает через `hostNetwork`, а Deployment использует `Recreate`, чтобы локальный registry был доступен Kaniko по loopback и повторный rollout не конфликтовал за порт.
- Для внутренних build/migration images в deploy templates включён `imagePullPolicy: Always`. Это убирает stale-image сценарий, когда Kaniko пушит новый образ в тот же tag, а migration/workload pod берёт старый cached image с node.
- После исправления повторно применены `second`, `staff`, `web`, `web-public`; `agent-manager-migrations` применил `20260528120000_agent_manager_governance_refs.sql` и `20260530090000_agent_manager_read_surface_indexes.sql`.

## Проверки

- Реальный deploy rings `second`, `staff`, `web`, `web-public` выполнен без вывода секретов.
- Build jobs текущего прохода завершились `Complete` для сервисов второго кольца, `staff-gateway` и `web-console`; часть старых build jobs уже могла быть очищена по `ttlSecondsAfterFinished`.
- Migration jobs `platform-event-log`, `fleet-manager`, `runtime-manager`, `interaction-hub`, `governance-manager`, `agent-manager` завершились `Complete`.
- Deployments `fleet-manager`, `runtime-manager`, `interaction-hub`, `governance-manager`, `agent-manager`, `integration-gateway`, `codex-hook-ingress`, `staff-gateway`, `web-console`, `web-console-public-oauth2-proxy`, `kodex-public-ingress` находятся в Ready-состоянии.
- `staff-gateway` через локальный port-forward: `/health/readyz` вернул `204`, `/openapi/staff-gateway.v1.yaml` вернул `200`.
- `https://platform.kodex.works/` вернул `302` на GitHub OAuth без печати query/state.
- `/oauth2/callback` маршрутизируется через public Ingress к `oauth2-proxy`; прямой запрос без OAuth `code/state` возвращает контролируемую ошибку `oauth2-proxy`.
- Public Ingress targets только `web-console-public-oauth2-proxy`; `web-console` остаётся `ClusterIP`.
- `Certificate` для публичного web contour и `ClusterIssuer` Ready.
- `bash bootstrap/host/plan_backend_deploy.sh --env-file bootstrap/host/config.env --require-kubernetes` прошёл render/kustomize/live dry-run plan без изменений кластера.
- Server-side dry-run прошёл для `bootstrap-foundation`, сервисов второго кольца, `staff-gateway`, `web-console`, `web-console-public`.
- `go test ./cmd/bootstrap-backend-deploy/...`.
- `go test ./cmd/bootstrap-deploy-plan/...`.
- `git diff --check`.

## Ограничения

- Интерактивный вход владельца через GitHub OAuth не выполнялся из агентской сессии. Проверены TLS/certificate, redirect, callback route, allowlist/proxy path и отсутствие прямого public route к `web-console`.