### PR TITLE
agent-5/self-deploy: controlled trigger for final live check

### DIFF
--- a/services/internal/project-catalog/internal/domain/service/service_test.go
+++ b/services/internal/project-catalog/internal/domain/service/service_test.go
@@ -2571,11 +2571,19 @@ func TestGetSelfDeployBuildPlanAllowsCodeOnlySignalCommitAfterPolicyCommit(t *te
 	if result.Status != enum.SelfDeployBuildPlanStatusReady {
 		t.Fatalf("status = %s, reason=%s, want ready for code-only change", result.Status, result.SafeReason)
 	}
+	if result.SafeReason != "" {
+		t.Fatalf("safe reason = %q, want empty ready diagnostic", result.SafeReason)
+	}
+	item := result.Plan.BuildItems[0]
 	spec := result.Plan.BuildItems[0].BuildExecutionSpec
+	if item.Status != SelfDeployBuildPlanItemStatusReady || item.SafeReason != "" {
+		t.Fatalf("item status/reason = %s/%q, want ready without stale policy reason", item.Status, item.SafeReason)
+	}
 	if spec.SourceCommitSHA != codeCommit ||
+		spec.SourceRef != input.SourceRef ||
 		result.Plan.MergeCommitSHA != codeCommit ||
 		result.Plan.ServicesYaml.SourceCommitSHA != policyCommit {
-		t.Fatalf("commits = spec %q plan %q policy %q, want code commit and older policy commit", spec.SourceCommitSHA, result.Plan.MergeCommitSHA, result.Plan.ServicesYaml.SourceCommitSHA)
+		t.Fatalf("refs = spec commit %q spec source %q plan commit %q policy commit %q, want code commit/ref and older policy commit", spec.SourceCommitSHA, spec.SourceRef, result.Plan.MergeCommitSHA, result.Plan.ServicesYaml.SourceCommitSHA)
 	}
 }
 


### PR DESCRIPTION
## Что выполнено

- Добавлено test-only уточнение для `project-catalog`: code-only deploy-relevant signal с commit новее checked `services.yaml` policy остаётся `READY`, не получает stale reason и прокидывает code commit/source ref в build spec.
- Production logic не менялась; diff нужен как controlled deploy-relevant trigger после #1079 для финальной live-проверки self-deploy.

## Live-проверка перед trigger

- Fresh `main` после #1079 раскатан в `kodex-prod`: `first` ring с rebuild, `second` ring через `--skip-build` для recovery/build dispatch.
- Старый approved plan `7b24d574-902b-4d1e-b7cb-ab57967688a1` остался stale/replan: staff summary показывает `needs_services_policy_reconcile`, safe error `policy_stale`, reason `services_policy_source_ref_mismatch`.
- Это ожидаемый operator-action outcome для старого plan; нужен новый deploy-relevant merge/push.

## Проверки

- `go test ./services/internal/project-catalog/internal/domain/service/...`
- `make test-go`
- `make lint-go`
- `make dupl-go`
- `git diff --check`
- deploy preflight с `--require-kubernetes`
- `go run ./cmd/bootstrap-operational-acceptance --env-file bootstrap/host/config.env`

## Ограничения

- Gate повторно не approve-ился.
- Ручной SQL, checkpoint reset, redelivery и `kubectl patch` не выполнялись.