### PR TITLE
agent-3/agent-manager: self-deploy — deploy-relevant controlled trigger

### DIFF
--- a/services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go
+++ b/services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go
@@ -248,6 +248,57 @@ func TestSelfDeploySignalEventHandlerIgnoresNotDeployRelevantEvent(t *testing.T)
 	}
 }
 
+func TestSelfDeploySignalEventHandlerRequiresDeployRelevantTriggerBeforeProjectRead(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.MustParse("44444444-5555-4666-8777-888888888888")
+	repositoryID := uuid.MustParse("55555555-6666-4777-8888-999999999999")
+	reader := &fakeSelfDeploySignalReader{result: readySelfDeploySignal(projectID, repositoryID)}
+	creator := &fakeSelfDeployPlanCreator{}
+	handler := selfDeploySignalEventHandler{
+		cfg: Config{
+			SelfDeploySignalConsumerProjectID:    projectID.String(),
+			SelfDeploySignalConsumerRepositoryID: repositoryID.String(),
+			SelfDeploySignalConsumerTargetBranch: "main",
+		},
+		reader:  reader,
+		creator: creator,
+	}
+
+	docsOnly := handler.HandleEvent(context.Background(), eventconsumer.Event{StoredEvent: selfDeploySignalStoredEvent(t, providerevents.Payload{
+		SignalKey:  "provider:github:repository_change:push:codex-k8s/kodex:main:docs-only",
+		BaseBranch: "main",
+	})})
+	if docsOnly.Status != eventconsumer.ResultAck {
+		t.Fatalf("HandleEvent(docs-only) = %+v, want ack", docsOnly)
+	}
+	if len(reader.inputs) != 0 || len(creator.inputs) != 0 {
+		t.Fatalf("docs-only reader inputs = %d, creator inputs = %d, want 0", len(reader.inputs), len(creator.inputs))
+	}
+
+	deployRelevant := handler.HandleEvent(context.Background(), eventconsumer.Event{StoredEvent: selfDeploySignalStoredEvent(t, providerevents.Payload{
+		SignalKey:             "provider:github:repository_change:push:codex-k8s/kodex:main:deploy-relevant",
+		BaseBranch:            "main",
+		DeployRelevantChanged: true,
+	})})
+	if deployRelevant.Status != eventconsumer.ResultAck {
+		t.Fatalf("HandleEvent(deploy-relevant) = %+v, want ack", deployRelevant)
+	}
+	if len(reader.inputs) != 1 || len(creator.inputs) != 1 {
+		t.Fatalf("deploy-relevant reader inputs = %d, creator inputs = %d, want 1", len(reader.inputs), len(creator.inputs))
+	}
+	if reader.inputs[0].ProjectID != projectID {
+		t.Fatalf("lookup project id = %s, want %s", reader.inputs[0].ProjectID, projectID)
+	}
+	if reader.inputs[0].RepositoryID == nil || *reader.inputs[0].RepositoryID != repositoryID {
+		t.Fatalf("lookup repository id = %v, want %s", reader.inputs[0].RepositoryID, repositoryID)
+	}
+	input := creator.inputs[0].CreateSelfDeployPlanInput
+	if input.GovernanceContext.GatePolicyRef != "governance:gate_policy/self_deploy.owner_gate" {
+		t.Fatalf("gate policy ref = %q", input.GovernanceContext.GatePolicyRef)
+	}
+}
+
 func TestSelfDeploySignalEventHandlerPoisonsMissingProjectRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Что выполнено

- Добавлен regression test для `agent-manager` self-deploy consumer.
- Тест проверяет, что non-deploy-relevant provider signal подтверждается без чтения `project-catalog` и без создания `SelfDeployPlan`.
- Тест проверяет, что deploy-relevant signal для `main` вызывает `GetSelfDeploySignal`, создаёт безопасный plan input и сохраняет нормализованный `governance:gate_policy/self_deploy.owner_gate`.

## Проверки

- `go test ./services/internal/agent-manager/...`
- `go test ./cmd/bootstrap-operational-acceptance/... ./cmd/bootstrap-backend-deploy/... ./cmd/bootstrap-deploy-plan/...`
- `make lint-go`
- `git diff --check`

## Назначение live-проверки

Это малый полезный regression-test срез и controlled deploy-relevant merge/push после rollout #1048. После merge агент #5 должен проверить цепочку: fresh provider signal -> `GetSelfDeploySignal=READY` -> `SelfDeployPlan` -> governance gate.

## Ограничения

- Контракты, `services.yaml`, deploy/bootstrap, env/secrets и внешние submodules не менялись.
