### PR TITLE
agent-4/governance: self-deploy — target type migration

### DIFF
--- a/docs/domains/risk-and-release-governance/architecture/data_model.md
+++ b/docs/domains/risk-and-release-governance/architecture/data_model.md
@@ -84,7 +84,7 @@ approvals:
 | Поле | Тип | Может быть пустым | Примечание |
 |---|---|---:|---|
 | `id` | uuid | нет | Идентификатор оценки. |
-| `target_type` | enum | нет | `transition`, `pull_request`, `release_candidate`, `runtime_job`, `policy_change`, `document`. |
+| `target_type` | enum | нет | `transition`, `pull_request`, `release_candidate`, `runtime_job`, `policy_change`, `document`, `merge`, `postdeploy`, `rollback`, `self_deploy_plan`. |
 | `target_ref` | text | нет | Внешняя ссылка на оцениваемый объект. |
 | `project_ref` | text | да | Проект, если применимо. |
 | `repository_ref` | text | да | Репозиторий, если применимо. |
@@ -162,7 +162,7 @@ approvals:
 | `id` | uuid | нет | Идентификатор gate. |
 | `risk_assessment_id` | uuid | да | Связанная оценка риска. |
 | `gate_policy_id` | uuid | да | Policy, которая потребовала gate. |
-| `target_type` | enum | нет | `transition`, `merge`, `release`, `postdeploy`, `rollback`, `policy_change`, `document_approval`. |
+| `target_type` | enum | нет | `transition`, `pull_request`, `release_candidate`, `runtime_job`, `policy_change`, `document`, `merge`, `postdeploy`, `rollback`, `self_deploy_plan`. |
 | `target_ref` | text | нет | Что именно ждёт решения. |
 | `interaction_request_ref` | text | да | Ссылка на delivery request в `interaction-hub`. |
 | `evidence_package` | jsonb | нет | Безопасный пакет фактов и refs. |

--- a/services/internal/governance-manager/cmd/cli/migrations/20260609090000_governance_self_deploy_plan_target_type.sql
+++ b/services/internal/governance-manager/cmd/cli/migrations/20260609090000_governance_self_deploy_plan_target_type.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE governance_manager_risk_assessments
+    DROP CONSTRAINT IF EXISTS governance_manager_risk_assessments_target_type_chk,
+    ADD CONSTRAINT governance_manager_risk_assessments_target_type_chk
+        CHECK (target_type IN ('transition', 'pull_request', 'release_candidate', 'runtime_job', 'policy_change', 'document', 'merge', 'postdeploy', 'rollback', 'self_deploy_plan'));
+
+ALTER TABLE governance_manager_gate_requests
+    DROP CONSTRAINT IF EXISTS governance_manager_gate_requests_target_type_chk,
+    ADD CONSTRAINT governance_manager_gate_requests_target_type_chk
+        CHECK (target_type IN ('transition', 'pull_request', 'release_candidate', 'runtime_job', 'policy_change', 'document', 'merge', 'postdeploy', 'rollback', 'self_deploy_plan'));
+
+-- +goose Down
+SELECT 1;

--- a/services/internal/governance-manager/cmd/cli/migrations/migrations_test.go
+++ b/services/internal/governance-manager/cmd/cli/migrations/migrations_test.go
@@ -1,6 +1,8 @@
 package migrations
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	migrationtest "github.com/codex-k8s/kodex/libs/go/migrationtest"
@@ -10,4 +12,23 @@ func TestGooseMigrationFiles(t *testing.T) {
 	t.Parallel()
 
 	migrationtest.AssertGooseMigrationFiles(t, ".")
+}
+
+func TestSelfDeployPlanTargetTypeMigration(t *testing.T) {
+	t.Parallel()
+
+	contentBytes, err := os.ReadFile("20260609090000_governance_self_deploy_plan_target_type.sql")
+	if err != nil {
+		t.Fatalf("read self-deploy target migration: %v", err)
+	}
+	content := string(contentBytes)
+	for _, expected := range []string{
+		"governance_manager_risk_assessments_target_type_chk",
+		"governance_manager_gate_requests_target_type_chk",
+		"'self_deploy_plan'",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("self-deploy target migration misses %q:\n%s", expected, content)
+		}
+	}
 }

