### PR TITLE
agent-5/deploy: SELFDEPLOY — stale provider signal не блокирует consumer

### DIFF
--- a/services/internal/agent-manager/internal/app/self_deploy_signal_consumer.go
+++ b/services/internal/agent-manager/internal/app/self_deploy_signal_consumer.go
@@ -147,10 +147,16 @@ func (h selfDeploySignalEventHandler) HandleEvent(ctx context.Context, event eve
 	}
 	enriched, err := h.reader.GetSelfDeploySignal(ctx, lookup)
 	if err != nil {
+		if errors.Is(err, errs.ErrNotFound) {
+			return selfDeploySignalStaleProviderResult()
+		}
 		return selfDeploySignalConsumerError(err)
 	}
 	if enriched.Status == agentservice.SelfDeploySignalStatusNotDeployRelevant {
 		return eventconsumer.Ack()
+	}
+	if enriched.Status == agentservice.SelfDeploySignalStatusProviderSignalNotFound {
+		return selfDeploySignalStaleProviderResult()
 	}
 	if enriched.Status != agentservice.SelfDeploySignalStatusReady {
 		return selfDeploySignalNotReadyResult(enriched)
@@ -300,6 +306,10 @@ func selfDeploySignalNotReadyResult(result agentservice.SelfDeploySignalReadResu
 		reason = status
 	}
 	return eventconsumer.Retry(fmt.Errorf("self-deploy signal is not ready: %s: %s", status, reason))
+}
+
+func selfDeploySignalStaleProviderResult() eventconsumer.Result {
+	return eventconsumer.Poison("stale_provider_signal", "provider repository change signal is unavailable and cannot be enriched")
 }
 
 var selfDeploySignalDomainErrorResults = []struct {

--- a/services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go
+++ b/services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go
@@ -104,6 +104,48 @@ func TestSelfDeploySignalEventHandlerRetriesNonReadyProjectSignal(t *testing.T) 
 	}
 }
 
+func TestSelfDeploySignalEventHandlerSkipsStaleProviderSignal(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	cases := []struct {
+		name   string
+		reader *fakeSelfDeploySignalReader
+	}{
+		{
+			name: "safe status",
+			reader: &fakeSelfDeploySignalReader{result: agentservice.SelfDeploySignalReadResult{
+				Status:     agentservice.SelfDeploySignalStatusProviderSignalNotFound,
+				SafeReason: "provider_signal_not_found",
+			}},
+		},
+		{
+			name:   "read not found",
+			reader: &fakeSelfDeploySignalReader{err: errs.ErrNotFound},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			creator := &fakeSelfDeployPlanCreator{}
+			handler := selfDeploySignalEventHandler{reader: tc.reader, creator: creator}
+			result := handler.HandleEvent(context.Background(), eventconsumer.Event{StoredEvent: selfDeploySignalStoredEvent(t, providerevents.Payload{
+				SignalKey:             "provider:github:repository_change:push:codex-k8s/kodex:main:stale",
+				ProjectID:             projectID.String(),
+				BaseBranch:            "main",
+				DeployRelevantChanged: true,
+			})})
+			if result.Status != eventconsumer.ResultPoison || result.Code != "stale_provider_signal" {
+				t.Fatalf("HandleEvent() = %+v, want stale provider poison", result)
+			}
+			if len(creator.inputs) != 0 {
+				t.Fatalf("created inputs = %d, want 0", len(creator.inputs))
+			}
+		})
+	}
+}
+
 func TestSelfDeploySignalEventHandlerIgnoresNotDeployRelevantEvent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Что выполнено

- `agent-manager.self-deploy-signal` больше не держит checkpoint на stale `provider.repository.changed`, если `project-catalog` возвращает safe статус `provider_signal_not_found` или gRPC `NotFound` для provider signal.
- Событие переводится в permanent safe diagnostic `stale_provider_signal` через `eventconsumer.Poison`, поэтому checkpoint продвигается, но событие не считается успешным созданием плана.
- Временные состояния, которые могут дозреть (`needs_services_policy_reconcile`, `provider_signal_not_ready`, `needs_repository_change_summary`), остаются retryable.
- Добавлен unit-тест на обе формы stale signal: safe статус и `errs.ErrNotFound`.

## Live-контекст

Fresh `main` после #1040 был раскатан штатным deploy tooling до обнаружения этого блокера. Миграция `platform-event-log` применена, deployments/jobs/certificate/webhook contour готовы. Self-deploy consumer больше не падает на schema drift, но застрял на старом event-log событии `provider.repository.changed` с safe причиной `not found`; новые события не доходят до создания `SelfDeployPlan`, пока checkpoint не продвинется.

## Проверки

- `go test ./services/internal/agent-manager/...`
- `go test ./cmd/bootstrap-operational-acceptance/... ./cmd/bootstrap-backend-deploy/... ./cmd/bootstrap-deploy-plan/...`
- `make test-go`
- `make lint-go`
- `make dupl-go`
- `git diff --check`
- `go run ./cmd/bootstrap-operational-acceptance --env-file bootstrap/host/config.env` до правки: production-контур готов, секреты проверены без вывода значений, unsigned webhook возвращает отказ без OAuth redirect.

## Ограничения/следующие шаги

- Rollout этого commit не выполнялся. После merge нужно раскатать fresh `main`, дождаться `agent-manager`, проверить продвижение checkpoint за stale event и повторить safe self-deploy checks: bound `RepositoryChangeSignal`, `GetSelfDeploySignal`, `SelfDeployPlan`, governance gate и staff summary.