### PR TITLE
agent-5/self-deploy: controlled trigger for final live check

### DIFF
--- a/services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go
+++ b/services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go
@@ -56,6 +56,9 @@ func TestSelfDeploySignalEventHandlerCreatesPlanFromProjectSignal(t *testing.T) 
 	if input.GovernanceContext.GatePolicyRef != "governance:gate_policy/self_deploy.owner_gate" {
 		t.Fatalf("gate policy ref = %q", input.GovernanceContext.GatePolicyRef)
 	}
+	if input.SafeSummary == "" {
+		t.Fatal("safe summary is empty, want project signal summary forwarded")
+	}
 }
 
 func TestSelfDeploySignalEventHandlerCreatesPlanFromLiveReadySignalShape(t *testing.T) {


### PR DESCRIPTION
## Что выполнено

- Добавлена минимальная test-only assertion в `services/internal/agent-manager/internal/app/self_deploy_signal_consumer_test.go`.
- Изменение находится в deploy-relevant path `services/internal/agent-manager/**`, но не меняет production logic.
- Это controlled trigger после финального rollout по #1090: после merge должен появиться новый deploy-relevant provider signal для проверки self-deploy end-to-end.

## Проверки

- `go test ./services/internal/agent-manager/internal/app/...`
- `git diff --check`

## Ограничения/следующие шаги

- #1090 не закрывается этим PR.
- После merge нужно наблюдать цепочку: GitHub webhook `202`, `RepositoryChangeSignal`, `GetSelfDeploySignal=READY`, `SelfDeployPlan`, governance gate, owner approve, build/deploy result через `cmd/self-deploy-chain-acceptance`.

Part of #1090
Part of #1084