--- a/services/internal/governance-manager/internal/repository/postgres/governance/repository_test.go
+++ b/services/internal/governance-manager/internal/repository/postgres/governance/repository_test.go
@@ -98,6 +98,55 @@ func TestWrapErrorMapsPostgresErrors(t *testing.T) {
 	}
 }
 
+func TestRepositoryIntegrationSelfDeployPlanTargetType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pool := openIntegrationPool(t, ctx)
+	repository := NewRepository(pool)
+	now := time.Date(2026, 6, 9, 9, 0, 0, 0, time.UTC)
+
+	assessment := testRiskAssessment(now)
+	assessment.Target = value.ExternalRef{Type: "self_deploy_plan", Ref: "agent:self-deploy-plan:target-check"}
+	assessment.Explanation = "self-deploy plan requires owner gate"
+	factor := entity.RiskFactor{
+		ID:               uuid.New(),
+		RiskAssessmentID: assessment.ID,
+		SourceType:       enum.RiskFactorSourceTypePolicy,
+		SourceRef:        "self-deploy:path-category:deploy",
+		RiskClass:        enum.RiskClassR2,
+		Summary:          "self-deploy plan requires gate",
+		CreatedAt:        now,
+	}
+	if err := repository.CreateRiskAssessment(ctx, assessment, []entity.RiskFactor{factor}, testCommandResult(uuid.New(), operationCreateRiskAssessment, "risk_assessment", assessment.ID, now), []entity.OutboxEvent{testEvent("governance.risk_assessment.requested", "risk_assessment", assessment.ID, now)}); err != nil {
+		t.Fatalf("create self-deploy risk assessment: %v", err)
+	}
+
+	request := entity.GateRequest{
+		VersionedBase:    entity.VersionedBase{ID: uuid.New(), Version: 1, CreatedAt: now, UpdatedAt: now},
+		RiskAssessmentID: &assessment.ID,
+		Target:           assessment.Target,
+		EvidenceRefs: []value.EvidenceRef{{
+			Kind:    "self_deploy_plan",
+			Ref:     assessment.Target.Ref,
+			Summary: "self-deploy plan gate input",
+			Digest:  "sha256:self-deploy-plan-target-check",
+		}},
+		EvidenceSummary: "self-deploy plan gate input",
+		Status:          enum.GateRequestStatusRequested,
+	}
+	if err := repository.CreateGateRequest(ctx, request, testCommandResult(uuid.New(), operationCreateGateRequest, "gate_request", request.ID, now), testEvent("governance.gate.requested", "gate", request.ID, now)); err != nil {
+		t.Fatalf("create self-deploy gate request: %v", err)
+	}
+	stored, err := repository.GetGateRequest(ctx, request.ID)
+	if err != nil {
+		t.Fatalf("get self-deploy gate request: %v", err)
+	}
+	if stored.Target.Type != "self_deploy_plan" || stored.RiskAssessmentID == nil || *stored.RiskAssessmentID != assessment.ID {
+		t.Fatalf("stored self-deploy gate request = %+v, want target and assessment link", stored)
+	}
+}
+
 func TestRepositoryIntegrationGovernanceStateAndOutbox(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Что выполнено
- Добавлена новая forward-only goose migration, которая расширяет `governance_manager_risk_assessments_target_type_chk` и `governance_manager_gate_requests_target_type_chk` значением `self_deploy_plan`.
- `Down` часть сделана no-op, чтобы rollback не ломал live rows с уже записанным `self_deploy_plan`.
- Добавлены проверка миграции и PostgreSQL repository/schema test на создание `RiskAssessment` и `GateRequest` с `target_type=self_deploy_plan`.
- Обновлена data model документация по допустимым `target_type` для risk assessments и gate requests.

## Проверки
- `go test ./services/internal/governance-manager/...`
- `make test-go-migrations`
- `make test-go`
- `make lint-go`
- `make dupl-go`
- `git diff --check`

## После merge
- Агент #5 должен раскатать fresh `main` и проверить, что existing self-deploy plan снова доходит до создания `risk_assessment` и `gate_request`.