### PR TITLE
agent-1/self-deploy: controlled deploy-relevant trigger

### DIFF
--- a/services/internal/runtime-manager/internal/domain/service/build_context_test.go
+++ b/services/internal/runtime-manager/internal/domain/service/build_context_test.go
@@ -65,6 +65,25 @@ func TestPrepareBuildContextReusesFingerprintAcrossCommands(t *testing.T) {
 	}
 }
 
+func TestPrepareBuildContextNormalizesAffectedServiceKeys(t *testing.T) {
+	t.Parallel()
+
+	svc, _ := newTestService()
+	input := testPrepareBuildContextInput()
+	input.AffectedServiceKeys = []string{" runtime-manager ", "", "access-manager", "runtime-manager"}
+	input.Meta = commandMeta(mustUUID("00000000-0000-0000-0000-000000001112"), 0)
+
+	buildContext, err := svc.PrepareBuildContext(context.Background(), input)
+	if err != nil {
+		t.Fatalf("PrepareBuildContext(): %v", err)
+	}
+
+	want := []string{"access-manager", "runtime-manager"}
+	if !sameStringSlices(buildContext.AffectedServiceKeys, want) {
+		t.Fatalf("affected service keys = %#v, want normalized %#v", buildContext.AffectedServiceKeys, want)
+	}
+}
+
 func TestBuildContextProgressRequiresCheckedSnapshotBeforeReady(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Что выполнено
- Добавлен минимальный deploy-relevant trigger для проверки live self-deploy цепочки после #1066.
- Изменён путь `services/internal/runtime-manager/internal/domain/service/build_context_test.go`, который входит в `services/**` и должен классифицироваться как deploy-relevant, но не меняет runtime/self-deploy поведение.
- Unit test закрепляет нормализацию `AffectedServiceKeys` в `PrepareBuildContext`: пустые значения отбрасываются, дубли удаляются, ключи сортируются для стабильного build context input.

Почему это deploy-relevant
- Изменение находится в backend-сервисе `runtime-manager` под `services/**`, а не в документации.
- Правка безопасна для live: затронут только unit test, без изменений бизнес-логики, секретов, env, manifest, deploy tooling или runtime/self-deploy контракта.

После merge
- Агент #5 должен проверить цепочку: webhook -> provider signal -> project signal READY -> SelfDeployPlan -> governance gate -> owner approve -> build context -> build -> deploy.

Проверки
- `go test ./services/internal/runtime-manager/internal/domain/service`
- `go test ./services/internal/runtime-manager/...`
- `make test-go`
- `make lint-go`
- `make dupl-go`
- `git diff --check`
