### PR TITLE
agent-6/delivery: self-deploy — controlled trigger checkpoint

### DIFF
--- a/docs/delivery/coordination/agent-6-risk-governance.md
+++ b/docs/delivery/coordination/agent-6-risk-governance.md
@@ -144,6 +144,14 @@
 - Команда возвращает `pending`, `approved`, `rejected` или `blocked` summary; runtime build/deploy jobs остаются запрещены до `approved`.
 - Вход хранит только project/repository/source/provider refs, service keys, path categories, expected runtime job types, `services.yaml` ref/digest, changed-file summary ref, bounded summary и fingerprint; raw webhook body, diff, полный YAML, provider response, logs, prompt/transcript, kubeconfig и секреты не принимаются.
 
+## Live checkpoint self-deploy после rollout #1048
+
+- Webhook и provider-контур сигналов для self-repo работают: новый merge/push в `main` создаёт безопасный `provider.repository.changed` сигнал без raw webhook body, diff или provider response.
+- `project-catalog.GetSelfDeploySignal` для self-repo возвращает `READY`: checked `services.yaml` policy импортирована, latest policy находится в состоянии valid/synced и содержит 14 service descriptors.
+- #1048 обновил live `agent-manager` и исправил ветку `invalid_self_deploy_signal`, но событие #1048 было зафиксировано checkpoint старым кодом до rollout и не является достаточной проверкой обновлённого consumer.
+- Следующий контролируемый merge/push после rollout #1048 проверяет цепочку: fresh provider signal -> `GetSelfDeploySignal=READY` -> `SelfDeployPlan` -> governance gate.
+- Runtime build/deploy jobs не запускаются этим checkpoint: запуск остаётся заблокирован до явного owner/governance decision и отдельной проверки агентом #5.
+
 ## Ближайшие зависимости
 
 | Домен | Что нужно согласовать |


### PR DESCRIPTION
## Что выполнено

- Зафиксирован live checkpoint self-deploy после rollout #1048 в `docs/delivery/coordination/agent-6-risk-governance.md`.
- Документ отражает текущее безопасное состояние: webhook/provider signal работает, `GetSelfDeploySignal=READY`, checked `services.yaml` policy импортирована, latest policy valid/synced и содержит 14 descriptors.
- Зафиксировано, что #1048 исправил `invalid_self_deploy_signal`, но событие #1048 было обработано старым кодом до rollout, поэтому нужен fresh controlled merge/push.
- Код, `services.yaml`, proto/OpenAPI/AsyncAPI, deploy/bootstrap manifests, env/secrets/config не менялись.

## Проверки

- Self-check по `docs/design-guidelines/common/check_list.md`: релевантны пункты про границы, отсутствие секретов/PII, отсутствие изменения контрактов/deploy и чистый русский текст с code identifiers; нарушений не найдено.
- `git diff --check`

## Ограничения/следующие шаги

- Это безопасный delivery checkpoint и controlled merge/push для live self-deploy проверки после #1048.
- После merge агент #5 должен проверить цепочку: fresh provider signal -> `GetSelfDeploySignal=READY` -> `SelfDeployPlan` -> governance gate.
- Runtime build/deploy jobs не запускаются этим изменением и остаются заблокированы до owner/governance decision.